### PR TITLE
Fixed version and remove gazebo_plugins dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robotnik_sensors</name>
-  <version>0.0.0</version>
+  <version>1.1.2</version>
   <description>Robotnik standard sensors description. URDF and meshses.</description>
   <license>BSD</license>
 
@@ -17,7 +17,7 @@
 
   <depend>urdf</depend>
   <depend>xacro</depend>
-  <depend>gazebo_plugins</depend>
+  <!--depend>gazebo_plugins</depend-->
 
   <!-- Not available from ROS2 repository -->
   <!-- <depend>hector_gazebo_plugins</depend> -->


### PR DESCRIPTION
Removed gazebo_plugins in order to remove install all graphical packages in docker container.
Fix version error, without this fix can't generate deb package.