### PR TITLE
add missed dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -25,5 +25,6 @@
   <run_depend>hector_gazebo_thermal_camera</run_depend>
   <run_depend>gazebo_plugins</run_depend>
   <run_depend>gazebo_ros_control</run_depend>
+  <run_depend>velodyne_gazebo_plugins</run_depend>
   
 </package>


### PR DESCRIPTION
This pull request includes a small change to the `package.xml` file. The change adds a new runtime dependency for `velodyne_gazebo_plugins`.

* [`package.xml`](diffhunk://#diff-37a67ff78eb7260214b323353263b9af40a2fa98719a1e81937fae0159df87a3R28): Added `velodyne_gazebo_plugins` as a runtime dependency.