### PR TITLE
added xacro: namespace for macro use

### DIFF
--- a/urdf/asus_xtion_pro.urdf.xacro
+++ b/urdf/asus_xtion_pro.urdf.xacro
@@ -106,7 +106,7 @@
     </link>
 
   <!-- RGBD sensor for simulation, same as Kinect -->
-  <sensor_xtion_pro_gazebo/>
+  <xacro:sensor_xtion_pro_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/axis.urdf.xacro
+++ b/urdf/axis.urdf.xacro
@@ -117,7 +117,7 @@
       <material>Gazebo/FlatBlack</material>
     </gazebo>
     <!-- Axis sensor for simulation -->
-    <sensor_axis_gazebo/>
+    <xacro:sensor_axis_gazebo/>
   </xacro:macro>
 
 

--- a/urdf/axis_m5013.urdf.xacro
+++ b/urdf/axis_m5013.urdf.xacro
@@ -122,7 +122,7 @@
     </gazebo>
 
     <!-- Axis sensor for simulation -->
-    <sensor_axis_m5013_gazebo/>
+    <xacro:sensor_axis_m5013_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/axis_m5525.urdf.xacro
+++ b/urdf/axis_m5525.urdf.xacro
@@ -123,7 +123,7 @@
     </gazebo>
 
     <!-- Axis sensor for simulation -->
-    <sensor_axis_m5525_gazebo/>
+    <xacro:sensor_axis_m5525_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/axis_q8641.urdf.xacro
+++ b/urdf/axis_q8641.urdf.xacro
@@ -151,7 +151,7 @@
       <material>Gazebo/FlatBlack</material>
     </gazebo>
     <!-- Axis sensor for simulation -->
-    <sensor_axis_q8641_gazebo/>
+    <xacro:sensor_axis_q8641_gazebo/>
   </xacro:macro>
 
 

--- a/urdf/benewake_ce30.urdf.xacro
+++ b/urdf/benewake_ce30.urdf.xacro
@@ -54,7 +54,7 @@
     </joint>
     <link name="${prefix}_link"/>
 
-  <sensor_benewake_ce30_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" vfov="${vfov}" fps="${fps}" gpu="${gpu}"/>
+  <xacro:sensor_benewake_ce30_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" vfov="${vfov}" fps="${fps}" gpu="${gpu}"/>
 
   </xacro:macro>
 

--- a/urdf/fotonic_e.urdf.xacro
+++ b/urdf/fotonic_e.urdf.xacro
@@ -71,7 +71,7 @@
 
 
 		<!-- Fotonic sensor for simulation -->
-		<sensor_fotonic_gazebo/>
+		<xacro:sensor_fotonic_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/hokuyo3d.urdf.xacro
+++ b/urdf/hokuyo3d.urdf.xacro
@@ -41,7 +41,7 @@
 
 
     <!-- Hokuyo sensor for simulation -->
-    <sensor_hokuyo3d_gazebo gpu="${gpu}"/>
+    <xacro:sensor_hokuyo3d_gazebo gpu="${gpu}"/>
 
   </xacro:macro>
 

--- a/urdf/hokuyo_urg04lx.urdf.xacro
+++ b/urdf/hokuyo_urg04lx.urdf.xacro
@@ -40,7 +40,7 @@
 	</joint>
 
     <!-- Hokuyo sensor for simulation -->
-    <sensor_hokuyo_urg04lx_gazebo/>
+    <xacro:sensor_hokuyo_urg04lx_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/hokuyo_utm30lx.urdf.xacro
+++ b/urdf/hokuyo_utm30lx.urdf.xacro
@@ -39,7 +39,7 @@
 	</joint>
 
     <!-- Hokuyo sensor for simulation -->
-    <sensor_hokuyo_utm_gazebo/>
+    <xacro:sensor_hokuyo_utm_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/intel_r430.urdf.xacro
+++ b/urdf/intel_r430.urdf.xacro
@@ -120,7 +120,7 @@
 
 
   <!-- RGBD sensor for simulation, same as Kinect -->
-  <sensor_r430_gazebo/>
+  <xacro:sensor_r430_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/kinect.urdf.xacro
+++ b/urdf/kinect.urdf.xacro
@@ -102,7 +102,7 @@
 	</link>
 
 		<!-- Kinect sensor for simulation -->
-	  <sensor_kinect_gazebo/>
+	  <xacro:sensor_kinect_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/kinectv2.urdf.xacro
+++ b/urdf/kinectv2.urdf.xacro
@@ -124,7 +124,7 @@
     </link>
 
         <!-- Kinect sensor for simulation -->
-      <sensor_kinectv2_gazebo cloudCutoffMax="${cloudCutoffMax}" far="${far}"/>
+      <xacro:sensor_kinectv2_gazebo cloudCutoffMax="${cloudCutoffMax}" far="${far}"/>
 
   </xacro:macro>
 

--- a/urdf/orbbec_astra.urdf.xacro
+++ b/urdf/orbbec_astra.urdf.xacro
@@ -119,7 +119,7 @@
     </link>
 
   <!-- RGBD sensor for simulation, same as Kinect -->
-  <sensor_orbbec_astra_gazebo/>
+  <xacro:sensor_orbbec_astra_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/ouster1.urdf.xacro
+++ b/urdf/ouster1.urdf.xacro
@@ -45,7 +45,7 @@
 
     <link name="${prefix}_link"/>
 
-    <sensor_ouster1_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" hsamples="${hsamples}" vfov="${vfov}" vsamples="${vsamples}" fps="${fps}" gpu="${gpu}"/>
+    <xacro:sensor_ouster1_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" hsamples="${hsamples}" vfov="${vfov}" vsamples="${vsamples}" fps="${fps}" gpu="${gpu}"/>
 
   </xacro:macro>
 
@@ -98,15 +98,15 @@
   </xacro:macro>
 
   <xacro:macro name="sensor_ouster1_16" params="prefix parent prefix_topic:='ouster' *origin hsamples fps gpu:=true">
-    <sensor_ouster1 prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.5" range_max="120.0" hfov="360.0" hsamples="${hsamples}" vfov="32.2" vsamples="16" fps="${fps}" gpu="${gpu}" >
+    <xacro:sensor_ouster1 prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.5" range_max="120.0" hfov="360.0" hsamples="${hsamples}" vfov="32.2" vsamples="16" fps="${fps}" gpu="${gpu}" >
       <xacro:insert_block name="origin" />
-    </sensor_ouster1>
+    </xacro:sensor_ouster1>
   </xacro:macro>
 
   <xacro:macro name="sensor_ouster1_64" params="prefix parent prefix_topic:='ouster' *origin hsamples fps gpu:=true">
-    <sensor_ouster1 prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.5" range_max="120.0" hfov="360.0" hsamples="${hsamples}" vfov="32.2" vsamples="64" fps="${fps}" gpu="${gpu}" >
+    <xacro:sensor_ouster1 prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.5" range_max="120.0" hfov="360.0" hsamples="${hsamples}" vfov="32.2" vsamples="64" fps="${fps}" gpu="${gpu}" >
       <xacro:insert_block name="origin" />
-    </sensor_ouster1>
+    </xacro:sensor_ouster1>
   </xacro:macro>
 
 </robot>

--- a/urdf/pointgrey_bumblebee2.urdf.xacro
+++ b/urdf/pointgrey_bumblebee2.urdf.xacro
@@ -133,26 +133,26 @@
   </xacro:macro>
 
   <xacro:macro name="BB2-03S2C-25" params="prefix:=bumblebee" >
-    <pointgrey_bumblebee2 prefix="${prefix}" hfov="1.69296937443" />
+    <xacro:pointgrey_bumblebee2 prefix="${prefix}" hfov="1.69296937443" />
   </xacro:macro>
 
   <xacro:macro name="BB2-03S2C-38" params="prefix:=bumblebee" >
-    <pointgrey_bumblebee2 prefix="${prefix}" hfov="1.15191730632" />
+    <xacro:pointgrey_bumblebee2 prefix="${prefix}" hfov="1.15191730632" />
   </xacro:macro>
 
   <xacro:macro name="BB2-03S2C-60" params="prefix=bumblebee" >
-    <pointgrey_bumblebee2 prefix="${prefix}" hfov="0.75049157835" />
+    <xacro:pointgrey_bumblebee2 prefix="${prefix}" hfov="0.75049157835" />
   </xacro:macro>
 
   <xacro:macro name="BB2-08S2C-25" params="frame:=bumblebee name:=bumblebee" >
-    <pointgrey_bumblebee2 prefix="${prefix}" hfov="1.69296937443" high_res="true" />
+    <xacro:pointgrey_bumblebee2 prefix="${prefix}" hfov="1.69296937443" high_res="true" />
   </xacro:macro>
 
   <xacro:macro name="BB2-08S2C-38" params="frame:=bumblebee name:=bumblebee" >
-    <pointgrey_bumblebee2 prefix="${prefix}" hfov="1.15191730632" high_res="true" />
+    <xacro:pointgrey_bumblebee2 prefix="${prefix}" hfov="1.15191730632" high_res="true" />
   </xacro:macro>
 
   <xacro:macro name="BB2-08S2C-60" params="frame:=bumblebee name:=bumblebee" >
-    <pointgrey_bumblebee2 prefix="${prefix}" hfov="0.75049157835" high_res="true" />
+    <xacro:pointgrey_bumblebee2 prefix="${prefix}" hfov="0.75049157835" high_res="true" />
   </xacro:macro>
 </robot>

--- a/urdf/rplidar.urdf.xacro
+++ b/urdf/rplidar.urdf.xacro
@@ -43,7 +43,7 @@
     </link>
 
 
-    <sensor_rplidar_gazebo/>
+    <xacro:sensor_rplidar_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/rplidar_a2.urdf.xacro
+++ b/urdf/rplidar_a2.urdf.xacro
@@ -42,7 +42,7 @@
     </link>
 
 
-    <sensor_rplidar_a2_gazebo/>
+    <xacro:sensor_rplidar_a2_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/rs_bpearl.urdf.xacro
+++ b/urdf/rs_bpearl.urdf.xacro
@@ -45,7 +45,7 @@
     </joint>
     <link name="${prefix}_link"/>
 
-  <sensor_rs_bpearl_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" samples="${samples}" vfov="${vfov}" lasers="${lasers}" fps="${fps}" gpu="${gpu}"/>
+  <xacro:sensor_rs_bpearl_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" samples="${samples}" vfov="${vfov}" lasers="${lasers}" fps="${fps}" gpu="${gpu}"/>
 
   </xacro:macro>
 

--- a/urdf/rslidar.urdf.xacro
+++ b/urdf/rslidar.urdf.xacro
@@ -44,7 +44,7 @@
     </joint>
     <link name="${prefix}_link"/>
 
-  <sensor_rslidar_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" hres="${hres}" vfov="${vfov}" vres="${vres}" fps="${fps}" gpu="${gpu}"/>
+  <xacro:sensor_rslidar_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" hres="${hres}" vfov="${vfov}" vres="${vres}" fps="${fps}" gpu="${gpu}"/>
 
   </xacro:macro>
 
@@ -97,20 +97,20 @@
   </xacro:macro>
 
   <xacro:macro name="sensor_rslidar_16" params="prefix parent prefix_topic:='lidar_3d' *origin gpu:=false">
-    <sensor_rslidar prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.4" range_max="150.0" hfov="360.0" hres="0.1" vfov="30.0" vres="2.0" fps="20.0" gpu="${gpu}" >
+    <xacro:sensor_rslidar prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.4" range_max="150.0" hfov="360.0" hres="0.1" vfov="30.0" vres="2.0" fps="20.0" gpu="${gpu}" >
       <xacro:insert_block name="origin" />
-    </sensor_rslidar>
+    </xacro:sensor_rslidar>
   </xacro:macro>
 
   <xacro:macro name="sensor_rslidar_32" params="prefix parent prefix_topic:='lidar_3d' *origin gpu:=false">
-    <sensor_rslidar prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.4" range_max="200.0" hfov="360.0" hres="0.1" vfov="40.0" vres="0.33" fps="20.0" gpu="${gpu}" >
+    <xacro:sensor_rslidar prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.4" range_max="200.0" hfov="360.0" hres="0.1" vfov="40.0" vres="0.33" fps="20.0" gpu="${gpu}" >
       <xacro:insert_block name="origin" />
-    </sensor_rslidar>
+    </xacro:sensor_rslidar>
   </xacro:macro>
 
   <xacro:macro name="sensor_rslidar_ruby" params="prefix parent prefix_topic:='lidar_3d' *origin gpu:=false">
-    <sensor_rslidar prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.4" range_max="250.0" hfov="360.0" hres="0.1" vfov="40.0" vres="0.1" fps="20.0" gpu="${gpu}" >
+    <xacro:sensor_rslidar prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.4" range_max="250.0" hfov="360.0" hres="0.1" vfov="40.0" vres="0.1" fps="20.0" gpu="${gpu}" >
       <xacro:insert_block name="origin" />
-    </sensor_rslidar>
+    </xacro:sensor_rslidar>
   </xacro:macro>
 </robot>

--- a/urdf/rubedos_viper.urdf.xacro
+++ b/urdf/rubedos_viper.urdf.xacro
@@ -128,9 +128,9 @@
   </xacro:macro>
 
   <xacro:macro name="sensor_rubedos_viper" params="prefix:=myviper parent *origin" >
-    <rubedos_viper prefix="${prefix}" parent="${parent}">
+    <xacro:rubedos_viper prefix="${prefix}" parent="${parent}">
       <xacro:insert_block name="origin" />
-    </rubedos_viper>
+    </xacro:rubedos_viper>
   </xacro:macro>
 
 </robot>

--- a/urdf/sick_microscan3.urdf.xacro
+++ b/urdf/sick_microscan3.urdf.xacro
@@ -43,7 +43,7 @@
 		<link name="${prefix}_link" />
 
 		<!-- Sick sensor sensor for simulation -->
-		<sensor_sick_microscan3_gazebo />
+		<xacro:sensor_sick_microscan3_gazebo />
 
 	</xacro:macro>
 

--- a/urdf/sick_s300.urdf.xacro
+++ b/urdf/sick_s300.urdf.xacro
@@ -61,7 +61,7 @@
     </transmission>
 
 	<!-- Sick sensor sensor for simulation -->
-	<sensor_sick_s300_gazebo />
+	<xacro:sensor_sick_s300_gazebo />
 
   </xacro:macro>
 

--- a/urdf/sick_s3000.urdf.xacro
+++ b/urdf/sick_s3000.urdf.xacro
@@ -35,7 +35,7 @@
 
 
 	<!-- Sick sensor sensor for simulation -->
-	<sensor_sick_s3000_gazebo/>
+	<xacro:sensor_sick_s3000_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/sick_tim551.urdf.xacro
+++ b/urdf/sick_tim551.urdf.xacro
@@ -43,7 +43,7 @@
     </link>
 
 
-    <sensor_sick_tim551_gazebo/>
+    <xacro:sensor_sick_tim551_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/sick_tim571.urdf.xacro
+++ b/urdf/sick_tim571.urdf.xacro
@@ -43,7 +43,7 @@
     </link>
 
 
-    <sensor_sick_tim571_gazebo/>
+    <xacro:sensor_sick_tim571_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/ueye_cp_gige.urdf.xacro
+++ b/urdf/ueye_cp_gige.urdf.xacro
@@ -61,7 +61,7 @@
                izz="0.0001" />
     </inertial>
     </link>
-    <sensor_ueye_cp_gige_gazebo />
+    <xacro:sensor_ueye_cp_gige_gazebo />
   </xacro:macro>
 
   <xacro:macro name="sensor_ueye_cp_gige_gazebo">

--- a/urdf/velodyne_vlp16.urdf.xacro
+++ b/urdf/velodyne_vlp16.urdf.xacro
@@ -41,7 +41,7 @@
     </link>
 
     <!-- Velodyne sensor for simulation -->
-    <sensor_velodyne_vlp16_gazebo range_min="${range_min}" range_max="${range_max}" gpu="${gpu}" />
+    <xacro:sensor_velodyne_vlp16_gazebo range_min="${range_min}" range_max="${range_max}" gpu="${gpu}" />
 
   </xacro:macro>
 


### PR DESCRIPTION
As xacro tags should be used with namespace, this PR fixes this for the usage of different macros across changed files.
This fixes the warning in Melodic. Furthermore, the urdf will be created correctly for Noetic.

Please see [xacro - ROS Wiki](http://wiki.ros.org/xacro) Section 13. Deprecated Syntax