### PR TITLE
added xacro: namespace to use a macro

### DIFF
--- a/urdf/asus_xtion_pro.urdf.xacro
+++ b/urdf/asus_xtion_pro.urdf.xacro
@@ -96,7 +96,7 @@
     </link>
 
   <!-- RGBD sensor for simulation, same as Kinect -->
-  <sensor_xtion_pro_gazebo/>
+  <xacro:sensor_xtion_pro_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/axis.urdf.xacro
+++ b/urdf/axis.urdf.xacro
@@ -117,7 +117,7 @@
       <material>Gazebo/FlatBlack</material>
     </gazebo>
     <!-- Axis sensor for simulation -->
-    <sensor_axis_gazebo/>
+    <xacro:sensor_axis_gazebo/>
   </xacro:macro>
 
 

--- a/urdf/axis_m5013.urdf.xacro
+++ b/urdf/axis_m5013.urdf.xacro
@@ -121,7 +121,7 @@
     </gazebo>
 
     <!-- Axis sensor for simulation -->
-    <sensor_axis_m5013_gazebo/>
+    <xacro:sensor_axis_m5013_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/axis_m5525.urdf.xacro
+++ b/urdf/axis_m5525.urdf.xacro
@@ -122,7 +122,7 @@
     </gazebo>
 
     <!-- Axis sensor for simulation -->
-    <sensor_axis_m5525_gazebo/>
+    <xacro:sensor_axis_m5525_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/axis_q8641.urdf.xacro
+++ b/urdf/axis_q8641.urdf.xacro
@@ -162,7 +162,7 @@
       <material>Gazebo/FlatBlack</material>
     </gazebo>
     <!-- Axis sensor for simulation -->
-    <sensor_axis_q8641_gazebo/>
+    <xacro:sensor_axis_q8641_gazebo/>
   </xacro:macro>
 
 

--- a/urdf/azure_kinect.urdf.xacro
+++ b/urdf/azure_kinect.urdf.xacro
@@ -65,7 +65,7 @@
     </link>
 
     <!-- RGBD sensor for simulation, same as Kinect -->
-    <sensor_azure_kinect_gazebo/>
+    <xacro:sensor_azure_kinect_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/benewake_ce30.urdf.xacro
+++ b/urdf/benewake_ce30.urdf.xacro
@@ -44,7 +44,7 @@
     </joint>
     <link name="${prefix}_link"/>
 
-  <sensor_benewake_ce30_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" vfov="${vfov}" fps="${fps}" gpu="${gpu}"/>
+  <xacro:sensor_benewake_ce30_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" vfov="${vfov}" fps="${fps}" gpu="${gpu}"/>
 
   </xacro:macro>
 
@@ -98,15 +98,15 @@
   </xacro:macro>
 
   <xacro:macro name="sensor_benewake_ce30a" params="prefix parent prefix_topic:='lidar_3d' *origin gpu:=false">
-    <sensor_benewake_ce30 prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.1" range_max="4.0" hfov="132.0" vfov="9.0" fps="20.0" gpu="${gpu}" >
+    <xacro:sensor_benewake_ce30 prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.1" range_max="4.0" hfov="132.0" vfov="9.0" fps="20.0" gpu="${gpu}" >
       <xacro:insert_block name="origin" />
-    </sensor_benewake_ce30>
+    </xacro:sensor_benewake_ce30>
   </xacro:macro>
 
   <xacro:macro name="sensor_benewake_ce30c" params="prefix parent prefix_topic:='lidar_3d' *origin gpu:=false">
-    <sensor_benewake_ce30 prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.1" range_max="4.0" hfov="132.0" vfov="9.0" fps="20.0" gpu="${gpu}" >
+    <xacro:sensor_benewake_ce30 prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.1" range_max="4.0" hfov="132.0" vfov="9.0" fps="20.0" gpu="${gpu}" >
       <xacro:insert_block name="origin" />
-    </sensor_benewake_ce30>
+    </xacro:sensor_benewake_ce30>
   </xacro:macro>
 
 </robot>

--- a/urdf/benewake_ce30d.urdf.xacro
+++ b/urdf/benewake_ce30d.urdf.xacro
@@ -45,7 +45,7 @@
     </joint>
     <link name="${prefix}_link"/>
 
-  <sensor_benewake_ce30d_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" vfov="${vfov}" fps="${fps}" gpu="${gpu}"/>
+  <xacro:sensor_benewake_ce30d_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" vfov="${vfov}" fps="${fps}" gpu="${gpu}"/>
 
   </xacro:macro>
 

--- a/urdf/embedded_s.urdf.xacro
+++ b/urdf/embedded_s.urdf.xacro
@@ -70,7 +70,7 @@
     </link>
 
   <!-- RGBD sensor for simulation, same as Kinect -->
-  <sensor_astra_embedded_s_gazebo/>
+  <xacro:sensor_astra_embedded_s_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/fotonic_e.urdf.xacro
+++ b/urdf/fotonic_e.urdf.xacro
@@ -62,7 +62,7 @@
 
 
     <!-- Fotonic sensor for simulation -->
-    <sensor_fotonic_gazebo/>
+    <xacro:sensor_fotonic_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/hokuyo3d.urdf.xacro
+++ b/urdf/hokuyo3d.urdf.xacro
@@ -42,7 +42,7 @@
 
 
     <!-- Hokuyo sensor for simulation -->
-    <sensor_hokuyo3d_gazebo gpu="${gpu}"/>
+    <xacro:sensor_hokuyo3d_gazebo gpu="${gpu}"/>
 
   </xacro:macro>
 

--- a/urdf/hokuyo_urg04lx.urdf.xacro
+++ b/urdf/hokuyo_urg04lx.urdf.xacro
@@ -39,7 +39,7 @@
   </joint>
 
     <!-- Hokuyo sensor for simulation -->
-    <sensor_hokuyo_urg04lx_gazebo/>
+    <xacro:sensor_hokuyo_urg04lx_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/hokuyo_utm30lx.urdf.xacro
+++ b/urdf/hokuyo_utm30lx.urdf.xacro
@@ -39,7 +39,7 @@
 	</joint>
 
     <!-- Hokuyo sensor for simulation -->
-    <sensor_hokuyo_utm_gazebo/>
+    <xacro:sensor_hokuyo_utm_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/intel_r430.urdf.xacro
+++ b/urdf/intel_r430.urdf.xacro
@@ -119,7 +119,7 @@
 
 
   <!-- RGBD sensor for simulation, same as Kinect -->
-  <sensor_r430_gazebo/>
+  <xacro:sensor_r430_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/kinect.urdf.xacro
+++ b/urdf/kinect.urdf.xacro
@@ -72,7 +72,7 @@
 	</link>
 
 		<!-- Kinect sensor for simulation -->
-	  <sensor_kinect_gazebo/>
+	  <xacro:sensor_kinect_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/kinectv2.urdf.xacro
+++ b/urdf/kinectv2.urdf.xacro
@@ -94,7 +94,7 @@
     </link>
 
         <!-- Kinect sensor for simulation -->
-      <sensor_kinectv2_gazebo cloudCutoffMax="${cloudCutoffMax}" far="${far}"/>
+      <xacro:sensor_kinectv2_gazebo cloudCutoffMax="${cloudCutoffMax}" far="${far}"/>
 
   </xacro:macro>
 

--- a/urdf/orbbec_astra.urdf.xacro
+++ b/urdf/orbbec_astra.urdf.xacro
@@ -85,7 +85,7 @@
     </link>
 
   <!-- RGBD sensor for simulation, same as Kinect -->
-  <sensor_orbbec_astra_gazebo/>
+  <xacro:sensor_orbbec_astra_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/ouster1.urdf.xacro
+++ b/urdf/ouster1.urdf.xacro
@@ -44,7 +44,7 @@
 
     <link name="${prefix}_link"/>
 
-    <sensor_ouster1_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" hsamples="${hsamples}" vfov="${vfov}" vsamples="${vsamples}" fps="${fps}" gpu="${gpu}"/>
+    <xacro:sensor_ouster1_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" hsamples="${hsamples}" vfov="${vfov}" vsamples="${vsamples}" fps="${fps}" gpu="${gpu}"/>
 
   </xacro:macro>
 

--- a/urdf/rplidar.urdf.xacro
+++ b/urdf/rplidar.urdf.xacro
@@ -43,7 +43,7 @@
     </link>
 
 
-    <sensor_rplidar_gazebo/>
+    <xacro:sensor_rplidar_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/rplidar_a2.urdf.xacro
+++ b/urdf/rplidar_a2.urdf.xacro
@@ -42,7 +42,7 @@
     </link>
 
 
-    <sensor_rplidar_a2_gazebo/>
+    <xacro:sensor_rplidar_a2_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/rs_bpearl.urdf.xacro
+++ b/urdf/rs_bpearl.urdf.xacro
@@ -46,7 +46,7 @@
     </joint>
     <link name="${prefix}_link"/>
 
-  <sensor_rs_bpearl_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" samples="${samples}" vfov="${vfov}" lasers="${lasers}" fps="${fps}" gpu="${gpu}"/>
+  <xacro:sensor_rs_bpearl_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" samples="${samples}" vfov="${vfov}" lasers="${lasers}" fps="${fps}" gpu="${gpu}"/>
 
   </xacro:macro>
 

--- a/urdf/rslidar.urdf.xacro
+++ b/urdf/rslidar.urdf.xacro
@@ -44,7 +44,7 @@
     </joint>
     <link name="${prefix}_link"/>
 
-  <sensor_rslidar_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" hres="${hres}" vfov="${vfov}" vres="${vres}" fps="${fps}" gpu="${gpu}"/>
+  <xacro:sensor_rslidar_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" hres="${hres}" vfov="${vfov}" vres="${vres}" fps="${fps}" gpu="${gpu}"/>
 
   </xacro:macro>
 
@@ -97,20 +97,20 @@
   </xacro:macro>
 
   <xacro:macro name="sensor_rslidar_16" params="prefix parent prefix_topic:='lidar_3d' *origin gpu:=false">
-    <sensor_rslidar prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.4" range_max="150.0" hfov="360.0" hres="0.1" vfov="30.0" vres="2.0" fps="20.0" gpu="${gpu}" >
+    <xacro:sensor_rslidar prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.4" range_max="150.0" hfov="360.0" hres="0.1" vfov="30.0" vres="2.0" fps="20.0" gpu="${gpu}" >
       <xacro:insert_block name="origin" />
-    </sensor_rslidar>
+    </xacro:sensor_rslidar>
   </xacro:macro>
 
   <xacro:macro name="sensor_rslidar_32" params="prefix parent prefix_topic:='lidar_3d' *origin gpu:=false">
-    <sensor_rslidar prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.4" range_max="200.0" hfov="360.0" hres="0.1" vfov="40.0" vres="0.33" fps="20.0" gpu="${gpu}" >
+    <xacro:sensor_rslidar prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.4" range_max="200.0" hfov="360.0" hres="0.1" vfov="40.0" vres="0.33" fps="20.0" gpu="${gpu}" >
       <xacro:insert_block name="origin" />
-    </sensor_rslidar>
+    </xacro:sensor_rslidar>
   </xacro:macro>
 
   <xacro:macro name="sensor_rslidar_ruby" params="prefix parent prefix_topic:='lidar_3d' *origin gpu:=false">
-    <sensor_rslidar prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.4" range_max="250.0" hfov="360.0" hres="0.1" vfov="40.0" vres="0.1" fps="20.0" gpu="${gpu}" >
+    <xacro:sensor_rslidar prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.4" range_max="250.0" hfov="360.0" hres="0.1" vfov="40.0" vres="0.1" fps="20.0" gpu="${gpu}" >
       <xacro:insert_block name="origin" />
-    </sensor_rslidar>
+    </xacro:sensor_rslidar>
   </xacro:macro>
 </robot>

--- a/urdf/rslidar_mems.urdf.xacro
+++ b/urdf/rslidar_mems.urdf.xacro
@@ -45,7 +45,7 @@
     <link name="${prefix}_link"/>
 
     <!-- sensor for simulation -->
-    <sensor_rslidar_mems_gazebo range_min="1" range_max="180" gpu="false" />
+    <xacro:sensor_rslidar_mems_gazebo range_min="1" range_max="180" gpu="false" />
 
   </xacro:macro>
 

--- a/urdf/sick_nanoscan3.urdf.xacro
+++ b/urdf/sick_nanoscan3.urdf.xacro
@@ -43,7 +43,7 @@
 		<link name="${prefix}_link" />
 
 		<!-- Sick sensor sensor for simulation -->
-		<sensor_sick_nanoscan3_gazebo />
+		<xacro:sensor_sick_nanoscan3_gazebo />
 
 	</xacro:macro>
 

--- a/urdf/sick_outdoorscan3.urdf.xacro
+++ b/urdf/sick_outdoorscan3.urdf.xacro
@@ -43,7 +43,7 @@
 		<link name="${prefix}_link" />
 
 		<!-- Sick sensor sensor for simulation -->
-		<sensor_sick_outdoorscan3_gazebo />
+		<xacro:sensor_sick_outdoorscan3_gazebo />
 
 	</xacro:macro>
 

--- a/urdf/sick_s300.urdf.xacro
+++ b/urdf/sick_s300.urdf.xacro
@@ -52,7 +52,7 @@
 
 
 	<!-- Sick sensor sensor for simulation -->
-	<sensor_sick_s300_gazebo />
+	<xacro:sensor_sick_s300_gazebo />
 
   </xacro:macro>
 

--- a/urdf/sick_s3000.urdf.xacro
+++ b/urdf/sick_s3000.urdf.xacro
@@ -46,7 +46,7 @@
 
 
 	<!-- Sick sensor sensor for simulation -->
-	<sensor_sick_s3000_gazebo/>
+	<xacro:sensor_sick_s3000_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/sick_tim551.urdf.xacro
+++ b/urdf/sick_tim551.urdf.xacro
@@ -43,7 +43,7 @@
     </link>
 
 
-    <sensor_sick_tim551_gazebo/>
+    <xacro:sensor_sick_tim551_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/sick_tim571.urdf.xacro
+++ b/urdf/sick_tim571.urdf.xacro
@@ -43,7 +43,7 @@
     </link>
 
 
-    <sensor_sick_tim571_gazebo/>
+    <xacro:sensor_sick_tim571_gazebo/>
 
   </xacro:macro>
 

--- a/urdf/velodyne_vlp16.urdf.xacro
+++ b/urdf/velodyne_vlp16.urdf.xacro
@@ -41,7 +41,7 @@
     </link>
 
     <!-- Velodyne sensor for simulation -->
-    <sensor_velodyne_vlp16_gazebo range_min="${range_min}" range_max="${range_max}" gpu="${gpu}" />
+    <xacro:sensor_velodyne_vlp16_gazebo range_min="${range_min}" range_max="${range_max}" gpu="${gpu}" />
 
   </xacro:macro>
 

--- a/urdf/ydlidar_4f.urdf.xacro
+++ b/urdf/ydlidar_4f.urdf.xacro
@@ -62,7 +62,7 @@
       </inertial>
     </link>
 	  
-    <sensor_ydlidar_4f_gazebo />
+    <xacro:sensor_ydlidar_4f_gazebo />
 
   </xacro:macro>
 


### PR DESCRIPTION
Several urdf files have been modified to call other macros without the ('Deprecated: xacro tag 'XX' w/o 'xacro:' xml namespace prefix (will be forbidden in Noetic)'). The commit fixes the warning in Melodic, since it will be forbidden in Noetic.