### PR TITLE
removed dep velodyne_gazebo_plugins from robotnik_sensors_gazebo package

### DIFF
--- a/robotnik_sensors_gazebo/package.xml
+++ b/robotnik_sensors_gazebo/package.xml
@@ -23,8 +23,8 @@
   <!-- GAZEBO PLUGINS -->
   <exec_depend>gazebo_ros_pkgs</exec_depend>
   <exec_depend>gazebo_ros2_control</exec_depend>
-  <exec_depend>velodyne_gazebo_plugins</exec_depend>
   <!-- Uncomment on release on rosdistro -->
+  <!-- <exec_depend>velodyne_gazebo_plugins</exec_depend> -->
   <!-- <exec_depend>realsense_gazebo_plugin</exec_depend> -->
 
   <exec_depend>robot_state_publisher</exec_depend>


### PR DESCRIPTION
This pull request includes a small change to the `robotnik_sensors_gazebo/package.xml` file. The change involves commenting out the `velodyne_gazebo_plugins` dependency, which was previously an active dependency.

The main reason is ros2 jazzy distro this package is not longer maintained. Removed and added later without that package.
- Removed: https://github.com/ros/rosdistro/pull/35534
- Added: https://github.com/ros/rosdistro/pull/44670

* [`robotnik_sensors_gazebo/package.xml`](diffhunk://#diff-2c7947e7c7732201330052391b4368fb73cfa68d5f6c19d87a927d54759b8174L26-R27): Commented out the `velodyne_gazebo_plugins` dependency.