### PR TITLE
Changed type of hardwareInterface of Pan and tilt joints and fixed bug in pan velocity limits 

### DIFF
--- a/urdf/axis.urdf.xacro
+++ b/urdf/axis.urdf.xacro
@@ -43,7 +43,7 @@
       <!-- check the displacement -->
       <parent link="${prefix}_base_link"/>
       <child link="${prefix}_pan_link"/>
-      <limit effort="${ptz_joint_effort_limit}" velocity="${ptz_joint_velocity_limit}" lower="-3.1416" upper="3.1416"/>
+      <limit effort="${ptz_joint_effort_limit}" velocity="${ptz_joint_velocity_limit}" lower="-3.1415" upper="3.1415"/>
       <joint_properties damping="${ptz_joint_damping}" friction="{ptz_joint_friction}"/>
     </joint>
     <link name="${prefix}_pan_link">
@@ -56,10 +56,10 @@
     <transmission name="${prefix}_pan_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}_pan_joint">
-        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
       </joint>
       <actuator name="pan_motor">
-        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
         <mechanicalReduction>${ptz_mechanical_reduction}</mechanicalReduction>
       </actuator>
     </transmission>
@@ -81,10 +81,10 @@
     <transmission name="${prefix}_tilt_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}_tilt_joint">
-        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
       </joint>
       <actuator name="tilt_motor">
-        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
         <mechanicalReduction>${ptz_mechanical_reduction}</mechanicalReduction>
       </actuator>
     </transmission>
@@ -119,10 +119,10 @@
     <!-- Axis sensor for simulation -->
     <sensor_axis_gazebo/>
   </xacro:macro>
-  
-    
-    
-    
+
+
+
+
   <xacro:macro name="sensor_axis_gazebo">
     <gazebo reference="${prefix}_frame_link">
       <sensor type="camera" name="${prefix}_sensor">
@@ -156,5 +156,5 @@
       </sensor>
     </gazebo>
   </xacro:macro>
-  
+
 </robot>


### PR DESCRIPTION
If the pan tilt control is implemented as a position_controllers/JointPositionControl, the motion of camera is jerky and unnatural and thus not suited for simulation purposes. Thus I changed it to a velocity_controllers/JointPositionControl which can read in PID parameters to smoothly control the joint value.

Also the velocity limits for the pan joint were set as -3.1416 to 3.1416, which during control led to 2 values of error being possible. Changing it to -3.1415 to 3.1415 fixes this issue and makes the camera axes move smoothly and naturally.

I have created another PR in the summit_xl_common repository addressing the same (https://github.com/RobotnikAutomation/summit_xl_common/pull/5) 

I'd appreciate comments. Thanks -Siddharth