### PR TITLE
[WIP] chore: apply xlm format

### DIFF
--- a/.github/.prettierrc.json
+++ b/.github/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "printWidth": 60,
+  "singleAttributePerLine": true,
+  "bracketSameLine": true,
+  "xmlSelfClosingSpace": true,
+  "xmlQuoteAttributes": "double",
+  "xmlWhitespaceSensitivity": "strict"
+}

--- a/.github/.prettierrc.json
+++ b/.github/.prettierrc.json
@@ -5,6 +5,13 @@
   "singleAttributePerLine": true,
   "bracketSameLine": true,
   "xmlSelfClosingSpace": true,
+  "xmlSortAttributesByKey": false,
   "xmlQuoteAttributes": "double",
-  "xmlWhitespaceSensitivity": "strict"
+  "xmlWhitespaceSensitivity": "ignore",
+  "overrides": [
+  {
+      "files": ["*.xacro", "*.urdf"],
+      "options": { "parser": "xml" }
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -2,12 +2,80 @@
 
 This package contains the description of the sensors used in Robotnik robots.
 
+The types of sensors available are:
+- 2D LiDAR
+- 3D LiDAR
+- Camera
+- Depth Camera
+- GPS
+- IMU
+
+You can find the list of available sensors at the [Sensors section](#sensors).
+
 ## Installation
 
 Download this repository and use the branch ros2-devel
 
 ```bash
 git clone https://github.com/RobotnikAutomation/robotnik_sensors.git -b ros2-devel
+```
+
+## Usage
+
+The entrypoint of the package is the file [robotnik_sensors/urdf/all_sensors.urdf.xacro](robotnik_sensors/urdf/all_sensors.urdf.xacro). This file includes all the sensor description of the sensors.
+
+The sensors macros have the following arguments:
+
+| Arguments      	| Description                                                                   	|
+|----------------	|-------------------------------------------------------------------------------	|
+| frame_prefix   	| prefix added to the frame                                                     	|
+| parent         	| parent link of the sensor                                                     	|
+| origin         	| origin block for the position and orientation of the sensor                   	|
+
+For simulation, the following arguments are also available:
+
+| Arguments      	| Description                                                                   	|
+|----------------	|-------------------------------------------------------------------------------	|
+| node_namespace 	| namespace of the plugin                                                       	|
+| node_name      	| name used for the plugin node in Gazebo                                       	|
+| gazebo_ignition	| boolean to additional information for Gazebo Ignition simulation                              |
+| topic_prefix   	| prefix added to the topic name                                                	|
+| gpu             | boolean to use the GPU for the sensor (only available for 2d and 3d lidar)      |
+
+
+#### Example
+
+This example shows how to include a SICK S300 2D LiDAR in a robot description:
+
+```sh
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/all_sensors.urdf.xacro" />
+  
+  <xacro:sensor_sick_s300
+    frame_prefix="$(arg prefix)front_laser_"
+    parent="$(arg prefix)chassis_link"
+    node_namespace="$(arg namespace)"
+    node_name="front_laser"
+    gazebo_ignition="$(arg gazebo_ignition)">
+    <origin xyz="${front_laser_offset_x} ${front_laser_offset_y} ${front_laser_offset_z}" rpy="0 ${-PI} ${-3/4*PI}" />
+  </xacro:sensor_sick_s300>
+```
+
+### Contributing
+
+All files must be formatted using [Prettier](https://prettier.io/) with the configuration found in [.github/.prettierrc.json](.github/.prettierrc.json).
+
+Install npm, prettier and prettier/plugin-xml:
+
+```bash
+sudo apt install npm
+sudo npm install -g prettier @prettier/plugin-xml
+```
+
+To format the files, run:
+
+```bash
+prettier --plugin=$(npm root -g)/@prettier/plugin-xml/src/plugin.js --config .github/.prettierrc.json --write "robotnik_sensors/urdf/**/*.{xml,xacro,urdf}"
 ```
 
 ## Sensors
@@ -43,7 +111,7 @@ The available sensors in the package are:
 - axis_m5525
 - axis_m5526
 
-### Depth
+### Depth Camera
 
 - azure_kinect
 - intel_realsense_d435
@@ -63,50 +131,3 @@ The available sensors in the package are:
 - myahrs
 - pixhawk
 - vectornav
-
-
-## Usage
-
-This repository contains a package *robotnik_sensors* which includes the URDF description of the sensors.
-
-The entrypoint of the package is the file [robotnik_sensors/urdf/sensors.urdf.xacro](robotnik_sensors/urdf/sensors.urdf.xacro). This file includes all the sensors macros and the description of the sensors.
-
-The sensors macros have the following arguments:
-
-| Arguments      	| Description                                                                   	|
-|----------------	|-------------------------------------------------------------------------------	|
-| frame_prefix   	| prefix added to the frame                                                     	|
-| parent         	| parent link of the sensor                                                     	|
-| origin         	| origin block for the position and orientation of the sensor                   	|
-
-For simulation, the following arguments are also available:
-
-| Arguments      	| Description                                                                   	|
-|----------------	|-------------------------------------------------------------------------------	|
-| node_namespace 	| namespace of the plugin                                                       	|
-| node_name      	| name used for the plugin node in Gazebo                                       	|
-| gazebo_ignition	| boolean to include the plugin for Gazebo Ignition                               |
-| topic_prefix   	| prefix added to the topic name                                                	|
-| gpu             | boolean to use the GPU for the sensor (only available for 2d and 3d lidar)      |
-
-You can find an example of the usage in the [default.urdf.xacro](robotnik_sensors_gazebo/urdf/default.urdf.xacro) file in robotnik_sensors_gazebo.
-
-```sh
-  <xacro:include
-    filename="$(find robotnik_sensors)/urdf/all_sensors.urdf.xacro" />
-  <xacro:call
-      macro="sensor_$(arg sensor_type)"
-      frame_prefix="$(arg sensor_name)_"
-      parent="world"
-      node_namespace="$(arg sensor_ns)"
-      node_name="$(arg sensor_name)"
-      gazebo_ignition="true"
-      topic_prefix="~/">
-    <origin xyz="0.0 0.0 0.1" rpy="0.0 0.0 0.0"/>
-  </xacro:call>
-```
-
-The macro names are sensor_ + the name of the sensor described above. For example:
-
-- sensor_intel_realsence_d435
-- sensor_vectornav

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ For simulation, the following arguments are also available:
 You can find an example of the usage in the [default.urdf.xacro](robotnik_sensors_gazebo/urdf/default.urdf.xacro) file in robotnik_sensors_gazebo.
 
 ```sh
-  <xacro:include filename="$(find robotnik_sensors)/urdf/all_sensors.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/all_sensors.urdf.xacro" />
   <xacro:call
       macro="sensor_$(arg sensor_type)"
       frame_prefix="$(arg sensor_name)_"

--- a/robotnik_sensors/urdf/2d_lidar/hokuyo_urg04lx.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/hokuyo_urg04lx.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_hokuyo_urg04lx"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
@@ -36,7 +35,7 @@
           xyz="0.0 0.0 0.0"
           rpy="0 0 0" />
         <geometry>
-            <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/hokuyo_urg_04lx.dae" />
         </geometry>
       </visual>
@@ -63,8 +62,7 @@
         rpy="0 0 0" />
     </joint>
 
-    <link name="${frame_prefix}link">
-    </link>
+    <link name="${frame_prefix}link" />
 
     <!-- Hokuyo sensor for simulation -->
     <xacro:lidar_2d_plugin
@@ -78,9 +76,6 @@
       frame_link="${frame_prefix}link"
       rate="10"
       resolution="0.004359297"
-      samples="640">
-    </xacro:lidar_2d_plugin>
-
+      samples="640" />
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/2d_lidar/hokuyo_urg04lx.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/hokuyo_urg04lx.urdf.xacro
@@ -1,45 +1,66 @@
-<?xml version="1.0"?>
-<robot name="sensor_hokuyo_urg04lx" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_hokuyo_urg04lx"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_hokuyo_urg04lx"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=hokuyo_urg04lx
-                       node_namespace:=${None}
-                       topic_prefix:=~/">
+  <xacro:macro
+    name="sensor_hokuyo_urg04lx"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=hokuyo_urg04lx
+            node_namespace:=${None}
+            topic_prefix:=~/">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <visual>
-        <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+        <origin
+          xyz="0.0 0.0 0.0"
+          rpy="0 0 0" />
         <geometry>
-            <mesh filename="package://robotnik_sensors/meshes/hokuyo_urg_04lx.dae"/>
+            <mesh
+            filename="package://robotnik_sensors/meshes/hokuyo_urg_04lx.dae" />
         </geometry>
       </visual>
       <inertial>
-        <origin xyz="0.0 0 0.035" rpy="0 0 0" />
+        <origin
+          xyz="0.0 0 0.035"
+          rpy="0 0 0" />
         <mass value="0.160" />
-        <xacro:solid_cuboid_inertia m="0.160" w="0.05" h="0.05" d="0.07" />
+        <xacro:solid_cuboid_inertia
+          m="0.160"
+          w="0.05"
+          h="0.05"
+          d="0.07" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-      <parent link="${frame_prefix}base_link"/>
-      <child link="${frame_prefix}link"/>
-      <origin xyz="0.00 0 0.05315" rpy="0 0 0"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
+      <origin
+        xyz="0.00 0 0.05315"
+        rpy="0 0 0" />
     </joint>
 
     <link name="${frame_prefix}link">
@@ -57,8 +78,7 @@
       frame_link="${frame_prefix}link"
       rate="10"
       resolution="0.004359297"
-      samples="640"
-    >
+      samples="640">
     </xacro:lidar_2d_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/2d_lidar/hokuyo_ust10lx.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/hokuyo_ust10lx.urdf.xacro
@@ -1,54 +1,77 @@
-<?xml version="1.0"?>
-<robot name="sensor_hokuyo_ust10lx" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_hokuyo_ust10lx"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_hokuyo_ust10lx"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=hokuyo_ust10lx
-                       node_namespace:=${None}
-                       topic_prefix:=~/
-                       gpu:=false">
+  <xacro:macro
+    name="sensor_hokuyo_ust10lx"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=hokuyo_ust10lx
+            node_namespace:=${None}
+            topic_prefix:=~/
+            gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <collision>
-        <origin xyz="0 0 0.0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0.0"
+          rpy="0 0 0" />
         <geometry>
-          <box size="0.010 0.010 0.010"/>
+          <box size="0.010 0.010 0.010" />
         </geometry>
       </collision>
 
       <visual>
-        <origin xyz="0 0 0.0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0.0"
+          rpy="0 0 0" />
         <geometry>
-            <mesh filename="package://robotnik_sensors/meshes/hokuyo_ust_10lx.dae"/>
+            <mesh
+            filename="package://robotnik_sensors/meshes/hokuyo_ust_10lx.dae" />
         </geometry>
       </visual>
 
       <inertial>
-        <origin xyz="0.0 0 0.035" rpy="0 0 0" />
+        <origin
+          xyz="0.0 0 0.035"
+          rpy="0 0 0" />
         <mass value="0.130" />
-        <xacro:solid_cuboid_inertia m="0.130" w="0.05" h="0.05" d="0.07" />
+        <xacro:solid_cuboid_inertia
+          m="0.130"
+          w="0.05"
+          h="0.05"
+          d="0.07" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-      <origin xyz="0 0 0.0474" rpy="0 0 0"/>
-      <parent link="${frame_prefix}base_link"/>
-      <child link="${frame_prefix}link"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0.0474"
+        rpy="0 0 0" />
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
     </joint>
 
     <link name="${frame_prefix}link">
@@ -66,8 +89,7 @@
       frame_link="${frame_prefix}link"
       rate="40"
       resolution="0.004359297"
-      samples="1081"
-    >
+      samples="1081">
     </xacro:lidar_2d_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/2d_lidar/hokuyo_ust10lx.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/hokuyo_ust10lx.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_hokuyo_ust10lx"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
@@ -46,7 +45,7 @@
           xyz="0 0 0.0"
           rpy="0 0 0" />
         <geometry>
-            <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/hokuyo_ust_10lx.dae" />
         </geometry>
       </visual>
@@ -74,8 +73,7 @@
       <child link="${frame_prefix}link" />
     </joint>
 
-    <link name="${frame_prefix}link">
-    </link>
+    <link name="${frame_prefix}link" />
 
     <!-- Hokuyo sensor for simulation -->
     <xacro:lidar_2d_plugin
@@ -89,9 +87,6 @@
       frame_link="${frame_prefix}link"
       rate="40"
       resolution="0.004359297"
-      samples="1081">
-    </xacro:lidar_2d_plugin>
-
+      samples="1081" />
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/2d_lidar/hokuyo_ust20lx.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/hokuyo_ust20lx.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_hokuyo_ust20lx"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
@@ -72,7 +71,7 @@
       <origin
         xyz="0.00 0.0 0.0474"
         rpy="0 0 0" />
-	  </joint>
+    </joint>
 
     <link name="${frame_prefix}link" />
 
@@ -88,8 +87,6 @@
       frame_link="${frame_prefix}link"
       rate="40"
       resolution="0.004359297"
-      samples="1081">
-    </xacro:lidar_2d_plugin>
-
+      samples="1081" />
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/2d_lidar/hokuyo_ust20lx.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/hokuyo_ust20lx.urdf.xacro
@@ -1,55 +1,80 @@
-<?xml version="1.0"?>
-<robot name="sensor_hokuyo_ust20lx" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_hokuyo_ust20lx"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_hokuyo_ust20lx"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=hokuyo_ust20lx
-                       node_namespace:=${None}
-                       topic_prefix:=~/
-                       gpu:=false">
+  <xacro:macro
+    name="sensor_hokuyo_ust20lx"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=hokuyo_ust20lx
+            node_namespace:=${None}
+            topic_prefix:=~/
+            gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <collision>
-        <origin xyz="0 0 0.036" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0.036"
+          rpy="0 0 0" />
         <geometry>
-          <cylinder length="0.072" radius="0.022"/>
+          <cylinder
+            length="0.072"
+            radius="0.022" />
         </geometry>
       </collision>
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/hokuyo_ust_20lx.dae"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/hokuyo_ust_20lx.dae" />
         </geometry>
       </visual>
       <inertial>
-        <origin xyz="0.0 0 0.036" rpy="0 0 0" />
+        <origin
+          xyz="0.0 0 0.036"
+          rpy="0 0 0" />
         <mass value="0.130" />
-        <xacro:solid_cuboid_inertia m="0.130" w="0.05" h="0.05" d="0.07" />
+        <xacro:solid_cuboid_inertia
+          m="0.130"
+          w="0.05"
+          h="0.05"
+          d="0.07" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-      <parent link="${frame_prefix}base_link"/>
-      <child link="${frame_prefix}link"/>
-      <origin xyz="0.00 0.0 0.0474" rpy="0 0 0"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
+      <origin
+        xyz="0.00 0.0 0.0474"
+        rpy="0 0 0" />
 	  </joint>
 
-    <link name="${frame_prefix}link"/>
+    <link name="${frame_prefix}link" />
 
     <!-- Hokuyo sensor for simulation -->
     <xacro:lidar_2d_plugin
@@ -63,8 +88,7 @@
       frame_link="${frame_prefix}link"
       rate="40"
       resolution="0.004359297"
-      samples="1081"
-    >
+      samples="1081">
     </xacro:lidar_2d_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/2d_lidar/hokuyo_utm30lx.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/hokuyo_utm30lx.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_hokuyo_utm30lx"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
@@ -35,14 +34,13 @@
       <child link="${frame_prefix}base_link" />
     </joint>
 
-
     <link name="${frame_prefix}base_link">
       <visual>
         <origin
           xyz="0 0 0.055"
           rpy="0 0 0" />
         <geometry>
-            <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/hokuyo_utm_30lx.dae" />
         </geometry>
       </visual>
@@ -68,10 +66,9 @@
       <origin
         xyz="0.00 0 0.055"
         rpy="0 0 0" />
-	  </joint>
+    </joint>
 
-    <link name="${frame_prefix}link">
-    </link>
+    <link name="${frame_prefix}link" />
 
     <!-- Hokuyo sensor for simulation -->
     <xacro:lidar_2d_plugin
@@ -85,9 +82,6 @@
       frame_link="${frame_prefix}link"
       rate="30"
       resolution="0.01"
-      samples="1081">
-    </xacro:lidar_2d_plugin>
-
+      samples="1081" />
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/2d_lidar/hokuyo_utm30lx.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/hokuyo_utm30lx.urdf.xacro
@@ -1,52 +1,73 @@
-<?xml version="1.0"?>
-<robot name="sensor_hokuyo_utm30lx" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_hokuyo_utm30lx"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_hokuyo_utm30lx"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=hokuyo_utm30lx
-                       node_namespace:=${None}
-                       topic_prefix:=~/
-                       gpu:=false">
+  <xacro:macro
+    name="sensor_hokuyo_utm30lx"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=hokuyo_utm30lx
+            node_namespace:=${None}
+            topic_prefix:=~/
+            gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <!-- FRONT MOUNT  -->
       <!-- origin xyz="0.29 0 0.1" -->
       <!-- TOP MOUNT -->
       <!-- origin xyz="0.0 0.0 0.325"-->
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
 
     <link name="${frame_prefix}base_link">
       <visual>
-        <origin xyz="0 0 0.055" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0.055"
+          rpy="0 0 0" />
         <geometry>
-            <mesh filename="package://robotnik_sensors/meshes/hokuyo_utm_30lx.dae"/>
+            <mesh
+            filename="package://robotnik_sensors/meshes/hokuyo_utm_30lx.dae" />
         </geometry>
       </visual>
 
       <inertial>
-        <origin xyz="0.0 0 0.0435" rpy="0 0 0" />
+        <origin
+          xyz="0.0 0 0.0435"
+          rpy="0 0 0" />
         <mass value="0.370" />
-        <xacro:solid_cuboid_inertia m="0.370" w="0.06" h="0.06" d="0.087" />
+        <xacro:solid_cuboid_inertia
+          m="0.370"
+          w="0.06"
+          h="0.06"
+          d="0.087" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-      <parent link="${frame_prefix}base_link"/>
-      <child link="${frame_prefix}link"/>
-      <origin xyz="0.00 0 0.055" rpy="0 0 0"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
+      <origin
+        xyz="0.00 0 0.055"
+        rpy="0 0 0" />
 	  </joint>
 
     <link name="${frame_prefix}link">
@@ -64,8 +85,7 @@
       frame_link="${frame_prefix}link"
       rate="30"
       resolution="0.01"
-      samples="1081"
-    >
+      samples="1081">
     </xacro:lidar_2d_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="lidar_2d_plugin"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="lidar_2d_plugin"
     params="node_namespace
@@ -17,7 +16,6 @@
             resolution
             samples
             ">
-
     <xacro:if value="${gazebo_ignition}">
       <gazebo reference="${frame_link}">
         <sensor
@@ -52,7 +50,5 @@
         </sensor>
       </gazebo>
     </xacro:if>
-
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro
@@ -1,8 +1,11 @@
-<?xml version="1.0"?>
-<robot name="lidar_2d_plugin" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="lidar_2d_plugin"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="lidar_2d_plugin" params="
-            node_namespace
+  <xacro:macro
+    name="lidar_2d_plugin"
+    params="node_namespace
             node_name
             gazebo_ignition
             min_range
@@ -17,7 +20,9 @@
 
     <xacro:if value="${gazebo_ignition}">
       <gazebo reference="${frame_link}">
-        <sensor type="gpu_lidar" name="${node_name}">
+        <sensor
+          type="gpu_lidar"
+          name="${node_name}">
           <pose>0 0 0 0 0 0</pose>
           <visualize>false</visualize>
           <update_rate>${rate}</update_rate>
@@ -42,8 +47,8 @@
             </noise>
           </lidar>
 
-          <topic> ${node_namespace}/${node_name}/scan </topic>
-          <gz_frame_id> ${frame_link} </gz_frame_id>
+          <topic>${node_namespace}/${node_name}/scan</topic>
+          <gz_frame_id>${frame_link}</gz_frame_id>
         </sensor>
       </gazebo>
     </xacro:if>

--- a/robotnik_sensors/urdf/2d_lidar/sick_microscan3.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_microscan3.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_sick_microscan3"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
@@ -37,7 +36,7 @@
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
-		  <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/2d_lidar/sick/microscan3.dae" />
         </geometry>
       </visual>
@@ -46,7 +45,7 @@
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
-		  <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/2d_lidar/sick/microscan3.dae" />
         </geometry>
       </collision>
@@ -66,7 +65,7 @@
     <joint
       name="${frame_prefix}joint"
       type="fixed">
-		  <origin
+      <origin
         xyz="0.0 0 0.110"
         rpy="0 0 0" />
       <parent link="${frame_prefix}base_link" />
@@ -87,9 +86,6 @@
       frame_link="${frame_prefix}link"
       rate="30"
       resolution="0.00575"
-      samples="700">
-    </xacro:lidar_2d_plugin>
-
+      samples="700" />
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/2d_lidar/sick_microscan3.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_microscan3.urdf.xacro
@@ -1,55 +1,79 @@
-<?xml version="1.0"?>
-<robot name="sensor_sick_microscan3" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_sick_microscan3"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_sick_microscan3"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=sick_microscan3
-                       node_namespace:=${None}
-                       topic_prefix:=~/
-                       gpu:=false">
+  <xacro:macro
+    name="sensor_sick_microscan3"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=sick_microscan3
+            node_namespace:=${None}
+            topic_prefix:=~/
+            gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-		  <mesh filename="package://robotnik_sensors/meshes/2d_lidar/sick/microscan3.dae"/>
+		  <mesh
+            filename="package://robotnik_sensors/meshes/2d_lidar/sick/microscan3.dae" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-		  <mesh filename="package://robotnik_sensors/meshes/2d_lidar/sick/microscan3.dae"/>
+		  <mesh
+            filename="package://robotnik_sensors/meshes/2d_lidar/sick/microscan3.dae" />
         </geometry>
       </collision>
       <inertial>
         <mass value="1.15" />
-        <origin xyz="0 0 0.075" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="1.15" w="0.112" h="0.111" d="0.15" />
+        <origin
+          xyz="0 0 0.075"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="1.15"
+          w="0.112"
+          h="0.111"
+          d="0.15" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-		  <origin xyz="0.0 0 0.110" rpy="0 0 0"/>
-      <parent link="${frame_prefix}base_link"/>
-      <child link="${frame_prefix}link"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+		  <origin
+        xyz="0.0 0 0.110"
+        rpy="0 0 0" />
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
     </joint>
 
-    <link name="${frame_prefix}link"/>
+    <link name="${frame_prefix}link" />
 
     <!-- sick_microscan3 sensor for simulation -->
     <xacro:lidar_2d_plugin
@@ -63,8 +87,7 @@
       frame_link="${frame_prefix}link"
       rate="30"
       resolution="0.00575"
-      samples="700"
-    >
+      samples="700">
     </xacro:lidar_2d_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/2d_lidar/sick_nanoscan3.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_nanoscan3.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_sick_nanoscan3"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
@@ -37,7 +36,7 @@
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
-		  <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/2d_lidar/sick/nanoscan3.stl" />
         </geometry>
       </visual>
@@ -46,7 +45,7 @@
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
-		  <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/2d_lidar/sick/nanoscan3.stl" />
         </geometry>
       </collision>
@@ -60,7 +59,7 @@
           w="0.1006"
           h="0.1006"
           d="0.08" />
-	  </inertial>
+      </inertial>
     </link>
 
     <joint
@@ -87,9 +86,6 @@
       frame_link="${frame_prefix}link"
       rate="12.5"
       resolution="0.00575"
-      samples="1600">
-    </xacro:lidar_2d_plugin>
-
+      samples="1600" />
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/2d_lidar/sick_nanoscan3.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_nanoscan3.urdf.xacro
@@ -1,55 +1,79 @@
-<?xml version="1.0"?>
-<robot name="sensor_sick_nanoscan3" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_sick_nanoscan3"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_sick_nanoscan3"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=sick_nanoscan3
-                       node_namespace:=${None}
-                       topic_prefix:=~/
-                       gpu:=false">
+  <xacro:macro
+    name="sensor_sick_nanoscan3"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=sick_nanoscan3
+            node_namespace:=${None}
+            topic_prefix:=~/
+            gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-		  <mesh filename="package://robotnik_sensors/meshes/2d_lidar/sick/nanoscan3.stl"/>
+		  <mesh
+            filename="package://robotnik_sensors/meshes/2d_lidar/sick/nanoscan3.stl" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-		  <mesh filename="package://robotnik_sensors/meshes/2d_lidar/sick/nanoscan3.stl"/>
+		  <mesh
+            filename="package://robotnik_sensors/meshes/2d_lidar/sick/nanoscan3.stl" />
         </geometry>
       </collision>
       <inertial>
         <mass value="0.67" />
-        <origin xyz="0 0 0.04" rpy="0 0 0" />
-        <xacro:solid_cuboid_inertia m="0.67" w="0.1006" h="0.1006" d="0.08" />
+        <origin
+          xyz="0 0 0.04"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.67"
+          w="0.1006"
+          h="0.1006"
+          d="0.08" />
 	  </inertial>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-      <origin xyz="0.0 0 0.0505" rpy="0 0 0"/>
-      <parent link="${frame_prefix}base_link"/>
-      <child link="${frame_prefix}link"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0 0.0505"
+        rpy="0 0 0" />
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
     </joint>
 
-    <link name="${frame_prefix}link"/>
+    <link name="${frame_prefix}link" />
 
     <!-- sick_nanoscan3 sensor for simulation -->
     <xacro:lidar_2d_plugin
@@ -63,8 +87,7 @@
       frame_link="${frame_prefix}link"
       rate="12.5"
       resolution="0.00575"
-      samples="1600"
-    >
+      samples="1600">
     </xacro:lidar_2d_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/2d_lidar/sick_outdoorscan3.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_outdoorscan3.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_sick_outdoorscan3"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
@@ -36,7 +35,7 @@
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
-		  <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/2d_lidar/sick/outdoorscan3.dae" />
         </geometry>
       </visual>
@@ -45,27 +44,27 @@
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
-		  <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/2d_lidar/sick/outdoorscan3.dae" />
         </geometry>
       </collision>
       <inertial>
-		<mass value="1.15" />
-		<origin
+        <mass value="1.15" />
+        <origin
           xyz="0 0 0.075"
           rpy="0 0 0" />
-		<xacro:solid_cuboid_inertia
+        <xacro:solid_cuboid_inertia
           m="1.15"
           w="0.112"
           h="0.111"
           d="0.15" />
-	  </inertial>
+      </inertial>
     </link>
 
     <joint
       name="${frame_prefix}joint"
       type="fixed">
-	  <origin
+      <origin
         xyz="0.0 0 0.110"
         rpy="0 0 0" />
       <parent link="${frame_prefix}base_link" />
@@ -85,9 +84,7 @@
       frame_link="${frame_prefix}link"
       rate="12.5"
       resolution="0.00575"
-      samples="700">
-    </xacro:lidar_2d_plugin>
-
+      samples="700" />
   </xacro:macro>
 
   <xacro:macro name="sensor_sick_outdoorscan3_gazebo">
@@ -101,44 +98,44 @@
         name="ray_type"
         value="ray" />
     </xacro:unless>
-      <gazebo reference="${frame_prefix}link">
-        <sensor
+    <gazebo reference="${frame_prefix}link">
+      <sensor
         type="${ray_type}"
         name="${frame_prefix}sensor">
-          <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
-          <visualize>false</visualize>
-		      <update_rate>12.5</update_rate>
-          <ray>
-            <scan>
-              <horizontal>
-                <samples>700</samples>
-                <resolution>1</resolution>
-                <min_angle>${-radians(135)}</min_angle>
-                <max_angle>${radians(135)}</max_angle>
-              </horizontal>
-            </scan>
-            <range>
-              <min>0.05</min>
-			        <max>40.0</max>
-              <resolution>0.00575</resolution>
-            </range>
-            <noise>
-              <type>gaussian</type>
-              <mean>0.0</mean>
-              <stddev>0.01</stddev>
-            </noise>
-          </ray>
-          <plugin
+        <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+        <visualize>false</visualize>
+        <update_rate>12.5</update_rate>
+        <ray>
+          <scan>
+            <horizontal>
+              <samples>700</samples>
+              <resolution>1</resolution>
+              <min_angle>${-radians(135)}</min_angle>
+              <max_angle>${radians(135)}</max_angle>
+            </horizontal>
+          </scan>
+          <range>
+            <min>0.05</min>
+            <max>40.0</max>
+            <resolution>0.00575</resolution>
+          </range>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </ray>
+        <plugin
           name="${node_name}"
           filename="libgazebo_ros_ray_sensor.so">
-            <ros>
-              <namespace>${node_namespace}</namespace>
-              <remapping>~/out:=~/scan</remapping>
-            </ros>
-            <output_type>sensor_msgs/LaserScan</output_type>
-            <frame_name>${frame_prefix}link</frame_name>
-          </plugin>
-        </sensor>
-      </gazebo>
+          <ros>
+            <namespace>${node_namespace}</namespace>
+            <remapping>~/out:=~/scan</remapping>
+          </ros>
+          <output_type>sensor_msgs/LaserScan</output_type>
+          <frame_name>${frame_prefix}link</frame_name>
+        </plugin>
+      </sensor>
+    </gazebo>
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/2d_lidar/sick_outdoorscan3.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_outdoorscan3.urdf.xacro
@@ -1,54 +1,78 @@
-<?xml version="1.0"?>
-<robot name="sensor_sick_outdoorscan3" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_sick_outdoorscan3"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_sick_outdoorscan3"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=sick_outdoorscan3
-                       node_namespace:=${None}
-                       topic_prefix:=~/
-                       gpu:=false">
+  <xacro:macro
+    name="sensor_sick_outdoorscan3"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=sick_outdoorscan3
+            node_namespace:=${None}
+            topic_prefix:=~/
+            gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
     <link name="${frame_prefix}base_link">
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-		  <mesh filename="package://robotnik_sensors/meshes/2d_lidar/sick/outdoorscan3.dae"/>
+		  <mesh
+            filename="package://robotnik_sensors/meshes/2d_lidar/sick/outdoorscan3.dae" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-		  <mesh filename="package://robotnik_sensors/meshes/2d_lidar/sick/outdoorscan3.dae"/>
+		  <mesh
+            filename="package://robotnik_sensors/meshes/2d_lidar/sick/outdoorscan3.dae" />
         </geometry>
       </collision>
       <inertial>
 		<mass value="1.15" />
-		<origin xyz="0 0 0.075" rpy="0 0 0"/>
-		<xacro:solid_cuboid_inertia m="1.15" w="0.112" h="0.111" d="0.15" />
+		<origin
+          xyz="0 0 0.075"
+          rpy="0 0 0" />
+		<xacro:solid_cuboid_inertia
+          m="1.15"
+          w="0.112"
+          h="0.111"
+          d="0.15" />
 	  </inertial>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-	  <origin xyz="0.0 0 0.110" rpy="0 0 0"/>
-      <parent link="${frame_prefix}base_link"/>
-      <child link="${frame_prefix}link"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+	  <origin
+        xyz="0.0 0 0.110"
+        rpy="0 0 0" />
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
     </joint>
 
-    <link name="${frame_prefix}link"/>
+    <link name="${frame_prefix}link" />
 
     <xacro:lidar_2d_plugin
       node_namespace="${node_namespace}"
@@ -61,21 +85,26 @@
       frame_link="${frame_prefix}link"
       rate="12.5"
       resolution="0.00575"
-      samples="700"
-    >
+      samples="700">
     </xacro:lidar_2d_plugin>
 
   </xacro:macro>
 
   <xacro:macro name="sensor_sick_outdoorscan3_gazebo">
     <xacro:if value="${gpu}">
-      <xacro:property name="ray_type" value="gpu_ray" />
+      <xacro:property
+        name="ray_type"
+        value="gpu_ray" />
     </xacro:if>
     <xacro:unless value="${gpu}">
-      <xacro:property name="ray_type" value="ray" />
+      <xacro:property
+        name="ray_type"
+        value="ray" />
     </xacro:unless>
       <gazebo reference="${frame_prefix}link">
-        <sensor type="${ray_type}" name="${frame_prefix}sensor">
+        <sensor
+        type="${ray_type}"
+        name="${frame_prefix}sensor">
           <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
           <visualize>false</visualize>
 		      <update_rate>12.5</update_rate>
@@ -99,7 +128,9 @@
               <stddev>0.01</stddev>
             </noise>
           </ray>
-          <plugin name="${node_name}" filename="libgazebo_ros_ray_sensor.so">
+          <plugin
+          name="${node_name}"
+          filename="libgazebo_ros_ray_sensor.so">
             <ros>
               <namespace>${node_namespace}</namespace>
               <remapping>~/out:=~/scan</remapping>

--- a/robotnik_sensors/urdf/2d_lidar/sick_s300.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_s300.urdf.xacro
@@ -1,55 +1,79 @@
-<?xml version="1.0"?>
-<robot name="sensor_sick_s300" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_sick_s300"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_sick_s300"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=sick_s300
-                       node_namespace:=${None}
-                       topic_prefix:=~/
-                       gpu:=false">
+  <xacro:macro
+    name="sensor_sick_s300"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=sick_s300
+            node_namespace:=${None}
+            topic_prefix:=~/
+            gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <visual>
-        <origin xyz="0 0 0" rpy="${-pi/2} 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="${-radians(90)} 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/2d_lidar/sick/s300.dae"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/2d_lidar/sick/s300.dae" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="${-pi/2} 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="${-radians(90)} 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/2d_lidar/sick/s300.dae"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/2d_lidar/sick/s300.dae" />
         </geometry>
       </collision>
       <inertial>
         <mass value="0.25" />
-        <origin xyz="-0.0017 0 0.042875" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.25" w="0.061" h="0.06" d="0.08575" />
+        <origin
+          xyz="-0.0017 0 0.042875"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.25"
+          w="0.061"
+          h="0.06"
+          d="0.08575" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-      <origin xyz="0.0 0 0.116" rpy="0 0 0"/>
-      <parent link="${frame_prefix}base_link"/>
-      <child link="${frame_prefix}link"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0 0.116"
+        rpy="0 0 0" />
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
     </joint>
 
-    <link name="${frame_prefix}link"/>
+    <link name="${frame_prefix}link" />
 
     <xacro:lidar_2d_plugin
       node_namespace="${node_namespace}"
@@ -62,8 +86,7 @@
       frame_link="${frame_prefix}link"
       rate="25.0"
       resolution="0.00575"
-      samples="270"
-    >
+      samples="270">
     </xacro:lidar_2d_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/2d_lidar/sick_s300.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_s300.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_sick_s300"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
@@ -86,9 +85,6 @@
       frame_link="${frame_prefix}link"
       rate="25.0"
       resolution="0.00575"
-      samples="270">
-    </xacro:lidar_2d_plugin>
-
+      samples="270" />
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/2d_lidar/sick_s3000.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_s3000.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_sick_s3000"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
@@ -37,7 +36,7 @@
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
-		  <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/2d_lidar/sick/s3000.dae" />
         </geometry>
       </visual>
@@ -46,7 +45,7 @@
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
-		  <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/2d_lidar/sick/s3000.dae" />
         </geometry>
       </collision>
@@ -60,7 +59,7 @@
           w="0.16"
           h="0.160"
           d="0.185" />
-	  </inertial>
+      </inertial>
     </link>
 
     <joint
@@ -86,9 +85,6 @@
       frame_link="${frame_prefix}link"
       rate="15.0"
       resolution="0.00575"
-      samples="380">
-    </xacro:lidar_2d_plugin>
-
+      samples="380" />
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/2d_lidar/sick_s3000.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_s3000.urdf.xacro
@@ -1,55 +1,79 @@
-<?xml version="1.0"?>
-<robot name="sensor_sick_s3000" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_sick_s3000"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_sick_s3000"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=sick_s3000
-                       node_namespace:=${None}
-                       topic_prefix:=~/
-                       gpu:=false">
+  <xacro:macro
+    name="sensor_sick_s3000"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=sick_s3000
+            node_namespace:=${None}
+            topic_prefix:=~/
+            gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-		  <mesh filename="package://robotnik_sensors/meshes/2d_lidar/sick/s3000.dae"/>
+		  <mesh
+            filename="package://robotnik_sensors/meshes/2d_lidar/sick/s3000.dae" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-		  <mesh filename="package://robotnik_sensors/meshes/2d_lidar/sick/s3000.dae"/>
+		  <mesh
+            filename="package://robotnik_sensors/meshes/2d_lidar/sick/s3000.dae" />
         </geometry>
       </collision>
       <inertial>
         <mass value="3.3" />
-        <origin xyz="0.08 0 0.0925" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="3.3" w="0.16" h="0.160" d="0.185" />
+        <origin
+          xyz="0.08 0 0.0925"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="3.3"
+          w="0.16"
+          h="0.160"
+          d="0.185" />
 	  </inertial>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-      <origin xyz="0.093 0 0.0625" rpy="0 0 0"/>
-      <parent link="${frame_prefix}base_link"/>
-      <child link="${frame_prefix}link"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+      <origin
+        xyz="0.093 0 0.0625"
+        rpy="0 0 0" />
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
     </joint>
 
-    <link name="${frame_prefix}link"/>
+    <link name="${frame_prefix}link" />
 
     <xacro:lidar_2d_plugin
       node_namespace="${node_namespace}"
@@ -62,8 +86,7 @@
       frame_link="${frame_prefix}link"
       rate="15.0"
       resolution="0.00575"
-      samples="380"
-    >
+      samples="380">
     </xacro:lidar_2d_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/2d_lidar/sick_tim551.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_tim551.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_sick_tim551"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
@@ -37,7 +36,7 @@
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
-         <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/2d_lidar/sick/tim551.dae" />
         </geometry>
       </collision>
@@ -46,7 +45,7 @@
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
-            <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/2d_lidar/sick/tim551.dae" />
         </geometry>
       </visual>
@@ -86,9 +85,6 @@
       frame_link="${frame_prefix}link"
       rate="15.0"
       resolution="0.00575"
-      samples="1600">
-    </xacro:lidar_2d_plugin>
-
+      samples="1600" />
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/2d_lidar/sick_tim551.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_tim551.urdf.xacro
@@ -1,55 +1,79 @@
-<?xml version="1.0"?>
-<robot name="sensor_sick_tim551" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_sick_tim551"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_sick_tim551"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=sick_tim551
-                       node_namespace:=${None}
-                       topic_prefix:=~/
-                       gpu:=false">
+  <xacro:macro
+    name="sensor_sick_tim551"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=sick_tim551
+            node_namespace:=${None}
+            topic_prefix:=~/
+            gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-         <mesh filename="package://robotnik_sensors/meshes/2d_lidar/sick/tim551.dae"/>
+         <mesh
+            filename="package://robotnik_sensors/meshes/2d_lidar/sick/tim551.dae" />
         </geometry>
       </collision>
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-            <mesh filename="package://robotnik_sensors/meshes/2d_lidar/sick/tim551.dae"/>
+            <mesh
+            filename="package://robotnik_sensors/meshes/2d_lidar/sick/tim551.dae" />
         </geometry>
       </visual>
       <inertial>
         <mass value="0.25" />
-        <origin xyz="-0.0017 0 0.042875" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.25" w="0.061" h="0.06" d="0.08575" />
+        <origin
+          xyz="-0.0017 0 0.042875"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.25"
+          w="0.061"
+          h="0.06"
+          d="0.08575" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-      <origin xyz="0 0 0.06246" rpy="0 0 0"/>
-      <parent link="${frame_prefix}base_link"/>
-      <child link="${frame_prefix}link"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0.06246"
+        rpy="0 0 0" />
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
     </joint>
 
-    <link name="${frame_prefix}link"/>
+    <link name="${frame_prefix}link" />
 
     <xacro:lidar_2d_plugin
       node_namespace="${node_namespace}"
@@ -62,8 +86,7 @@
       frame_link="${frame_prefix}link"
       rate="15.0"
       resolution="0.00575"
-      samples="1600"
-    >
+      samples="1600">
     </xacro:lidar_2d_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/2d_lidar/sick_tim571.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_tim571.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_sick_tim551"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
@@ -37,7 +36,7 @@
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
-         <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/2d_lidar/sick/tim571.dae" />
         </geometry>
       </collision>
@@ -46,7 +45,7 @@
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
-            <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/2d_lidar/sick/tim571.dae" />
         </geometry>
       </visual>
@@ -86,9 +85,6 @@
       frame_link="${frame_prefix}link"
       rate="15.0"
       resolution="0.00575"
-      samples="810">
-    </xacro:lidar_2d_plugin>
-
+      samples="810" />
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/2d_lidar/sick_tim571.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_tim571.urdf.xacro
@@ -1,55 +1,79 @@
-<?xml version="1.0"?>
-<robot name="sensor_sick_tim551" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_sick_tim551"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/lidar_2d_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_sick_tim571"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=sick_tim571
-                       node_namespace:=${None}
-                       topic_prefix:=~/
-                       gpu:=false">
+  <xacro:macro
+    name="sensor_sick_tim571"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=sick_tim571
+            node_namespace:=${None}
+            topic_prefix:=~/
+            gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-         <mesh filename="package://robotnik_sensors/meshes/2d_lidar/sick/tim571.dae"/>
+         <mesh
+            filename="package://robotnik_sensors/meshes/2d_lidar/sick/tim571.dae" />
         </geometry>
       </collision>
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-            <mesh filename="package://robotnik_sensors/meshes/2d_lidar/sick/tim571.dae"/>
+            <mesh
+            filename="package://robotnik_sensors/meshes/2d_lidar/sick/tim571.dae" />
         </geometry>
       </visual>
       <inertial>
         <mass value="0.25" />
-        <origin xyz="-0.0017 0 0.042875" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.25" w="0.061" h="0.06" d="0.08575" />
+        <origin
+          xyz="-0.0017 0 0.042875"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.25"
+          w="0.061"
+          h="0.06"
+          d="0.08575" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-      <origin xyz="0 0 0.05746" rpy="0 0 0"/>
-      <parent link="${frame_prefix}base_link"/>
-      <child link="${frame_prefix}link"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0.05746"
+        rpy="0 0 0" />
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
     </joint>
 
-    <link name="${frame_prefix}link"/>
+    <link name="${frame_prefix}link" />
 
     <xacro:lidar_2d_plugin
       node_namespace="${node_namespace}"
@@ -57,13 +81,12 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.05"
       max_range="25.0"
-      min_angle="${-radians(135)}"
-      max_angle="${radians(135)}"
+      min_angle="${-radians(130)}"
+      max_angle="${radians(130)}"
       frame_link="${frame_prefix}link"
       rate="15.0"
       resolution="0.00575"
-      samples="810"
-    >
+      samples="810">
     </xacro:lidar_2d_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro
@@ -1,13 +1,16 @@
-<?xml version="1.0"?>
-<robot name="lidar_3d_plugin" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="lidar_3d_plugin"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="lidar_3d_plugin" params="
-            node_namespace
+  <xacro:macro
+    name="lidar_3d_plugin"
+    params="node_namespace
             node_name
             gazebo_ignition
             min_range
             max_range
-            min_angle:=0
+            min_angle
             max_angle
             frame_link
             rate
@@ -17,7 +20,9 @@
 
     <xacro:if value="${gazebo_ignition}">
       <gazebo reference="${frame_link}">
-        <sensor type="gpu_lidar" name="${node_name}">
+        <sensor
+          type="gpu_lidar"
+          name="${node_name}">
           <pose>0 0 0 0 0 0</pose>
           <visualize>false</visualize>
           <update_rate>${rate}</update_rate>
@@ -48,8 +53,8 @@
             </noise>
           </lidar>
 
-          <topic> ${node_namespace}/${node_name}/scan </topic>
-          <gz_frame_id> ${frame_link} </gz_frame_id>
+          <topic>${node_namespace}/${node_name}/scan</topic>
+          <gz_frame_id>${frame_link}</gz_frame_id>
         </sensor>
       </gazebo>
     </xacro:if>

--- a/robotnik_sensors/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="lidar_3d_plugin"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="lidar_3d_plugin"
     params="node_namespace
@@ -17,7 +16,6 @@
             horizontal_samples
             vertical_samples
             ">
-
     <xacro:if value="${gazebo_ignition}">
       <gazebo reference="${frame_link}">
         <sensor
@@ -58,7 +56,5 @@
         </sensor>
       </gazebo>
     </xacro:if>
-
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/3d_lidar/livox_mid_360.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/livox_mid_360.urdf.xacro
@@ -1,61 +1,85 @@
-<?xml version="1.0"?>
-<robot name="sensor_livox_mid_360" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_livox_mid_360"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
 
-  <xacro:property name="M_PI" value="3.1415926535897931" />
-
-  <xacro:macro name="sensor_livox_mid_360"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=livox_mid_360
-                       node_namespace:=${None}
-                       topic_prefix:=~/
-                       gpu:=false">
+  <xacro:macro
+    name="sensor_livox_mid_360"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=livox_mid_360
+            node_namespace:=${None}
+            topic_prefix:=~/
+            gpu:=false">
     <material name="black_alu">
-      <color rgba="0.9 0.9 0.9 1"/>
+      <color rgba="0.9 0.9 0.9 1" />
     </material>
 
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <visual>
-        <origin xyz="0 0 0" rpy="1.57 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="1.57 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/3d_lidar/livox_mid_360.stl" scale="0.001 0.001 0.001"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/3d_lidar/livox_mid_360.stl"
+            scale="0.001 0.001 0.001" />
         </geometry>
-        <material name="black_alu"/>
+        <material name="black_alu" />
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="1.57 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="1.57 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/3d_lidar/livox_mid_360.stl" scale="0.001 0.001 0.001"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/3d_lidar/livox_mid_360.stl"
+            scale="0.001 0.001 0.001" />
         </geometry>
       </collision>
       <inertial>
-        <origin xyz="-0.0 0.0 0.029" rpy="0 0 0" />
+        <origin
+          xyz="-0.0 0.0 0.029"
+          rpy="0 0 0" />
         <mass value="3.5" />
-        <xacro:solid_cuboid_inertia m="3.5" w="0.06" h="0.06" d="0.058" />
+        <xacro:solid_cuboid_inertia
+          m="3.5"
+          w="0.06"
+          h="0.06"
+          d="0.058" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-      <parent link="${frame_prefix}base_link"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+      <parent link="${frame_prefix}base_link" />
       <child link="${frame_prefix}link" />
-      <origin xyz="0.0 0 0.0365" rpy="0 0 0"/>
+      <origin
+        xyz="0.0 0 0.0365"
+        rpy="0 0 0" />
     </joint>
 
-    <link name="${frame_prefix}link"/>
+    <link name="${frame_prefix}link" />
 
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
@@ -63,12 +87,12 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="100.0"
+      min_angle="0.0"
       max_angle="85"
       frame_link="${frame_prefix}link"
       rate="10"
       horizontal_samples="1200"
-      vertical_samples="32"
-    >
+      vertical_samples="32">
     </xacro:lidar_3d_plugin>
   </xacro:macro>
 

--- a/robotnik_sensors/urdf/3d_lidar/livox_mid_360.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/livox_mid_360.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_livox_mid_360"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
 
@@ -92,8 +91,6 @@
       frame_link="${frame_prefix}link"
       rate="10"
       horizontal_samples="1200"
-      vertical_samples="32">
-    </xacro:lidar_3d_plugin>
+      vertical_samples="32" />
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/3d_lidar/ouster.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/ouster.urdf.xacro
@@ -1,61 +1,83 @@
-<?xml version="1.0"?>
-<robot name="sensor_ouster" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_ouster"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
 
-  <xacro:property name="M_PI" value="3.1415926535897931" />
-
-  <xacro:macro name="sensor_ouster"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=ouster
-                       node_namespace:=${None}
-                       topic_prefix:=~/
-                       gpu:=false">
+  <xacro:macro
+    name="sensor_ouster"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=ouster
+            node_namespace:=${None}
+            topic_prefix:=~/
+            gpu:=false">
     <material name="black_alu">
-      <color rgba="0.9 0.9 0.9 1"/>
+      <color rgba="0.9 0.9 0.9 1" />
     </material>
 
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/ouster1.STL"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/ouster1.STL" />
         </geometry>
-        <material name="black_alu"/>
+        <material name="black_alu" />
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/ouster1.STL"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/ouster1.STL" />
         </geometry>
       </collision>
       <inertial>
-        <origin xyz="-0.0 0.0 0.029" rpy="0 0 0" />
+        <origin
+          xyz="-0.0 0.0 0.029"
+          rpy="0 0 0" />
         <mass value="3.5" />
-        <xacro:solid_cuboid_inertia m="3.5" w="0.06" h="0.06" d="0.058" />
+        <xacro:solid_cuboid_inertia
+          m="3.5"
+          w="0.06"
+          h="0.06"
+          d="0.058" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-      <parent link="${frame_prefix}base_link"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+      <parent link="${frame_prefix}base_link" />
       <child link="${frame_prefix}link" />
-      <origin xyz="0.0 0 0.0365" rpy="0 0 0"/>
+      <origin
+        xyz="0.0 0 0.0365"
+        rpy="0 0 0" />
     </joint>
 
-    <link name="${frame_prefix}link"/>
+    <link name="${frame_prefix}link" />
 
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
@@ -63,12 +85,12 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="50.0"
+      min_angle="0.0"
       max_angle="85"
       frame_link="${frame_prefix}link"
       rate="10"
       horizontal_samples="1200"
-      vertical_samples="32"
-    >
+      vertical_samples="32">
     </xacro:lidar_3d_plugin>
 
 

--- a/robotnik_sensors/urdf/3d_lidar/ouster.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/ouster.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_ouster"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
 
@@ -90,11 +89,6 @@
       frame_link="${frame_prefix}link"
       rate="10"
       horizontal_samples="1200"
-      vertical_samples="32">
-    </xacro:lidar_3d_plugin>
-
-
+      vertical_samples="32" />
   </xacro:macro>
-
-
 </robot>

--- a/robotnik_sensors/urdf/3d_lidar/robosense_bpearl.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/robosense_bpearl.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_robosense_bpearl"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
 
@@ -16,7 +15,6 @@
             node_namespace:=${None}
             topic_prefix:=~/
             gpu:=false">
-
     <xacro:if value="${node_namespace == None}">
       <xacro:property
         name="node_namespace"
@@ -86,8 +84,6 @@
       frame_link="${frame_prefix}link"
       rate="10"
       horizontal_samples="1200"
-      vertical_samples="32">
-    </xacro:lidar_3d_plugin>
-
+      vertical_samples="32" />
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/3d_lidar/robosense_bpearl.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/robosense_bpearl.urdf.xacro
@@ -1,57 +1,79 @@
-<?xml version="1.0"?>
-<robot name="sensor_robosense_bpearl" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_robosense_bpearl"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
-  
-  <xacro:macro name="sensor_robosense_bpearl"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=robosense_bpearl
-                       node_namespace:=${None}
-                       topic_prefix:=~/
-                       gpu:=false">
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
+
+  <xacro:macro
+    name="sensor_robosense_bpearl"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=robosense_bpearl
+            node_namespace:=${None}
+            topic_prefix:=~/
+            gpu:=false">
 
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/3d_lidar/robotsense/bpearl.dae"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/3d_lidar/robotsense/bpearl.dae" />
         </geometry>
       </collision>
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/3d_lidar/robotsense/bpearl.dae"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/3d_lidar/robotsense/bpearl.dae" />
         </geometry>
         <material name="blackgray_color">
-          <color rgba="0.25 0.25 0.25 1"/>
+          <color rgba="0.25 0.25 0.25 1" />
         </material>
       </visual>
       <inertial>
         <mass value="0.92" />
         <origin xyz="0 0 0.055" />
-        <xacro:solid_cuboid_inertia m="0.92" w="0.111" h="0.111" d="0.11" />
+        <xacro:solid_cuboid_inertia
+          m="0.92"
+          w="0.111"
+          h="0.111"
+          d="0.11" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-      <parent link="${frame_prefix}base_link"/>
-      <child link="${frame_prefix}link"/>
-      <origin xyz="0 0 0.09427" rpy="0 0 0"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
+      <origin
+        xyz="0 0 0.09427"
+        rpy="0 0 0" />
     </joint>
-    <link name="${frame_prefix}link"/>
+    <link name="${frame_prefix}link" />
 
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
@@ -59,12 +81,12 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="100.0"
-      max_angle="85"
+      min_angle="0.0"
+      max_angle="85.0"
       frame_link="${frame_prefix}link"
       rate="10"
       horizontal_samples="1200"
-      vertical_samples="32"
-    >
+      vertical_samples="32">
     </xacro:lidar_3d_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/3d_lidar/robosense_helios_16p.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/robosense_helios_16p.urdf.xacro
@@ -1,58 +1,80 @@
-<?xml version="1.0"?>
-<robot name="sensor_robosense_helios" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_robosense_helios"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
-  
-  <xacro:macro name="sensor_robosense_helios_16p"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=robosense_helios_16p
-                       node_namespace:=${None}
-                       topic_prefix:=~/
-                       gpu:=false">
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
+
+  <xacro:macro
+    name="sensor_robosense_helios_16p"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=robosense_helios_16p
+            node_namespace:=${None}
+            topic_prefix:=~/
+            gpu:=false">
 
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/3d_lidar/robotsense/helios_16p.stl"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/3d_lidar/robotsense/helios_16p.stl" />
         </geometry>
       </collision>
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/3d_lidar/robotsense/helios_16p.stl"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/3d_lidar/robotsense/helios_16p.stl" />
         </geometry>
         <material name="blackgray_color">
-          <color rgba="0.25 0.25 0.25 1"/>
+          <color rgba="0.25 0.25 0.25 1" />
         </material>
       </visual>
       <inertial>
         <mass value="0.840" />
         <origin xyz="0 0 0.04135" />
-		<xacro:solid_cuboid_inertia m="0.840" w="0.109" h="0.109" d="0.0827" />
+		<xacro:solid_cuboid_inertia
+          m="0.840"
+          w="0.109"
+          h="0.109"
+          d="0.0827" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-      <parent link="${frame_prefix}base_link"/>
-      <child link="${frame_prefix}link"/>
-      <origin xyz="0.0 0 0.0635" rpy="0 0 0"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
+      <origin
+        xyz="0.0 0 0.0635"
+        rpy="0 0 0" />
     </joint>
 
-    <link name="${frame_prefix}link"/>
+    <link name="${frame_prefix}link" />
 
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
@@ -60,12 +82,12 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="50.0"
-      max_angle="85"
+      min_angle="0.0"
+      max_angle="85.0"
       frame_link="${frame_prefix}link"
       rate="10"
       horizontal_samples="1200"
-      vertical_samples="16"
-    >
+      vertical_samples="16">
     </xacro:lidar_3d_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/3d_lidar/robosense_helios_16p.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/robosense_helios_16p.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_robosense_helios"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
 
@@ -16,7 +15,6 @@
             node_namespace:=${None}
             topic_prefix:=~/
             gpu:=false">
-
     <xacro:if value="${node_namespace == None}">
       <xacro:property
         name="node_namespace"
@@ -56,7 +54,7 @@
       <inertial>
         <mass value="0.840" />
         <origin xyz="0 0 0.04135" />
-		<xacro:solid_cuboid_inertia
+        <xacro:solid_cuboid_inertia
           m="0.840"
           w="0.109"
           h="0.109"
@@ -87,9 +85,6 @@
       frame_link="${frame_prefix}link"
       rate="10"
       horizontal_samples="1200"
-      vertical_samples="16">
-    </xacro:lidar_3d_plugin>
-
+      vertical_samples="16" />
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/3d_lidar/sick_multiscan_100.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/sick_multiscan_100.urdf.xacro
@@ -1,61 +1,85 @@
-<?xml version="1.0"?>
-<robot name="sensor_sick_multiscan_100" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_sick_multiscan_100"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
 
-  <xacro:property name="M_PI" value="3.1415926535897931" />
-
-  <xacro:macro name="sensor_sick_multiscan_100"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=sick_multiscan_100
-                       node_namespace:=${None}
-                       topic_prefix:=~/
-                       gpu:=false">
+  <xacro:macro
+    name="sensor_sick_multiscan_100"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=sick_multiscan_100
+            node_namespace:=${None}
+            topic_prefix:=~/
+            gpu:=false">
     <material name="black_alu">
-      <color rgba="0.9 0.9 0.9 1"/>
+      <color rgba="0.9 0.9 0.9 1" />
     </material>
 
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <cylinder radius="0.05" length="0.1"/>
+          <cylinder
+            radius="0.05"
+            length="0.1" />
         </geometry>
-        <material name="black_alu"/>
+        <material name="black_alu" />
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <cylinder radius="0.05" length="0.1"/>
+          <cylinder
+            radius="0.05"
+            length="0.1" />
         </geometry>
       </collision>
       <inertial>
-        <origin xyz="-0.0 0.0 0.029" rpy="0 0 0" />
+        <origin
+          xyz="-0.0 0.0 0.029"
+          rpy="0 0 0" />
         <mass value="3.5" />
-        <xacro:solid_cuboid_inertia m="3.5" w="0.06" h="0.06" d="0.058" />
+        <xacro:solid_cuboid_inertia
+          m="3.5"
+          w="0.06"
+          h="0.06"
+          d="0.058" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-      <parent link="${frame_prefix}base_link"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+      <parent link="${frame_prefix}base_link" />
       <child link="${frame_prefix}link" />
-      <origin xyz="0.0 0 0.0365" rpy="0 0 0"/>
+      <origin
+        xyz="0.0 0 0.0365"
+        rpy="0 0 0" />
     </joint>
 
-    <link name="${frame_prefix}link"/>
+    <link name="${frame_prefix}link" />
 
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
@@ -63,12 +87,12 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="52.0"
+      min_angle="0.0"
       max_angle="65"
       frame_link="${frame_prefix}link"
       rate="10"
       horizontal_samples="1200"
-      vertical_samples="16"
-    >
+      vertical_samples="16">
     </xacro:lidar_3d_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/3d_lidar/sick_multiscan_100.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/sick_multiscan_100.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_sick_multiscan_100"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
 
@@ -92,10 +91,6 @@
       frame_link="${frame_prefix}link"
       rate="10"
       horizontal_samples="1200"
-      vertical_samples="16">
-    </xacro:lidar_3d_plugin>
-
+      vertical_samples="16" />
   </xacro:macro>
-
-
 </robot>

--- a/robotnik_sensors/urdf/3d_lidar/velodyne_vlp16.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/velodyne_vlp16.urdf.xacro
@@ -1,55 +1,79 @@
-<?xml version="1.0"?>
-<robot name="sensor_velodyne_vlp16" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_velodyne_vlp16"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_velodyne_vlp16"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=velodyne_vlp16
-                       node_namespace:=${None}
-                       topic_prefix:=~/
-                       gpu:=false">
+  <xacro:macro
+    name="sensor_velodyne_vlp16"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=velodyne_vlp16
+            node_namespace:=${None}
+            topic_prefix:=~/
+            gpu:=false">
 
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/3d_lidar/velodyne/vlp16.dae"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/3d_lidar/velodyne/vlp16.dae" />
         </geometry>
       </collision>
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/3d_lidar/velodyne/vlp16.dae"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/3d_lidar/velodyne/vlp16.dae" />
         </geometry>
       </visual>
       <inertial>
         <mass value="0.830" />
-        <origin xyz="0 0 0.03555" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.830" w="0.1033" h="0.1033" d="0.0711" />
+        <origin
+          xyz="0 0 0.03555"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.830"
+          w="0.1033"
+          h="0.1033"
+          d="0.0711" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-      <parent link="${frame_prefix}base_link"/>
-      <child link="${frame_prefix}link"/>
-      <origin xyz="0.0 0 0.035" rpy="0 0 0"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
+      <origin
+        xyz="0.0 0 0.035"
+        rpy="0 0 0" />
     </joint>
 
-    <link name="${frame_prefix}link"/>
+    <link name="${frame_prefix}link" />
 
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
@@ -62,8 +86,7 @@
       frame_link="${frame_prefix}link"
       rate="10"
       horizontal_samples="1200"
-      vertical_samples="15"
-    >
+      vertical_samples="15">
     </xacro:lidar_3d_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/3d_lidar/velodyne_vlp16.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/velodyne_vlp16.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_velodyne_vlp16"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
 
@@ -16,7 +15,6 @@
             node_namespace:=${None}
             topic_prefix:=~/
             gpu:=false">
-
     <xacro:if value="${node_namespace == None}">
       <xacro:property
         name="node_namespace"
@@ -86,9 +84,6 @@
       frame_link="${frame_prefix}link"
       rate="10"
       horizontal_samples="1200"
-      vertical_samples="15">
-    </xacro:lidar_3d_plugin>
-
+      vertical_samples="15" />
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/all_sensors.urdf.xacro
+++ b/robotnik_sensors/urdf/all_sensors.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="all_sensors"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <!-- This file unifies all sensors that can be used on simulation, defined as xacro:macros -->
 
   <xacro:include
@@ -89,5 +88,4 @@
     filename="$(find robotnik_sensors)/urdf/camera/axis_m5525.urdf.xacro" />
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/camera/axis_m5526.urdf.xacro" />
-
 </robot>

--- a/robotnik_sensors/urdf/all_sensors.urdf.xacro
+++ b/robotnik_sensors/urdf/all_sensors.urdf.xacro
@@ -1,55 +1,93 @@
-<?xml version="1.0"?>
-<robot name="all_sensors" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="all_sensors"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
   <!-- This file unifies all sensors that can be used on simulation, defined as xacro:macros -->
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/utils/inertia.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/utils/inertia.urdf.xacro" />
 
   <!-- Depth sensors -->
-  <xacro:include filename="$(find robotnik_sensors)/urdf/depth/intel_realsense_d435.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/depth/intel_realsense_d435i.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/depth/orbbec_astra.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/depth/stereolabs_generic.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/depth/stereolabs_zed2.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/depth/stereolabs_zed2i.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/depth/azure_kinect.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/depth/intel_realsense_d435.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/depth/intel_realsense_d435i.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/depth/orbbec_astra.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/depth/stereolabs_generic.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/depth/stereolabs_zed2.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/depth/stereolabs_zed2i.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/depth/azure_kinect.urdf.xacro" />
 
   <!-- 2D Lidars -->
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/sick_microscan3.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/sick_nanoscan3.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/sick_outdoorscan3.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/sick_s300.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/sick_s3000.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/sick_tim551.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/sick_tim571.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/hokuyo_urg04lx.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/hokuyo_ust10lx.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/hokuyo_ust20lx.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/2d_lidar/hokuyo_utm30lx.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/sick_microscan3.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/sick_nanoscan3.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/sick_outdoorscan3.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/sick_s300.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/sick_s3000.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/sick_tim551.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/sick_tim571.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/hokuyo_urg04lx.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/hokuyo_ust10lx.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/hokuyo_ust20lx.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/2d_lidar/hokuyo_utm30lx.urdf.xacro" />
 
   <!-- 3D Lidars -->
-  <xacro:include filename="$(find robotnik_sensors)/urdf/3d_lidar/velodyne_vlp16.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/3d_lidar/robosense_bpearl.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/3d_lidar/robosense_helios_16p.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/3d_lidar/ouster.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/3d_lidar/livox_mid_360.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/3d_lidar/sick_multiscan_100.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/3d_lidar/velodyne_vlp16.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/3d_lidar/robosense_bpearl.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/3d_lidar/robosense_helios_16p.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/3d_lidar/ouster.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/3d_lidar/livox_mid_360.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/3d_lidar/sick_multiscan_100.urdf.xacro" />
 
   <!-- IMUs -->
-  <xacro:include filename="$(find robotnik_sensors)/urdf/imu/vectornav.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/imu/myahrs.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/imu/pixhawk.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/imu/vectornav.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/imu/myahrs.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/imu/pixhawk.urdf.xacro" />
 
   <!-- GPS -->
-  <xacro:include filename="$(find robotnik_sensors)/urdf/gps/gps.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/gps/gps_with_mast.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/gps/ublox.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/gps/ublox_with_mast.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/gps/gps.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/gps/gps_with_mast.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/gps/ublox.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/gps/ublox_with_mast.urdf.xacro" />
 
   <!-- Camera -->
-  <xacro:include filename="$(find robotnik_sensors)/urdf/camera/axis_m5013.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/camera/axis_m5074.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/camera/axis_m5525.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/camera/axis_m5526.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/camera/axis_m5013.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/camera/axis_m5074.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/camera/axis_m5525.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/camera/axis_m5526.urdf.xacro" />
 
 </robot>

--- a/robotnik_sensors/urdf/camera/axis_m5013.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/axis_m5013.urdf.xacro
@@ -1,110 +1,192 @@
-<?xml version="1.0"?>
-<robot xmlns:xacro="http://wiki.ros.org/xacro" name="sensor_axis_m5013">
-  <xacro:property name="ptz_joint_effort_limit" value="100.0"/>
-  <xacro:property name="ptz_joint_velocity_limit" value="100.0"/>
-  <xacro:property name="ptz_joint_friction" value="0.1"/>
-  <xacro:property name="ptz_joint_damping" value="0.1"/>
-  <xacro:property name="ptz_mechanical_reduction" value="1.0"/>
-  <xacro:property name="PI" value="3.14159265359"/>
+<?xml version="1.0" ?>
+<robot
+  xmlns:xacro="http://wiki.ros.org/xacro"
+  name="sensor_axis_m5013">
+  <xacro:property
+    name="ptz_joint_effort_limit"
+    value="100.0" />
+  <xacro:property
+    name="ptz_joint_velocity_limit"
+    value="100.0" />
+  <xacro:property
+    name="ptz_joint_friction"
+    value="0.1" />
+  <xacro:property
+    name="ptz_joint_damping"
+    value="0.1" />
+  <xacro:property
+    name="ptz_mechanical_reduction"
+    value="1.0" />
 
-  <xacro:arg name="axis_m5013_controllers_params_file" default=""/> <!-- $(find robotnik_sensors_gazebo)/config/camera/axis_m5013.yaml -->
+  <xacro:arg
+    name="axis_m5013_controllers_params_file"
+    default="" /> <!-- $(find robotnik_sensors_gazebo)/config/camera/axis_m5013.yaml -->
 
-  <xacro:macro name="sensor_axis_m5013"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=axis_m5013
-                       node_namespace:=${None}
-                       topic_prefix:=~/">
+  <xacro:macro
+    name="sensor_axis_m5013"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=axis_m5013
+            node_namespace:=${None}
+            topic_prefix:=~/">
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
-      <axis xyz="0 1 0"/>
-      <xacro:insert_block name="origin"/>
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
+      <axis xyz="0 1 0" />
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <inertial>
-        <origin xyz="0.0175 0 0" rpy="0 ${PI/2} 0"/>
-        <mass value="0.3"/>
-        <xacro:solid_cuboid_inertia m="0.3" w="0.130" h="0.130" d="0.035" /> <!-- Data from axis M5013 datasheet -->
+        <origin
+          xyz="0.0175 0 0"
+          rpy="0 ${radians(90)} 0" />
+        <mass value="0.3" />
+        <xacro:solid_cuboid_inertia
+          m="0.3"
+          w="0.130"
+          h="0.130"
+          d="0.035" /> <!-- Data from axis M5013 datasheet -->
       </inertial>
       <visual>
-        <origin xyz="0 0 0" rpy="0 ${PI/2} 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 ${radians(90)} 0" />
         <!-- to center the axis model -->
         <material name="axis_color">
-          <color rgba="0.1 0.1 0.1 1"/>
+          <color rgba="0.1 0.1 0.1 1" />
         </material>
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/axis_m5013.dae" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/axis_m5013.dae"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0.0 0.0 0" rpy="0 ${PI/2} 0"/>
+        <origin
+          xyz="0.0 0.0 0"
+          rpy="0 ${radians(90)} 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/axis_m5013.stl" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/axis_m5013.stl"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </collision>
     </link>
 
-    <joint name="${frame_prefix}pan_joint" type="revolute">
-      <axis xyz="1 0 0"/>
-      <origin xyz="0.04 0.0 0.0" rpy="0 0 0"/>
+    <joint
+      name="${frame_prefix}pan_joint"
+      type="revolute">
+      <axis xyz="1 0 0" />
+      <origin
+        xyz="0.04 0.0 0.0"
+        rpy="0 0 0" />
       <!-- check the displacement -->
-      <parent link="${frame_prefix}base_link"/>
-      <child link="${frame_prefix}pan_link"/>
-      <limit effort="${ptz_joint_effort_limit}" velocity="${ptz_joint_velocity_limit}" lower="-3.1416" upper="3.1416"/>
-      <joint_properties damping="${ptz_joint_damping}" friction="{ptz_joint_friction}"/>
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}pan_link" />
+      <limit
+        effort="${ptz_joint_effort_limit}"
+        velocity="${ptz_joint_velocity_limit}"
+        lower="-3.1416"
+        upper="3.1416" />
+      <joint_properties
+        damping="${ptz_joint_damping}"
+        friction="{ptz_joint_friction}" />
     </joint>
     <link name="${frame_prefix}pan_link">
       <inertial>
-        <mass value="0.01"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.01" w="0.03" h="0.06" d="0.06" />
+        <mass value="0.01" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.01"
+          w="0.03"
+          h="0.06"
+          d="0.06" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}tilt_joint" type="revolute">
-      <axis xyz="0 -1 0"/>
-      <origin xyz="0.0 0.0 0.0" rpy="0 ${-PI/2} 0"/>
-      <parent link="${frame_prefix}pan_link"/>
-      <child link="${frame_prefix}tilt_link"/>
-      <limit effort="${ptz_joint_effort_limit}" velocity="${ptz_joint_velocity_limit}" lower="-1.5708" upper="1.5708"/>
-      <joint_properties damping="${ptz_joint_damping}" friction="{ptz_joint_friction}"/>
+    <joint
+      name="${frame_prefix}tilt_joint"
+      type="revolute">
+      <axis xyz="0 -1 0" />
+      <origin
+        xyz="0.0 0.0 0.0"
+        rpy="0 ${-radians(90)} 0" />
+      <parent link="${frame_prefix}pan_link" />
+      <child link="${frame_prefix}tilt_link" />
+      <limit
+        effort="${ptz_joint_effort_limit}"
+        velocity="${ptz_joint_velocity_limit}"
+        lower="-1.5708"
+        upper="1.5708" />
+      <joint_properties
+        damping="${ptz_joint_damping}"
+        friction="{ptz_joint_friction}" />
     </joint>
     <link name="${frame_prefix}tilt_link">
       <inertial>
-        <mass value="0.01"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.01" w="0.06" h="0.06" d="0.03" />
+        <mass value="0.01" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.01"
+          w="0.06"
+          h="0.06"
+          d="0.03" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}frame_joint" type="fixed">
-      <origin xyz="0.0 0 -0.03" rpy="0 ${PI/2} 0"/>
-      <parent link="${frame_prefix}tilt_link"/>
-      <child link="${frame_prefix}frame_link"/>
+    <joint
+      name="${frame_prefix}frame_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0 -0.03"
+        rpy="0 ${radians(90)} 0" />
+      <parent link="${frame_prefix}tilt_link" />
+      <child link="${frame_prefix}frame_link" />
     </joint>
     <link name="${frame_prefix}frame_link">
       <inertial>
-        <mass value="0.01"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.01" w="0.06" h="0.06" d="0.03" />
+        <mass value="0.01" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.01"
+          w="0.06"
+          h="0.06"
+          d="0.03" />
       </inertial>
     </link>
     <!-- Optical frame -->
-    <joint name="${frame_prefix}optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="${-PI/2} 0 ${-PI/2}"/>
-      <parent link="${frame_prefix}frame_link"/>
-      <child link="${frame_prefix}optical_frame_link"/>
+    <joint
+      name="${frame_prefix}optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
+      <parent link="${frame_prefix}frame_link" />
+      <child link="${frame_prefix}optical_frame_link" />
     </joint>
     <link name="${frame_prefix}optical_frame_link">
       <inertial>
-        <mass value="0.01"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.01" w="0.06" h="0.03" d="0.06" />
+        <mass value="0.01" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.01"
+          w="0.06"
+          h="0.03"
+          d="0.06" />
       </inertial>
     </link>
     <gazebo reference="${frame_prefix}base_link">
@@ -125,8 +207,7 @@
       video_height="480"
       min_depth="0.1"
       max_depth="100"
-      rate="30"
-    >
+      rate="30">
     </xacro:camera_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/camera/axis_m5013.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/axis_m5013.urdf.xacro
@@ -20,7 +20,8 @@
 
   <xacro:arg
     name="axis_m5013_controllers_params_file"
-    default="" /> <!-- $(find robotnik_sensors_gazebo)/config/camera/axis_m5013.yaml -->
+    default="" />
+  <!-- $(find robotnik_sensors_gazebo)/config/camera/axis_m5013.yaml -->
 
   <xacro:macro
     name="sensor_axis_m5013"
@@ -31,7 +32,6 @@
             node_name:=axis_m5013
             node_namespace:=${None}
             topic_prefix:=~/">
-
     <joint
       name="${frame_prefix}base_joint"
       type="fixed">
@@ -51,7 +51,8 @@
           m="0.3"
           w="0.130"
           h="0.130"
-          d="0.035" /> <!-- Data from axis M5013 datasheet -->
+          d="0.035" />
+        <!-- Data from axis M5013 datasheet -->
       </inertial>
       <visual>
         <origin
@@ -207,9 +208,6 @@
       video_height="480"
       min_depth="0.1"
       max_depth="100"
-      rate="30">
-    </xacro:camera_plugin>
-
+      rate="30" />
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/camera/axis_m5074.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/axis_m5074.urdf.xacro
@@ -20,7 +20,8 @@
 
   <xacro:arg
     name="axis_m5074_controllers_params_file"
-    default="" /> <!-- $(find robotnik_sensors_gazebo)/config/camera/axis_m5074.yaml-->
+    default="" />
+  <!-- $(find robotnik_sensors_gazebo)/config/camera/axis_m5074.yaml-->
 
   <xacro:macro
     name="sensor_axis_m5074"
@@ -31,7 +32,6 @@
             node_name:=axis_m5074
             node_namespace:=${None}
             topic_prefix:=~/">
-
     <joint
       name="${frame_prefix}base_joint"
       type="fixed">
@@ -50,7 +50,8 @@
           m="0.3"
           w="0.130"
           h="0.130"
-          d="0.035" /> <!-- Data from axis M5013 datasheet -->
+          d="0.035" />
+        <!-- Data from axis M5013 datasheet -->
       </inertial>
       <visual>
         <origin
@@ -206,10 +207,6 @@
       video_height="480"
       min_depth="0.1"
       max_depth="100"
-      rate="30">
-    </xacro:camera_plugin>
-
+      rate="30" />
   </xacro:macro>
-
-
 </robot>

--- a/robotnik_sensors/urdf/camera/axis_m5074.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/axis_m5074.urdf.xacro
@@ -1,109 +1,191 @@
-<?xml version="1.0"?>
-<robot xmlns:xacro="http://wiki.ros.org/xacro" name="sensor_axis_m5074">
-  <xacro:property name="ptz_joint_effort_limit" value="100.0"/>
-  <xacro:property name="ptz_joint_velocity_limit" value="100.0"/>
-  <xacro:property name="ptz_joint_friction" value="0.1"/>
-  <xacro:property name="ptz_joint_damping" value="0.1"/>
-  <xacro:property name="ptz_mechanical_reduction" value="1.0"/>
-  <xacro:property name="PI" value="3.14159265359"/>
+<?xml version="1.0" ?>
+<robot
+  xmlns:xacro="http://wiki.ros.org/xacro"
+  name="sensor_axis_m5074">
+  <xacro:property
+    name="ptz_joint_effort_limit"
+    value="100.0" />
+  <xacro:property
+    name="ptz_joint_velocity_limit"
+    value="100.0" />
+  <xacro:property
+    name="ptz_joint_friction"
+    value="0.1" />
+  <xacro:property
+    name="ptz_joint_damping"
+    value="0.1" />
+  <xacro:property
+    name="ptz_mechanical_reduction"
+    value="1.0" />
 
-  <xacro:arg name="axis_m5074_controllers_params_file" default=""/> <!-- $(find robotnik_sensors_gazebo)/config/camera/axis_m5074.yaml-->
+  <xacro:arg
+    name="axis_m5074_controllers_params_file"
+    default="" /> <!-- $(find robotnik_sensors_gazebo)/config/camera/axis_m5074.yaml-->
 
-  <xacro:macro name="sensor_axis_m5074"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=axis_m5074
-                       node_namespace:=${None}
-                       topic_prefix:=~/">
+  <xacro:macro
+    name="sensor_axis_m5074"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=axis_m5074
+            node_namespace:=${None}
+            topic_prefix:=~/">
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
-      <axis xyz="0 1 0"/>
-      <xacro:insert_block name="origin"/>
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
+      <axis xyz="0 1 0" />
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
     <link name="${frame_prefix}base_link">
       <inertial>
-        <origin xyz="0.0175 0 0" rpy="0 ${PI/2} 0"/>
-        <mass value="0.3"/>
-        <xacro:solid_cuboid_inertia m="0.3" w="0.130" h="0.130" d="0.035" /> <!-- Data from axis M5013 datasheet -->
+        <origin
+          xyz="0.0175 0 0"
+          rpy="0 ${radians(90)} 0" />
+        <mass value="0.3" />
+        <xacro:solid_cuboid_inertia
+          m="0.3"
+          w="0.130"
+          h="0.130"
+          d="0.035" /> <!-- Data from axis M5013 datasheet -->
       </inertial>
       <visual>
-        <origin xyz="0 0 0" rpy="0 ${PI/2} 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 ${radians(90)} 0" />
         <!-- to center the axis model -->
         <material name="axis_color">
-          <color rgba="0.1 0.1 0.1 1"/>
+          <color rgba="0.1 0.1 0.1 1" />
         </material>
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/axis_m5013.dae" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/axis_m5013.dae"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0.0 0.0 0" rpy="0 ${PI/2} 0"/>
+        <origin
+          xyz="0.0 0.0 0"
+          rpy="0 ${radians(90)} 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/axis_m5013.stl" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/axis_m5013.stl"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </collision>
     </link>
 
-    <joint name="${frame_prefix}pan_joint" type="revolute">
-      <axis xyz="1 0 0"/>
-      <origin xyz="0.04 0.0 0.0" rpy="0 0 0"/>
+    <joint
+      name="${frame_prefix}pan_joint"
+      type="revolute">
+      <axis xyz="1 0 0" />
+      <origin
+        xyz="0.04 0.0 0.0"
+        rpy="0 0 0" />
       <!-- check the displacement -->
-      <parent link="${frame_prefix}base_link"/>
-      <child link="${frame_prefix}pan_link"/>
-      <limit effort="${ptz_joint_effort_limit}" velocity="${ptz_joint_velocity_limit}" lower="-3.1416" upper="3.1416"/>
-      <joint_properties damping="${ptz_joint_damping}" friction="{ptz_joint_friction}"/>
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}pan_link" />
+      <limit
+        effort="${ptz_joint_effort_limit}"
+        velocity="${ptz_joint_velocity_limit}"
+        lower="-3.1416"
+        upper="3.1416" />
+      <joint_properties
+        damping="${ptz_joint_damping}"
+        friction="{ptz_joint_friction}" />
     </joint>
     <link name="${frame_prefix}pan_link">
       <inertial>
-        <mass value="0.01"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.01" w="0.03" h="0.06" d="0.06" />
+        <mass value="0.01" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.01"
+          w="0.03"
+          h="0.06"
+          d="0.06" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}tilt_joint" type="revolute">
-      <axis xyz="0 -1 0"/>
-      <origin xyz="0.0 0.0 0.0" rpy="0 ${-PI/2} 0"/>
-      <parent link="${frame_prefix}pan_link"/>
-      <child link="${frame_prefix}tilt_link"/>
-      <limit effort="${ptz_joint_effort_limit}" velocity="${ptz_joint_velocity_limit}" lower="-1.5708" upper="1.5708"/>
-      <joint_properties damping="${ptz_joint_damping}" friction="{ptz_joint_friction}"/>
+    <joint
+      name="${frame_prefix}tilt_joint"
+      type="revolute">
+      <axis xyz="0 -1 0" />
+      <origin
+        xyz="0.0 0.0 0.0"
+        rpy="0 ${-radians(90)} 0" />
+      <parent link="${frame_prefix}pan_link" />
+      <child link="${frame_prefix}tilt_link" />
+      <limit
+        effort="${ptz_joint_effort_limit}"
+        velocity="${ptz_joint_velocity_limit}"
+        lower="-1.5708"
+        upper="1.5708" />
+      <joint_properties
+        damping="${ptz_joint_damping}"
+        friction="{ptz_joint_friction}" />
     </joint>
     <link name="${frame_prefix}tilt_link">
       <inertial>
-        <mass value="0.01"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.01" w="0.06" h="0.06" d="0.03" />
+        <mass value="0.01" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.01"
+          w="0.06"
+          h="0.06"
+          d="0.03" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}frame_joint" type="fixed">
-      <origin xyz="0.0 0 -0.03" rpy="0 ${PI/2} 0"/>
-      <parent link="${frame_prefix}tilt_link"/>
-      <child link="${frame_prefix}frame_link"/>
+    <joint
+      name="${frame_prefix}frame_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0 -0.03"
+        rpy="0 ${radians(90)} 0" />
+      <parent link="${frame_prefix}tilt_link" />
+      <child link="${frame_prefix}frame_link" />
     </joint>
     <link name="${frame_prefix}frame_link">
       <inertial>
-        <mass value="0.01"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.01" w="0.06" h="0.06" d="0.03" />
+        <mass value="0.01" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.01"
+          w="0.06"
+          h="0.06"
+          d="0.03" />
       </inertial>
     </link>
     <!-- Optical frame -->
-    <joint name="${frame_prefix}optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="${-PI/2} 0 ${-PI/2}"/>
-      <parent link="${frame_prefix}frame_link"/>
-      <child link="${frame_prefix}optical_frame_link"/>
+    <joint
+      name="${frame_prefix}optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
+      <parent link="${frame_prefix}frame_link" />
+      <child link="${frame_prefix}optical_frame_link" />
     </joint>
     <link name="${frame_prefix}optical_frame_link">
       <inertial>
-        <mass value="0.01"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.01" w="0.06" h="0.03" d="0.06" />
+        <mass value="0.01" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.01"
+          w="0.06"
+          h="0.03"
+          d="0.06" />
       </inertial>
     </link>
     <gazebo reference="${frame_prefix}base_link">
@@ -124,8 +206,7 @@
       video_height="480"
       min_depth="0.1"
       max_depth="100"
-      rate="30"
-    >
+      rate="30">
     </xacro:camera_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/camera/axis_m5525.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/axis_m5525.urdf.xacro
@@ -1,110 +1,188 @@
-<?xml version="1.0"?>
-<robot xmlns:xacro="http://wiki.ros.org/xacro" name="sensor_axis_m5525">
-  <xacro:property name="ptz_joint_effort_limit" value="1.0"/>
-  <xacro:property name="ptz_joint_velocity_limit" value="1.0"/>
-  <xacro:property name="ptz_joint_friction" value="0.1"/>
-  <xacro:property name="ptz_joint_damping" value="0.1"/>
-  <xacro:property name="ptz_mechanical_reduction" value="1.0"/>
-  <xacro:property name="PI" value="3.14159265359"/>
+<?xml version="1.0" ?>
+<robot
+  xmlns:xacro="http://wiki.ros.org/xacro"
+  name="sensor_axis_m5525">
+  <xacro:property
+    name="ptz_joint_effort_limit"
+    value="1.0" />
+  <xacro:property
+    name="ptz_joint_velocity_limit"
+    value="1.0" />
+  <xacro:property
+    name="ptz_joint_friction"
+    value="0.1" />
+  <xacro:property
+    name="ptz_joint_damping"
+    value="0.1" />
+  <xacro:property
+    name="ptz_mechanical_reduction"
+    value="1.0" />
 
-  <xacro:arg name="axis_m5525_controllers_params_file" default=""/> <!-- $(find robotnik_sensors_gazebo)/config/camera/axis_m5525.yaml -->
+  <xacro:arg
+    name="axis_m5525_controllers_params_file"
+    default="" /> <!-- $(find robotnik_sensors_gazebo)/config/camera/axis_m5525.yaml -->
 
-  <xacro:macro name="sensor_axis_m5525"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=axis_m5525
-                       node_namespace:=${None}
-                       topic_prefix:=~/">
+  <xacro:macro
+    name="sensor_axis_m5525"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=axis_m5525
+            node_namespace:=${None}
+            topic_prefix:=~/">
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
-      <axis xyz="0 1 0"/>
-      <xacro:insert_block name="origin"/>
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
+      <axis xyz="0 1 0" />
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <inertial>
-        <origin xyz="0.066 0 0" rpy="0 ${3.1415/2} 0"/>
-        <mass value="0.8"/>
-        <xacro:solid_cuboid_inertia m="0.8" w="0.165" h="0.165" d="0.132" />
+        <origin
+          xyz="0.066 0 0"
+          rpy="0 ${3.1415/2} 0" />
+        <mass value="0.8" />
+        <xacro:solid_cuboid_inertia
+          m="0.8"
+          w="0.165"
+          h="0.165"
+          d="0.132" />
       </inertial>
       <visual>
-        <origin xyz="0 0 0" rpy="0 ${3.1415/2} 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 ${3.1415/2} 0" />
         <!-- to center the axis model -->
         <material name="axis_color">
-          <color rgba="0.1 0.1 0.1 1"/>
+          <color rgba="0.1 0.1 0.1 1" />
         </material>
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/axis_m5525.dae" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/axis_m5525.dae"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0.0 0.0 0" rpy="0 ${3.1415/2} 0"/>
+        <origin
+          xyz="0.0 0.0 0"
+          rpy="0 ${3.1415/2} 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/axis_m5525.stl" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/axis_m5525.stl"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </collision>
     </link>
 
-    <joint name="${frame_prefix}pan_joint" type="revolute">
-      <axis xyz="1 0 0"/>
-      <origin xyz="0.087 0.0 0.0" rpy="0 0 0"/>
+    <joint
+      name="${frame_prefix}pan_joint"
+      type="revolute">
+      <axis xyz="1 0 0" />
+      <origin
+        xyz="0.087 0.0 0.0"
+        rpy="0 0 0" />
       <!-- check the displacement -->
-      <parent link="${frame_prefix}base_link"/>
-      <child link="${frame_prefix}pan_link"/>
-      <limit effort="${ptz_joint_effort_limit}" velocity="${ptz_joint_velocity_limit}" lower="-3.1416" upper="3.1416"/>
-      <joint_properties damping="${ptz_joint_damping}" friction="{ptz_joint_friction}"/>
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}pan_link" />
+      <limit
+        effort="${ptz_joint_effort_limit}"
+        velocity="${ptz_joint_velocity_limit}"
+        lower="-3.1416"
+        upper="3.1416" />
+      <joint_properties
+        damping="${ptz_joint_damping}"
+        friction="{ptz_joint_friction}" />
     </joint>
     <link name="${frame_prefix}pan_link">
       <inertial>
-        <mass value="0.1"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.1" w="0.1" h="0.11" d="0.11" />
+        <mass value="0.1" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.1"
+          w="0.1"
+          h="0.11"
+          d="0.11" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}tilt_joint" type="revolute">
-      <axis xyz="0 -1 0"/>
-      <origin xyz="0.0 0.0 0.0" rpy="0 ${-PI/2} 0"/>
-      <parent link="${frame_prefix}pan_link"/>
-      <child link="${frame_prefix}tilt_link"/>
-      <limit effort="${ptz_joint_effort_limit}" velocity="${ptz_joint_velocity_limit}" lower="-1.5708" upper="1.5708"/>
-      <joint_properties damping="${ptz_joint_damping}" friction="{ptz_joint_friction}"/>
+    <joint
+      name="${frame_prefix}tilt_joint"
+      type="revolute">
+      <axis xyz="0 -1 0" />
+      <origin
+        xyz="0.0 0.0 0.0"
+        rpy="0 ${-radians(90)} 0" />
+      <parent link="${frame_prefix}pan_link" />
+      <child link="${frame_prefix}tilt_link" />
+      <limit
+        effort="${ptz_joint_effort_limit}"
+        velocity="${ptz_joint_velocity_limit}"
+        lower="-1.5708"
+        upper="1.5708" />
+      <joint_properties
+        damping="${ptz_joint_damping}"
+        friction="{ptz_joint_friction}" />
     </joint>
     <link name="${frame_prefix}tilt_link">
       <inertial>
-        <mass value="0.1"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.1" w="0.11" h="0.11" d="0.1" />
+        <mass value="0.1" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.1"
+          w="0.11"
+          h="0.11"
+          d="0.1" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}frame_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <parent link="${frame_prefix}tilt_link"/>
-      <child link="${frame_prefix}frame_link"/>
+    <joint
+      name="${frame_prefix}frame_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <parent link="${frame_prefix}tilt_link" />
+      <child link="${frame_prefix}frame_link" />
     </joint>
     <link name="${frame_prefix}frame_link">
       <inertial>
-        <mass value="0.1"/>
-        <origin xyz="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.1" w="0.11" h="0.11" d="0.1" />
+        <mass value="0.1" />
+        <origin xyz="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.1"
+          w="0.11"
+          h="0.11"
+          d="0.1" />
       </inertial>
     </link>
     <!-- Optical frame -->
-    <joint name="${frame_prefix}optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="${-3.1415/2} 0 ${-3.1415/2}"/>
-      <parent link="${frame_prefix}frame_link"/>
-      <child link="${frame_prefix}optical_frame_link"/>
+    <joint
+      name="${frame_prefix}optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="${-3.1415/2} 0 ${-3.1415/2}" />
+      <parent link="${frame_prefix}frame_link" />
+      <child link="${frame_prefix}optical_frame_link" />
     </joint>
     <link name="${frame_prefix}optical_frame_link">
       <inertial>
-        <mass value="0.1"/>
-        <origin xyz="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.1" w="0.11" h="0.11" d="0.1" />
+        <mass value="0.1" />
+        <origin xyz="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.1"
+          w="0.11"
+          h="0.11"
+          d="0.1" />
       </inertial>
     </link>
     <gazebo reference="${frame_prefix}base_link">
@@ -125,8 +203,7 @@
       video_height="480"
       min_depth="0.1"
       max_depth="100"
-      rate="30"
-    >
+      rate="30">
     </xacro:camera_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/camera/axis_m5525.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/axis_m5525.urdf.xacro
@@ -20,7 +20,8 @@
 
   <xacro:arg
     name="axis_m5525_controllers_params_file"
-    default="" /> <!-- $(find robotnik_sensors_gazebo)/config/camera/axis_m5525.yaml -->
+    default="" />
+  <!-- $(find robotnik_sensors_gazebo)/config/camera/axis_m5525.yaml -->
 
   <xacro:macro
     name="sensor_axis_m5525"
@@ -31,7 +32,6 @@
             node_name:=axis_m5525
             node_namespace:=${None}
             topic_prefix:=~/">
-
     <joint
       name="${frame_prefix}base_joint"
       type="fixed">
@@ -203,11 +203,6 @@
       video_height="480"
       min_depth="0.1"
       max_depth="100"
-      rate="30">
-    </xacro:camera_plugin>
-
+      rate="30" />
   </xacro:macro>
-
-
-
 </robot>

--- a/robotnik_sensors/urdf/camera/axis_m5526.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/axis_m5526.urdf.xacro
@@ -20,7 +20,8 @@
 
   <xacro:arg
     name="axis_m5526_controllers_params_file"
-    default="" /> <!--$(find robotnik_sensors_gazebo)/config/camera/axis_m5526.yaml-->
+    default="" />
+  <!--$(find robotnik_sensors_gazebo)/config/camera/axis_m5526.yaml-->
 
   <xacro:macro
     name="sensor_axis_m5526"
@@ -31,7 +32,6 @@
             node_name:=axis_m5526
             node_namespace:=${None}
             topic_prefix:=~/">
-
     <joint
       name="${frame_prefix}base_joint"
       type="fixed">
@@ -203,9 +203,6 @@
       video_height="480"
       min_depth="0.1"
       max_depth="100"
-      rate="30">
-    </xacro:camera_plugin>
-
+      rate="30" />
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/camera/axis_m5526.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/axis_m5526.urdf.xacro
@@ -1,110 +1,188 @@
-<?xml version="1.0"?>
-<robot xmlns:xacro="http://wiki.ros.org/xacro" name="sensor_axis_m5526">
-  <xacro:property name="ptz_joint_effort_limit" value="1.0"/>
-  <xacro:property name="ptz_joint_velocity_limit" value="1.0"/>
-  <xacro:property name="ptz_joint_friction" value="0.1"/>
-  <xacro:property name="ptz_joint_damping" value="0.1"/>
-  <xacro:property name="ptz_mechanical_reduction" value="1.0"/>
-  <xacro:property name="PI" value="3.14159265359"/>
+<?xml version="1.0" ?>
+<robot
+  xmlns:xacro="http://wiki.ros.org/xacro"
+  name="sensor_axis_m5526">
+  <xacro:property
+    name="ptz_joint_effort_limit"
+    value="1.0" />
+  <xacro:property
+    name="ptz_joint_velocity_limit"
+    value="1.0" />
+  <xacro:property
+    name="ptz_joint_friction"
+    value="0.1" />
+  <xacro:property
+    name="ptz_joint_damping"
+    value="0.1" />
+  <xacro:property
+    name="ptz_mechanical_reduction"
+    value="1.0" />
 
-  <xacro:arg name="axis_m5526_controllers_params_file" default=""/> <!--$(find robotnik_sensors_gazebo)/config/camera/axis_m5526.yaml-->
+  <xacro:arg
+    name="axis_m5526_controllers_params_file"
+    default="" /> <!--$(find robotnik_sensors_gazebo)/config/camera/axis_m5526.yaml-->
 
-  <xacro:macro name="sensor_axis_m5526"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=axis_m5526
-                       node_namespace:=${None}
-                       topic_prefix:=~/">
+  <xacro:macro
+    name="sensor_axis_m5526"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=axis_m5526
+            node_namespace:=${None}
+            topic_prefix:=~/">
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
-      <axis xyz="0 1 0"/>
-      <xacro:insert_block name="origin"/>
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
+      <axis xyz="0 1 0" />
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <inertial>
-        <origin xyz="0.066 0 0" rpy="0 ${3.1415/2} 0"/>
-        <mass value="0.8"/>
-        <xacro:solid_cuboid_inertia m="0.8" w="0.165" h="0.165" d="0.132" />
+        <origin
+          xyz="0.066 0 0"
+          rpy="0 ${3.1415/2} 0" />
+        <mass value="0.8" />
+        <xacro:solid_cuboid_inertia
+          m="0.8"
+          w="0.165"
+          h="0.165"
+          d="0.132" />
       </inertial>
       <visual>
-        <origin xyz="0 0 0" rpy="0 ${3.1415/2} 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 ${3.1415/2} 0" />
         <!-- to center the axis model -->
         <material name="axis_color">
-          <color rgba="0.1 0.1 0.1 1"/>
+          <color rgba="0.1 0.1 0.1 1" />
         </material>
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/axis_m5525.dae" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/axis_m5525.dae"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0.0 0.0 0" rpy="0 ${3.1415/2} 0"/>
+        <origin
+          xyz="0.0 0.0 0"
+          rpy="0 ${3.1415/2} 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/axis_m5525.stl" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/axis_m5525.stl"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </collision>
     </link>
 
-    <joint name="${frame_prefix}pan_joint" type="revolute">
-      <axis xyz="1 0 0"/>
-      <origin xyz="0.087 0.0 0.0" rpy="0 0 0"/>
+    <joint
+      name="${frame_prefix}pan_joint"
+      type="revolute">
+      <axis xyz="1 0 0" />
+      <origin
+        xyz="0.087 0.0 0.0"
+        rpy="0 0 0" />
       <!-- check the displacement -->
-      <parent link="${frame_prefix}base_link"/>
-      <child link="${frame_prefix}pan_link"/>
-      <limit effort="${ptz_joint_effort_limit}" velocity="${ptz_joint_velocity_limit}" lower="-3.1416" upper="3.1416"/>
-      <joint_properties damping="${ptz_joint_damping}" friction="{ptz_joint_friction}"/>
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}pan_link" />
+      <limit
+        effort="${ptz_joint_effort_limit}"
+        velocity="${ptz_joint_velocity_limit}"
+        lower="-3.1416"
+        upper="3.1416" />
+      <joint_properties
+        damping="${ptz_joint_damping}"
+        friction="{ptz_joint_friction}" />
     </joint>
     <link name="${frame_prefix}pan_link">
       <inertial>
-        <mass value="0.1"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.1" w="0.1" h="0.11" d="0.11" />
+        <mass value="0.1" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.1"
+          w="0.1"
+          h="0.11"
+          d="0.11" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}tilt_joint" type="revolute">
-      <axis xyz="0 -1 0"/>
-      <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
-      <parent link="${frame_prefix}pan_link"/>
-      <child link="${frame_prefix}tilt_link"/>
-      <limit effort="${ptz_joint_effort_limit}" velocity="${ptz_joint_velocity_limit}" lower="-1.5708" upper="1.5708"/>
-      <joint_properties damping="${ptz_joint_damping}" friction="{ptz_joint_friction}"/>
+    <joint
+      name="${frame_prefix}tilt_joint"
+      type="revolute">
+      <axis xyz="0 -1 0" />
+      <origin
+        xyz="0.0 0.0 0.0"
+        rpy="0 0 0" />
+      <parent link="${frame_prefix}pan_link" />
+      <child link="${frame_prefix}tilt_link" />
+      <limit
+        effort="${ptz_joint_effort_limit}"
+        velocity="${ptz_joint_velocity_limit}"
+        lower="-1.5708"
+        upper="1.5708" />
+      <joint_properties
+        damping="${ptz_joint_damping}"
+        friction="{ptz_joint_friction}" />
     </joint>
     <link name="${frame_prefix}tilt_link">
       <inertial>
-        <mass value="0.1"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.1" w="0.11" h="0.11" d="0.1" />
+        <mass value="0.1" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.1"
+          w="0.11"
+          h="0.11"
+          d="0.1" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}frame_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <parent link="${frame_prefix}tilt_link"/>
-      <child link="${frame_prefix}frame_link"/>
+    <joint
+      name="${frame_prefix}frame_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <parent link="${frame_prefix}tilt_link" />
+      <child link="${frame_prefix}frame_link" />
     </joint>
     <link name="${frame_prefix}frame_link">
       <inertial>
-        <mass value="0.1"/>
-        <origin xyz="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.1" w="0.11" h="0.11" d="0.1" />
+        <mass value="0.1" />
+        <origin xyz="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.1"
+          w="0.11"
+          h="0.11"
+          d="0.1" />
       </inertial>
     </link>
     <!-- Optical frame -->
-    <joint name="${frame_prefix}optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="${-3.1415/2} 0 ${-3.1415/2}"/>
-      <parent link="${frame_prefix}frame_link"/>
-      <child link="${frame_prefix}optical_frame_link"/>
+    <joint
+      name="${frame_prefix}optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="${-3.1415/2} 0 ${-3.1415/2}" />
+      <parent link="${frame_prefix}frame_link" />
+      <child link="${frame_prefix}optical_frame_link" />
     </joint>
     <link name="${frame_prefix}optical_frame_link">
       <inertial>
-        <mass value="0.1"/>
-        <origin xyz="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.1" w="0.11" h="0.11" d="0.1" />
+        <mass value="0.1" />
+        <origin xyz="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.1"
+          w="0.11"
+          h="0.11"
+          d="0.1" />
       </inertial>
     </link>
     <gazebo reference="${frame_prefix}base_link">
@@ -125,8 +203,7 @@
       video_height="480"
       min_depth="0.1"
       max_depth="100"
-      rate="30"
-    >
+      rate="30">
     </xacro:camera_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/camera/camera_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/camera_plugin.urdf.xacro
@@ -1,8 +1,11 @@
-<?xml version="1.0"?>
-<robot name="camera_plugin" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="camera_plugin"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="camera_plugin" params="
-            node_namespace
+  <xacro:macro
+    name="camera_plugin"
+    params="node_namespace
             node_name
             topic_prefix
             gazebo_ignition
@@ -19,7 +22,9 @@
 
     <xacro:if value="${gazebo_ignition}">
       <gazebo reference="${reference_frame}">
-        <sensor name="${node_name}" type="camera">
+        <sensor
+          name="${node_name}"
+          type="camera">
             <camera name="${node_name}">
             <horizontal_fov>${radians(horizontal_fov)}</horizontal_fov>
             <vertical_fov>${radians(float(vertical_fov))}</vertical_fov>

--- a/robotnik_sensors/urdf/camera/camera_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/camera_plugin.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="camera_plugin"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="camera_plugin"
     params="node_namespace
@@ -19,41 +18,46 @@
             max_depth
             rate
             ">
-
     <xacro:if value="${gazebo_ignition}">
       <gazebo reference="${reference_frame}">
         <sensor
           name="${node_name}"
           type="camera">
-            <camera name="${node_name}">
-            <horizontal_fov>${radians(horizontal_fov)}</horizontal_fov>
-            <vertical_fov>${radians(float(vertical_fov))}</vertical_fov>
+          <camera name="${node_name}">
+            <horizontal_fov>
+              ${radians(horizontal_fov)}
+            </horizontal_fov>
+            <vertical_fov>
+              ${radians(float(vertical_fov))}
+            </vertical_fov>
             <image>
               <width>${video_width}</width>
               <height>${video_height}</height>
-                <format>RGB_INT8</format>
+              <format>RGB_INT8</format>
             </image>
             <clip>
               <near>${min_depth}</near>
               <far>${max_depth}</far>
             </clip>
             <noise>
-                <type>gaussian</type>
-                <mean>0.0</mean>
-                <stddev>0.05</stddev>
+              <type>gaussian</type>
+              <mean>0.0</mean>
+              <stddev>0.05</stddev>
             </noise>
-            </camera>
-            <always_on>1</always_on>
-            <update_rate>${rate}</update_rate>
-            <visualize>false</visualize>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>${rate}</update_rate>
+          <visualize>false</visualize>
 
-            <topic>${node_namespace}/${node_name}/color/image_raw</topic>
-            <gz_frame_id>${optical_frame}</gz_frame_id>
-            <camera_info_topic>${node_namespace}/${node_name}/color/camera_info</camera_info_topic>
+          <topic>
+            ${node_namespace}/${node_name}/color/image_raw
+          </topic>
+          <gz_frame_id>${optical_frame}</gz_frame_id>
+          <camera_info_topic>
+            ${node_namespace}/${node_name}/color/camera_info
+          </camera_info_topic>
         </sensor>
       </gazebo>
     </xacro:if>
-
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/asus_xtion_pro.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/asus_xtion_pro.urdf.xacro
@@ -1,18 +1,28 @@
-<?xml version="1.0"?>
-<robot xmlns:xacro="http://wiki.ros.org/xacro" name="sensor_asus_xtion_pro">
+<?xml version="1.0" ?>
+<robot
+  xmlns:xacro="http://wiki.ros.org/xacro"
+  name="sensor_asus_xtion_pro">
 
   <!-- Xacro properties -->
   <!-- xacro:property name="M_SCALE" value="0.001"/ -->
-  <xacro:property name="M_SCALE" value="1.0"/>
+  <xacro:property
+    name="M_SCALE"
+    value="1.0" />
 
   <!-- xacro:property name="asus_xtion_scale" value="0.001"/ -->
-  <xacro:property name="asus_xtion_scale" value="1.0"/>
-  <xacro:property name="asus_xtion_pro_depth_rel_rgb_py" value="0.0270" />
-  <xacro:property name="asus_xtion_pro_rgb_rel_rgb_py"   value="-0.0220" />
-  <xacro:property name="M_PI" value="3.1415926535897931" />
+  <xacro:property
+    name="asus_xtion_scale"
+    value="1.0" />
+  <xacro:property
+    name="asus_xtion_pro_depth_rel_rgb_py"
+    value="0.0270" />
+  <xacro:property
+    name="asus_xtion_pro_rgb_rel_rgb_py"
+    value="-0.0220" />
 
-  <xacro:macro name="sensor_asus_xtion_pro"
-                params="frame_prefix
+  <xacro:macro
+    name="sensor_asus_xtion_pro"
+    params="frame_prefix
                         parent
                         *origin
                         model:=asus_xtion_pro
@@ -28,9 +38,11 @@
                         min_depth:=0.8
                         max_depth:=3.5">
 
-    <joint name="${frame_prefix}rgb_joint" type="fixed">
+    <joint
+      name="${frame_prefix}rgb_joint"
+      type="fixed">
 	  <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${frame_prefix}rgb_base_link" />
     </joint>
 
@@ -38,12 +50,20 @@
       <inertial>
         <mass value="0.01" />
         <origin xyz="-0.0175 0 0" />
-        <xacro:solid_cuboid_inertia m="0.01" w="0.035" h="0.180" d="0.05" />
+        <xacro:solid_cuboid_inertia
+          m="0.01"
+          w="0.035"
+          h="0.180"
+          d="0.05" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}rgb_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+    <joint
+      name="${frame_prefix}rgb_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
       <parent link="${frame_prefix}rgb_base_link" />
       <child link="${frame_prefix}rgb_optical_frame" />
     </joint>
@@ -52,38 +72,61 @@
       <inertial>
         <mass value="0.01" />
         <origin xyz="0 0 0" />
-        <xacro:solid_cuboid_inertia m="0.01" w="0.180" h="0.035" d="0.05" />
+        <xacro:solid_cuboid_inertia
+          m="0.01"
+          w="0.180"
+          h="0.035"
+          d="0.05" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-      <origin xyz="0 ${asus_xtion_pro_rgb_rel_rgb_py} 0"
-              rpy="0 0 0"/>
-      <parent link="${frame_prefix}rgb_base_link"/>
-      <child link="${frame_prefix}link"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+      <origin
+        xyz="0 ${asus_xtion_pro_rgb_rel_rgb_py} 0"
+        rpy="0 0 0" />
+      <parent link="${frame_prefix}rgb_base_link" />
+      <child link="${frame_prefix}link" />
     </joint>
     <link name="${frame_prefix}link">
       <visual>
-        <origin xyz="-0.01 0 0" rpy="${-M_PI/2} -${M_PI} ${-M_PI/2}"/>
+        <origin
+          xyz="-0.01 0 0"
+          rpy="${-radians(90)} -${radians(180)} ${-radians(90)}" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/asus_xtion_pro_live.dae" scale="${asus_xtion_scale} ${asus_xtion_scale} ${asus_xtion_scale}"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/asus_xtion_pro_live.dae"
+            scale="${asus_xtion_scale} ${asus_xtion_scale} ${asus_xtion_scale}" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
+        <origin
+          xyz="0.0 0.0 0.0"
+          rpy="0 0 0" />
         <geometry>
-        <box size="0.0730 .2760 0.0720"/>
+        <box size="0.0730 .2760 0.0720" />
       </geometry>
       </collision>
       <inertial>
         <mass value="0.01" />
-        <origin xyz="-0.0175 0.0025 0" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.01" w="0.035" h="0.180" d="0.05" />
+        <origin
+          xyz="-0.0175 0.0025 0"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.01"
+          w="0.035"
+          h="0.180"
+          d="0.05" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}depth_joint" type="fixed">
-      <origin xyz="0 ${asus_xtion_pro_depth_rel_rgb_py} 0" rpy="0 0 0" />
+    <joint
+      name="${frame_prefix}depth_joint"
+      type="fixed">
+      <origin
+        xyz="0 ${asus_xtion_pro_depth_rel_rgb_py} 0"
+        rpy="0 0 0" />
       <parent link="${frame_prefix}rgb_base_link" />
       <child link="${frame_prefix}depth_link" />
     </joint>
@@ -91,13 +134,22 @@
     <link name="${frame_prefix}depth_link">
       <inertial>
         <mass value="0.01" />
-        <origin xyz="-0.0175 -${asus_xtion_pro_depth_rel_rgb_py} 0" />
-        <xacro:solid_cuboid_inertia m="0.01" w="0.035" h="0.180" d="0.05" />
+        <origin
+          xyz="-0.0175 -${asus_xtion_pro_depth_rel_rgb_py} 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.01"
+          w="0.035"
+          h="0.180"
+          d="0.05" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}depth_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+    <joint
+      name="${frame_prefix}depth_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
       <parent link="${frame_prefix}depth_link" />
       <child link="${frame_prefix}depth_optical_frame" />
     </joint>
@@ -105,24 +157,31 @@
     <link name="${frame_prefix}depth_optical_frame">
       <inertial>
         <mass value="0.01" />
-        <origin xyz="${asus_xtion_pro_depth_rel_rgb_py} 0 -0.0175" />
-        <xacro:solid_cuboid_inertia m="0.01" w="0.18" h="0.05" d="0.035" />
+        <origin
+          xyz="${asus_xtion_pro_depth_rel_rgb_py} 0 -0.0175" />
+        <xacro:solid_cuboid_inertia
+          m="0.01"
+          w="0.18"
+          h="0.05"
+          d="0.035" />
       </inertial>
     </link>
 
   <!-- RGBD sensor for simulation, same as Kinect -->
-  <xacro:sensor_xtion_pro_gazebo/>
+  <xacro:sensor_xtion_pro_gazebo />
 
   </xacro:macro>
 
   <xacro:macro name="sensor_xtion_pro_gazebo">
 
     <gazebo reference="${frame_prefix}depth_link">
-      <sensor type="depth" name="${node_name}sensor">
+      <sensor
+        type="depth"
+        name="${node_name}sensor">
         <always_on>true</always_on>
         <update_rate>20.0</update_rate>
         <camera>
-          <horizontal_fov>${60.0*M_PI/180.0}</horizontal_fov>
+          <horizontal_fov>${radians(60)}</horizontal_fov>
           <image>
             <format>R8G8B8</format>
             <width>640</width>
@@ -133,7 +192,9 @@
             <far>3.5</far>
           </clip>
         </camera>
-        <plugin name="${node_name}controller" filename="libgazebo_ros_openni_kinect.so">
+        <plugin
+          name="${node_name}controller"
+          filename="libgazebo_ros_openni_kinect.so">
           <cameraName>${node_name}</cameraName>
           <alwaysOn>true</alwaysOn>
           <updateRate>15</updateRate>

--- a/robotnik_sensors/urdf/deprecated/asus_xtion_pro.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/asus_xtion_pro.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   xmlns:xacro="http://wiki.ros.org/xacro"
   name="sensor_asus_xtion_pro">
-
   <!-- Xacro properties -->
   <!-- xacro:property name="M_SCALE" value="0.001"/ -->
   <xacro:property
@@ -37,11 +36,10 @@
                         video_fps:=30
                         min_depth:=0.8
                         max_depth:=3.5">
-
     <joint
       name="${frame_prefix}rgb_joint"
       type="fixed">
-	  <xacro:insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}" />
       <child link="${frame_prefix}rgb_base_link" />
     </joint>
@@ -105,8 +103,8 @@
           xyz="0.0 0.0 0.0"
           rpy="0 0 0" />
         <geometry>
-        <box size="0.0730 .2760 0.0720" />
-      </geometry>
+          <box size="0.0730 .2760 0.0720" />
+        </geometry>
       </collision>
       <inertial>
         <mass value="0.01" />
@@ -167,13 +165,11 @@
       </inertial>
     </link>
 
-  <!-- RGBD sensor for simulation, same as Kinect -->
-  <xacro:sensor_xtion_pro_gazebo />
-
+    <!-- RGBD sensor for simulation, same as Kinect -->
+    <xacro:sensor_xtion_pro_gazebo />
   </xacro:macro>
 
   <xacro:macro name="sensor_xtion_pro_gazebo">
-
     <gazebo reference="${frame_prefix}depth_link">
       <sensor
         type="depth"
@@ -199,11 +195,21 @@
           <alwaysOn>true</alwaysOn>
           <updateRate>15</updateRate>
           <imageTopicName>rgb/image_raw</imageTopicName>
-          <depthImageTopicName>depth/image_raw</depthImageTopicName>
-          <pointCloudTopicName>depth/points</pointCloudTopicName>
-          <cameraInfoTopicName>rgb/camera_info</cameraInfoTopicName>
-          <depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
-          <frameName>${frame_prefix}depth_optical_frame</frameName>
+          <depthImageTopicName>
+            depth/image_raw
+          </depthImageTopicName>
+          <pointCloudTopicName>
+            depth/points
+          </pointCloudTopicName>
+          <cameraInfoTopicName>
+            rgb/camera_info
+          </cameraInfoTopicName>
+          <depthImageCameraInfoTopicName>
+            depth/camera_info
+          </depthImageCameraInfoTopicName>
+          <frameName>
+            ${frame_prefix}depth_optical_frame
+          </frameName>
           <baseline>0.1</baseline>
           <distortion_k1>0.0</distortion_k1>
           <distortion_k2>0.0</distortion_k2>

--- a/robotnik_sensors/urdf/deprecated/axis.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/axis.urdf.xacro
@@ -1,56 +1,102 @@
-<?xml version="1.0"?>
-<robot xmlns:xacro="http://wiki.ros.org/xacro" name="sensor_axis">
-  <xacro:property name="ptz_joint_effort_limit" value="100.0"/>
-  <xacro:property name="ptz_joint_velocity_limit" value="100.0"/>
-  <xacro:property name="ptz_joint_friction" value="0.1"/>
-  <xacro:property name="ptz_joint_damping" value="0.1"/>
-  <xacro:property name="ptz_mechanical_reduction" value="1.0"/>
+<?xml version="1.0" ?>
+<robot
+  xmlns:xacro="http://wiki.ros.org/xacro"
+  name="sensor_axis">
+  <xacro:property
+    name="ptz_joint_effort_limit"
+    value="100.0" />
+  <xacro:property
+    name="ptz_joint_velocity_limit"
+    value="100.0" />
+  <xacro:property
+    name="ptz_joint_friction"
+    value="0.1" />
+  <xacro:property
+    name="ptz_joint_damping"
+    value="0.1" />
+  <xacro:property
+    name="ptz_mechanical_reduction"
+    value="1.0" />
 
-  <xacro:macro name="sensor_axis" params="prefix parent *origin far:=^|8.0 near:=^|0.05">
-    <joint name="${prefix}_joint" type="fixed">
-      <axis xyz="0 1 0"/>
-      <xacro:insert_block name="origin"/>
-      <parent link="${parent}"/>
-      <child link="${prefix}_base_link"/>
+  <xacro:macro
+    name="sensor_axis"
+    params="prefix parent *origin far:=^|8.0 near:=^|0.05">
+    <joint
+      name="${prefix}_joint"
+      type="fixed">
+      <axis xyz="0 1 0" />
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${prefix}_base_link" />
     </joint>
     <link name="${prefix}_base_link">
       <inertial>
-        <origin xyz="0.0  0.0 -0.015" rpy="0 ${M_PI/2} 0"/>
-        <mass value="0.8"/>
-        <xacro:solid_cuboid_inertia m="0.8" w="0.152" h="0.132" d="0.132" />
+        <origin
+          xyz="0.0  0.0 -0.015"
+          rpy="0 ${radians(90)} 0" />
+        <mass value="0.8" />
+        <xacro:solid_cuboid_inertia
+          m="0.8"
+          w="0.152"
+          h="0.132"
+          d="0.132" />
       </inertial>
       <visual>
-        <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+        <origin
+          xyz="0.0 0.0 0.0"
+          rpy="0 0 0" />
         <!-- because the origin of the mesh file is not at the "center" of the model-->
         <material name="axis_color">
-          <color rgba="0.1 0.1 0.1 1"/>
+          <color rgba="0.1 0.1 0.1 1" />
         </material>
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/axis_p5514.stl" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/axis_p5514.stl"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+        <origin
+          xyz="0.0 0.0 0.0"
+          rpy="0 0 0" />
         <!-- because the origin of the mesh file is not at the "center" of the model-->
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/axis_p5514.stl" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/axis_p5514.stl"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </collision>
     </link>
-    <joint name="${prefix}_pan_joint" type="revolute">
-      <axis xyz="0 0 -1"/>
-      <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+    <joint
+      name="${prefix}_pan_joint"
+      type="revolute">
+      <axis xyz="0 0 -1" />
+      <origin
+        xyz="0.0 0.0 0.0"
+        rpy="0 0 0" />
       <!-- check the displacement -->
-      <parent link="${prefix}_base_link"/>
-      <child link="${prefix}_pan_link"/>
-      <limit effort="${ptz_joint_effort_limit}" velocity="${ptz_joint_velocity_limit}" lower="-3.1415" upper="3.1415"/>
-      <joint_properties damping="${ptz_joint_damping}" friction="{ptz_joint_friction}"/>
+      <parent link="${prefix}_base_link" />
+      <child link="${prefix}_pan_link" />
+      <limit
+        effort="${ptz_joint_effort_limit}"
+        velocity="${ptz_joint_velocity_limit}"
+        lower="-3.1415"
+        upper="3.1415" />
+      <joint_properties
+        damping="${ptz_joint_damping}"
+        friction="{ptz_joint_friction}" />
     </joint>
     <link name="${prefix}_pan_link">
       <inertial>
-        <mass value="0.1"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.1" w="0.1" h="0.11" d="0.11" />
+        <mass value="0.1" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.1"
+          w="0.1"
+          h="0.11"
+          d="0.11" />
       </inertial>
     </link>
     <transmission name="${prefix}_pan_trans">
@@ -63,19 +109,33 @@
         <mechanicalReduction>${ptz_mechanical_reduction}</mechanicalReduction>
       </actuator>
     </transmission>
-    <joint name="${prefix}_tilt_joint" type="revolute">
-      <axis xyz="0 -1 0"/>
-      <origin xyz="0.0 0.0 0.0"/>
-      <parent link="${prefix}_pan_link"/>
-      <child link="${prefix}_tilt_link"/>
-      <limit effort="${ptz_joint_effort_limit}" velocity="${ptz_joint_velocity_limit}" lower="-1.5708" upper="1.5708"/>
-      <joint_properties damping="${ptz_joint_damping}" friction="{ptz_joint_friction}"/>
+    <joint
+      name="${prefix}_tilt_joint"
+      type="revolute">
+      <axis xyz="0 -1 0" />
+      <origin xyz="0.0 0.0 0.0" />
+      <parent link="${prefix}_pan_link" />
+      <child link="${prefix}_tilt_link" />
+      <limit
+        effort="${ptz_joint_effort_limit}"
+        velocity="${ptz_joint_velocity_limit}"
+        lower="-1.5708"
+        upper="1.5708" />
+      <joint_properties
+        damping="${ptz_joint_damping}"
+        friction="{ptz_joint_friction}" />
     </joint>
     <link name="${prefix}_tilt_link">
       <inertial>
-        <mass value="0.1"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.1" w="0.11" h="0.11" d="0.1" />
+        <mass value="0.1" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.1"
+          w="0.11"
+          h="0.11"
+          d="0.1" />
       </inertial>
     </link>
     <transmission name="${prefix}_tilt_trans">
@@ -88,36 +148,52 @@
         <mechanicalReduction>${ptz_mechanical_reduction}</mechanicalReduction>
       </actuator>
     </transmission>
-    <joint name="${prefix}_frame_joint" type="fixed">
-      <origin xyz="0.0 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}_tilt_link"/>
-      <child link="${prefix}_frame_link"/>
+    <joint
+      name="${prefix}_frame_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0 0"
+        rpy="0 0 0" />
+      <parent link="${prefix}_tilt_link" />
+      <child link="${prefix}_frame_link" />
     </joint>
     <link name="${prefix}_frame_link">
       <inertial>
-        <mass value="0.1"/>
-        <origin xyz="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.1" w="0.11" h="0.11" d="0.1" />
+        <mass value="0.1" />
+        <origin xyz="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.1"
+          w="0.11"
+          h="0.11"
+          d="0.1" />
       </inertial>
     </link>
     <!-- Optical frame -->
-    <joint name="${prefix}_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}"/>
-      <parent link="${prefix}_frame_link"/>
-      <child link="${prefix}_optical_frame_link"/>
+    <joint
+      name="${prefix}_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
+      <parent link="${prefix}_frame_link" />
+      <child link="${prefix}_optical_frame_link" />
     </joint>
     <link name="${prefix}_optical_frame_link">
       <inertial>
-        <mass value="0.1"/>
-        <origin xyz="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.1" w="0.11" h="0.11" d="0.1" />
+        <mass value="0.1" />
+        <origin xyz="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.1"
+          w="0.11"
+          h="0.11"
+          d="0.1" />
       </inertial>
     </link>
     <gazebo reference="${prefix}_base_link">
       <material>Gazebo/FlatBlack</material>
     </gazebo>
     <!-- Axis sensor for simulation -->
-    <xacro:sensor_axis_gazebo/>
+    <xacro:sensor_axis_gazebo />
   </xacro:macro>
 
 
@@ -125,10 +201,12 @@
 
   <xacro:macro name="sensor_axis_gazebo">
     <gazebo reference="${prefix}_frame_link">
-      <sensor type="camera" name="${prefix}_sensor">
+      <sensor
+        type="camera"
+        name="${prefix}_sensor">
         <update_rate>30.0</update_rate>
         <camera>
-          <horizontal_fov>${60.0*M_PI/180.0}</horizontal_fov>
+          <horizontal_fov>${radians(60)}</horizontal_fov>
           <image>
             <format>R8G8B8</format>
             <width>640</width>
@@ -139,7 +217,9 @@
             <far>${far}</far>
           </clip>
         </camera>
-        <plugin name="${prefix}_controller" filename="libgazebo_ros_camera.so">
+        <plugin
+          name="${prefix}_controller"
+          filename="libgazebo_ros_camera.so">
           <alwaysOn>true</alwaysOn>
           <updateRate>0.0</updateRate>
           <cameraName>${prefix}</cameraName>

--- a/robotnik_sensors/urdf/deprecated/axis.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/axis.urdf.xacro
@@ -102,11 +102,17 @@
     <transmission name="${prefix}_pan_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}_pan_joint">
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
+        <hardwareInterface>
+          hardware_interface/VelocityJointInterface
+        </hardwareInterface>
       </joint>
       <actuator name="pan_motor">
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
-        <mechanicalReduction>${ptz_mechanical_reduction}</mechanicalReduction>
+        <hardwareInterface>
+          hardware_interface/VelocityJointInterface
+        </hardwareInterface>
+        <mechanicalReduction>
+          ${ptz_mechanical_reduction}
+        </mechanicalReduction>
       </actuator>
     </transmission>
     <joint
@@ -141,11 +147,17 @@
     <transmission name="${prefix}_tilt_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}_tilt_joint">
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
+        <hardwareInterface>
+          hardware_interface/VelocityJointInterface
+        </hardwareInterface>
       </joint>
       <actuator name="tilt_motor">
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
-        <mechanicalReduction>${ptz_mechanical_reduction}</mechanicalReduction>
+        <hardwareInterface>
+          hardware_interface/VelocityJointInterface
+        </hardwareInterface>
+        <mechanicalReduction>
+          ${ptz_mechanical_reduction}
+        </mechanicalReduction>
       </actuator>
     </transmission>
     <joint
@@ -196,9 +208,6 @@
     <xacro:sensor_axis_gazebo />
   </xacro:macro>
 
-
-
-
   <xacro:macro name="sensor_axis_gazebo">
     <gazebo reference="${prefix}_frame_link">
       <sensor
@@ -224,8 +233,12 @@
           <updateRate>0.0</updateRate>
           <cameraName>${prefix}</cameraName>
           <imageTopicName>image_raw</imageTopicName>
-          <cameraInfoTopicName>camera_info</cameraInfoTopicName>
-          <frameName>/${prefix}_optical_frame_link</frameName>
+          <cameraInfoTopicName>
+            camera_info
+          </cameraInfoTopicName>
+          <frameName>
+            /${prefix}_optical_frame_link
+          </frameName>
           <hackBaseline>0.0</hackBaseline>
           <distortionK1>0.0</distortionK1>
           <distortionK2>0.0</distortionK2>
@@ -236,5 +249,4 @@
       </sensor>
     </gazebo>
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/axis_q8641.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/axis_q8641.urdf.xacro
@@ -1,16 +1,32 @@
-<?xml version="1.0"?>
-<robot xmlns:xacro="http://wiki.ros.org/xacro" name="sensor_axis_q8641">
-  <xacro:property name="ptz_joint_effort_limit" value="100.0"/>
-  <xacro:property name="ptz_joint_velocity_limit" value="1.0"/>
-  <xacro:property name="ptz_joint_friction" value="0.1"/>
-  <xacro:property name="ptz_joint_damping" value="0.1"/>
-  <xacro:property name="ptz_mechanical_reduction" value="1.0"/>
-  <xacro:macro name="sensor_axis_q8641" params="prefix parent *origin far:=^|8.0 near:=^|0.05">
-    <joint name="${prefix}_joint" type="fixed">
-      <axis xyz="0 1 0"/>
-      <xacro:insert_block name="origin"/>
-      <parent link="${parent}"/>
-      <child link="${prefix}_base_link"/>
+<?xml version="1.0" ?>
+<robot
+  xmlns:xacro="http://wiki.ros.org/xacro"
+  name="sensor_axis_q8641">
+  <xacro:property
+    name="ptz_joint_effort_limit"
+    value="100.0" />
+  <xacro:property
+    name="ptz_joint_velocity_limit"
+    value="1.0" />
+  <xacro:property
+    name="ptz_joint_friction"
+    value="0.1" />
+  <xacro:property
+    name="ptz_joint_damping"
+    value="0.1" />
+  <xacro:property
+    name="ptz_mechanical_reduction"
+    value="1.0" />
+  <xacro:macro
+    name="sensor_axis_q8641"
+    params="prefix parent *origin far:=^|8.0 near:=^|0.05">
+    <joint
+      name="${prefix}_joint"
+      type="fixed">
+      <axis xyz="0 1 0" />
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${prefix}_base_link" />
     </joint>
     <link name="${prefix}_base_link">
       <!--inertial>
@@ -19,35 +35,59 @@
         <xacro:solid_cuboid_inertia m="2" w="0.175" h="0.175" d="0.12" />
       </inertial-->
       <inertial>
-        <mass value="0.001"/>
-        <inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
+        <mass value="0.001" />
+        <inertia
+          ixx="0.001"
+          ixy="0"
+          ixz="0"
+          iyy="0.001"
+          iyz="0"
+          izz="0.001" />
       </inertial>
       <visual>
-        <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+        <origin
+          xyz="0.0 0.0 0.0"
+          rpy="0 0 0" />
         <!-- because the origin of the mesh file is not at the "center" of the model-->
         <material name="axis_color">
-          <color rgba="0.1 0.1 0.1 1"/>
+          <color rgba="0.1 0.1 0.1 1" />
         </material>
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/axis_q8641_n1-1.STL" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/axis_q8641_n1-1.STL"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+        <origin
+          xyz="0.0 0.0 0.0"
+          rpy="0 0 0" />
         <!-- because the origin of the mesh file is not at the "center" of the model-->
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/axis_q8641_n1-1.STL" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/axis_q8641_n1-1.STL"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </collision>
     </link>
-    <joint name="${prefix}_pan_joint" type="revolute">
-      <axis xyz="0 0 -1"/>
-      <origin xyz="0.0 0.0 0.120" rpy="0 0 0"/>
+    <joint
+      name="${prefix}_pan_joint"
+      type="revolute">
+      <axis xyz="0 0 -1" />
+      <origin
+        xyz="0.0 0.0 0.120"
+        rpy="0 0 0" />
       <!-- check the displacement -->
-      <parent link="${prefix}_base_link"/>
-      <child link="${prefix}_pan_link"/>
-      <limit effort="${ptz_joint_effort_limit}" velocity="${ptz_joint_velocity_limit}" lower="-3.1415" upper="3.1415"/>
-      <joint_properties damping="${ptz_joint_damping}" friction="{ptz_joint_friction}"/>
+      <parent link="${prefix}_base_link" />
+      <child link="${prefix}_pan_link" />
+      <limit
+        effort="${ptz_joint_effort_limit}"
+        velocity="${ptz_joint_velocity_limit}"
+        lower="-3.1415"
+        upper="3.1415" />
+      <joint_properties
+        damping="${ptz_joint_damping}"
+        friction="{ptz_joint_friction}" />
     </joint>
     <link name="${prefix}_pan_link">
       <!--inertial>
@@ -56,24 +96,38 @@
         <xacro:solid_cuboid_inertia m="5.0" w="0.175" h="0.175" d="0.24" />
       </inertial-->
       <inertial>
-        <mass value="0.001"/>
-        <inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
+        <mass value="0.001" />
+        <inertia
+          ixx="0.001"
+          ixy="0"
+          ixz="0"
+          iyy="0.001"
+          iyz="0"
+          izz="0.001" />
       </inertial>
       <visual>
-        <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+        <origin
+          xyz="0.0 0.0 0.0"
+          rpy="0 0 0" />
         <!-- because the origin of the mesh file is not at the "center" of the model-->
         <material name="axis_color">
-          <color rgba="0.1 0.1 0.1 1"/>
+          <color rgba="0.1 0.1 0.1 1" />
         </material>
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/axis_q8641_n2-1.STL" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/axis_q8641_n2-1.STL"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+        <origin
+          xyz="0.0 0.0 0.0"
+          rpy="0 0 0" />
         <!-- because the origin of the mesh file is not at the "center" of the model-->
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/axis_q8641_n2-1.STL" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/axis_q8641_n2-1.STL"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </collision>
     </link>
@@ -87,13 +141,21 @@
         <mechanicalReduction>${ptz_mechanical_reduction}</mechanicalReduction>
       </actuator>
     </transmission>
-    <joint name="${prefix}_tilt_joint" type="revolute">
-      <axis xyz="0 -1 0"/>
-      <origin xyz="0.0 0.0 0.177"/>
-      <parent link="${prefix}_pan_link"/>
-      <child link="${prefix}_tilt_link"/>
-      <limit effort="${ptz_joint_effort_limit}" velocity="${ptz_joint_velocity_limit}" lower="-1.5708" upper="1.5708"/>
-      <joint_properties damping="${ptz_joint_damping}" friction="{ptz_joint_friction}"/>
+    <joint
+      name="${prefix}_tilt_joint"
+      type="revolute">
+      <axis xyz="0 -1 0" />
+      <origin xyz="0.0 0.0 0.177" />
+      <parent link="${prefix}_pan_link" />
+      <child link="${prefix}_tilt_link" />
+      <limit
+        effort="${ptz_joint_effort_limit}"
+        velocity="${ptz_joint_velocity_limit}"
+        lower="-1.5708"
+        upper="1.5708" />
+      <joint_properties
+        damping="${ptz_joint_damping}"
+        friction="{ptz_joint_friction}" />
     </joint>
     <link name="${prefix}_tilt_link">
       <!--inertial>
@@ -102,24 +164,38 @@
         <xacro:solid_cuboid_inertia m="5.0" w="0.24" h="0.09" d="0.09" />
       </inertial-->
       <inertial>
-        <mass value="0.001"/>
-        <inertia ixx="0.001" ixy="0" ixz="0" iyy="0.001" iyz="0" izz="0.001"/>
+        <mass value="0.001" />
+        <inertia
+          ixx="0.001"
+          ixy="0"
+          ixz="0"
+          iyy="0.001"
+          iyz="0"
+          izz="0.001" />
       </inertial>
       <visual>
-        <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+        <origin
+          xyz="0.0 0.0 0.0"
+          rpy="0 0 0" />
         <!-- because the origin of the mesh file is not at the "center" of the model-->
         <material name="axis_color">
-          <color rgba="0.1 0.1 0.1 1"/>
+          <color rgba="0.1 0.1 0.1 1" />
         </material>
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/camera_axis_q8641.STL" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/camera_axis_q8641.STL"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+        <origin
+          xyz="0.0 0.0 0.0"
+          rpy="0 0 0" />
         <!-- because the origin of the mesh file is not at the "center" of the model-->
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/camera_axis_q8641.STL" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/camera_axis_q8641.STL"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </collision>
     </link>
@@ -133,10 +209,14 @@
         <mechanicalReduction>${ptz_mechanical_reduction}</mechanicalReduction>
       </actuator>
     </transmission>
-    <joint name="${prefix}_frame_joint" type="fixed">
-      <origin xyz="0 0 0.11" rpy="0 0 0"/>
-      <parent link="${prefix}_tilt_link"/>
-      <child link="${prefix}_frame_link"/>
+    <joint
+      name="${prefix}_frame_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0.11"
+        rpy="0 0 0" />
+      <parent link="${prefix}_tilt_link" />
+      <child link="${prefix}_frame_link" />
     </joint>
     <link name="${prefix}_frame_link">
       <!--inertial>
@@ -146,10 +226,14 @@
       </inertial-->
     </link>
     <!-- Optical frame -->
-    <joint name="${prefix}_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}"/>
-      <parent link="${prefix}_frame_link"/>
-      <child link="${prefix}_optical_frame_link"/>
+    <joint
+      name="${prefix}_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
+      <parent link="${prefix}_frame_link" />
+      <child link="${prefix}_optical_frame_link" />
     </joint>
     <link name="${prefix}_optical_frame_link">
       <!--inertial>
@@ -162,7 +246,7 @@
       <material>Gazebo/FlatBlack</material>
     </gazebo>
     <!-- Axis sensor for simulation -->
-    <xacro:sensor_axis_q8641_gazebo/>
+    <xacro:sensor_axis_q8641_gazebo />
   </xacro:macro>
 
 
@@ -170,10 +254,12 @@
 
   <xacro:macro name="sensor_axis_q8641_gazebo">
     <gazebo reference="${prefix}_frame_link">
-      <sensor type="camera" name="${prefix}_sensor">
+      <sensor
+        type="camera"
+        name="${prefix}_sensor">
         <update_rate>30.0</update_rate>
         <camera>
-          <horizontal_fov>${60.0*M_PI/180.0}</horizontal_fov>
+          <horizontal_fov>${radians(60)}</horizontal_fov>
           <image>
             <format>R8G8B8</format>
             <width>640</width>
@@ -184,7 +270,9 @@
             <far>${far}</far>
           </clip>
         </camera>
-        <plugin name="${prefix}_controller" filename="libgazebo_ros_camera.so">
+        <plugin
+          name="${prefix}_controller"
+          filename="libgazebo_ros_camera.so">
           <alwaysOn>true</alwaysOn>
           <updateRate>0.0</updateRate>
           <cameraName>${prefix}</cameraName>

--- a/robotnik_sensors/urdf/deprecated/axis_q8641.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/axis_q8641.urdf.xacro
@@ -134,11 +134,17 @@
     <transmission name="${prefix}_pan_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}_pan_joint">
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
+        <hardwareInterface>
+          hardware_interface/VelocityJointInterface
+        </hardwareInterface>
       </joint>
       <actuator name="pan_motor">
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
-        <mechanicalReduction>${ptz_mechanical_reduction}</mechanicalReduction>
+        <hardwareInterface>
+          hardware_interface/VelocityJointInterface
+        </hardwareInterface>
+        <mechanicalReduction>
+          ${ptz_mechanical_reduction}
+        </mechanicalReduction>
       </actuator>
     </transmission>
     <joint
@@ -202,11 +208,17 @@
     <transmission name="${prefix}_tilt_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}_tilt_joint">
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
+        <hardwareInterface>
+          hardware_interface/VelocityJointInterface
+        </hardwareInterface>
       </joint>
       <actuator name="tilt_motor">
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
-        <mechanicalReduction>${ptz_mechanical_reduction}</mechanicalReduction>
+        <hardwareInterface>
+          hardware_interface/VelocityJointInterface
+        </hardwareInterface>
+        <mechanicalReduction>
+          ${ptz_mechanical_reduction}
+        </mechanicalReduction>
       </actuator>
     </transmission>
     <joint
@@ -249,9 +261,6 @@
     <xacro:sensor_axis_q8641_gazebo />
   </xacro:macro>
 
-
-
-
   <xacro:macro name="sensor_axis_q8641_gazebo">
     <gazebo reference="${prefix}_frame_link">
       <sensor
@@ -277,8 +286,12 @@
           <updateRate>0.0</updateRate>
           <cameraName>${prefix}</cameraName>
           <imageTopicName>image_raw</imageTopicName>
-          <cameraInfoTopicName>camera_info</cameraInfoTopicName>
-          <frameName>/${prefix}_optical_frame_link</frameName>
+          <cameraInfoTopicName>
+            camera_info
+          </cameraInfoTopicName>
+          <frameName>
+            /${prefix}_optical_frame_link
+          </frameName>
           <hackBaseline>0.0</hackBaseline>
           <distortionK1>0.0</distortionK1>
           <distortionK2>0.0</distortionK2>
@@ -289,5 +302,4 @@
       </sensor>
     </gazebo>
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/benewake_ce30.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/benewake_ce30.urdf.xacro
@@ -1,66 +1,100 @@
-<?xml version="1.0"?>
-<robot name="sensor_benewake_ce30" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_benewake_ce30"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:property name="M_PI" value="3.1415926535897931" />
-
-  <xacro:macro name="sensor_benewake_ce30" params="prefix parent prefix_topic *origin range_min range_max hfov vfov fps gpu:=^|true">
+  <xacro:macro
+    name="sensor_benewake_ce30"
+    params="prefix parent prefix_topic *origin range_min range_max hfov vfov fps gpu:=^|true">
     <material name="black_alu">
-      <color rgba="0.9 0.9 0.9 1"/>
+      <color rgba="0.9 0.9 0.9 1" />
     </material>
 
-    <joint name="${prefix}_base_joint" type="fixed">
+    <joint
+      name="${prefix}_base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${prefix}_base_link" />
     </joint>
 
     <link name="${prefix}_base_link">
       <visual>
       <!-- origin xyz="0 0 0" rpy="0 0 1.5708"/ -->
-      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/benewake_ce30.stl" />
+          <mesh
+            filename="package://robotnik_sensors/meshes/benewake_ce30.stl" />
         </geometry>
-        <material name="black_alu"/>
+        <material name="black_alu" />
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/benewake_ce30.stl" />
+          <mesh
+            filename="package://robotnik_sensors/meshes/benewake_ce30.stl" />
         </geometry>
       </collision>
       <inertial>
         <!-- The following are not reliable values, and should not be used for modeling -->
         <mass value="0.219" />
         <origin xyz="0 0 0.025" />
-        <xacro:solid_cuboid_inertia m="0.219" w="0.047" h="0.079" d="0.05" />
+        <xacro:solid_cuboid_inertia
+          m="0.219"
+          w="0.047"
+          h="0.079"
+          d="0.05" />
       </inertial>
     </link>
 
-    <joint name="${prefix}_joint" type="fixed">
-      <parent link="${prefix}_base_link"/>
+    <joint
+      name="${prefix}_joint"
+      type="fixed">
+      <parent link="${prefix}_base_link" />
       <!-- default ce30d_driver_ros configuration -->
       <child link="${prefix}_link" />
     </joint>
-    <link name="${prefix}_link"/>
+    <link name="${prefix}_link" />
 
-  <xacro:sensor_benewake_ce30_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" vfov="${vfov}" fps="${fps}" gpu="${gpu}"/>
+  <xacro:sensor_benewake_ce30_gazebo
+      range_min="${range_min}"
+      range_max="${range_max}"
+      hfov="${hfov}"
+      vfov="${vfov}"
+      fps="${fps}"
+      gpu="${gpu}" />
 
   </xacro:macro>
 
-  <xacro:macro name="sensor_benewake_ce30_gazebo" params="range_min range_max hfov vfov fps gpu">
+  <xacro:macro
+    name="sensor_benewake_ce30_gazebo"
+    params="range_min range_max hfov vfov fps gpu">
     <gazebo reference="${prefix}_link">
       <xacro:if value="${gpu}">
         <!-- Using GPU needs: https://github.com/RobotnikAutomation/velodyne_simulator -->
-        <xacro:property name="ray_type" value="gpu_ray" />
-        <xacro:property name="plugin_lib" value="libgazebo_ros_velodyne_gpu_laser.so" />
+        <xacro:property
+          name="ray_type"
+          value="gpu_ray" />
+        <xacro:property
+          name="plugin_lib"
+          value="libgazebo_ros_velodyne_gpu_laser.so" />
 
       </xacro:if>
       <xacro:unless value="${gpu}">
-        <xacro:property name="ray_type" value="ray" />
-        <xacro:property name="plugin_lib" value="libgazebo_ros_velodyne_laser.so" />
+        <xacro:property
+          name="ray_type"
+          value="ray" />
+        <xacro:property
+          name="plugin_lib"
+          value="libgazebo_ros_velodyne_laser.so" />
       </xacro:unless>
-        <sensor type="${ray_type}" name="${prefix}_sensor">
+        <sensor
+        type="${ray_type}"
+        name="${prefix}_sensor">
           <pose>0 0 0 0 0 0.0</pose>
           <visualize>false</visualize>
           <update_rate>${fps}</update_rate>
@@ -69,13 +103,13 @@
               <horizontal>
 				<!-- for a high quality simulation -->
                 <samples>320</samples>
-                <min_angle>-${hfov/2.0*M_PI/180.0}</min_angle>
-                <max_angle>${hfov/2.0*M_PI/180.0}</max_angle>
+                <min_angle>-${radians(hfov)}</min_angle>
+                <max_angle>${radians(hfov)}</max_angle>
               </horizontal>
               <vertical>
                 <samples>20</samples>
-                <min_angle>-${vfov/2.0*M_PI/180.0}</min_angle>
-                <max_angle>${vfov/2.0*M_PI/180.0}</max_angle>
+                <min_angle>-${radians(vfov)}</min_angle>
+                <max_angle>${radians(vfov)}</max_angle>
               </vertical>
             </scan>
             <range>
@@ -87,7 +121,9 @@
               <type>none</type>
             </noise>
           </ray>
-          <plugin name="${prefix}_controller" filename="${plugin_lib}">
+          <plugin
+          name="${prefix}_controller"
+          filename="${plugin_lib}">
             <topicName>${prefix_topic}/points</topicName>
             <frameName>/${prefix}_link</frameName>
             <gaussianNoise>0.008</gaussianNoise>
@@ -97,14 +133,36 @@
 
   </xacro:macro>
 
-  <xacro:macro name="sensor_benewake_ce30a" params="prefix parent prefix_topic:='lidar_3d' *origin gpu:=false">
-    <xacro:sensor_benewake_ce30 prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.1" range_max="4.0" hfov="132.0" vfov="9.0" fps="20.0" gpu="${gpu}" >
+  <xacro:macro
+    name="sensor_benewake_ce30a"
+    params="prefix parent prefix_topic:='lidar_3d' *origin gpu:=false">
+    <xacro:sensor_benewake_ce30
+      prefix="${prefix}"
+      parent="${parent}"
+      prefix_topic="${prefix_topic}"
+      range_min="0.1"
+      range_max="4.0"
+      hfov="132.0"
+      vfov="9.0"
+      fps="20.0"
+      gpu="${gpu}">
       <xacro:insert_block name="origin" />
     </xacro:sensor_benewake_ce30>
   </xacro:macro>
 
-  <xacro:macro name="sensor_benewake_ce30c" params="prefix parent prefix_topic:='lidar_3d' *origin gpu:=false">
-    <xacro:sensor_benewake_ce30 prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.1" range_max="4.0" hfov="132.0" vfov="9.0" fps="20.0" gpu="${gpu}" >
+  <xacro:macro
+    name="sensor_benewake_ce30c"
+    params="prefix parent prefix_topic:='lidar_3d' *origin gpu:=false">
+    <xacro:sensor_benewake_ce30
+      prefix="${prefix}"
+      parent="${parent}"
+      prefix_topic="${prefix_topic}"
+      range_min="0.1"
+      range_max="4.0"
+      hfov="132.0"
+      vfov="9.0"
+      fps="20.0"
+      gpu="${gpu}">
       <xacro:insert_block name="origin" />
     </xacro:sensor_benewake_ce30>
   </xacro:macro>

--- a/robotnik_sensors/urdf/deprecated/benewake_ce30.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/benewake_ce30.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_benewake_ce30"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="sensor_benewake_ce30"
     params="prefix parent prefix_topic *origin range_min range_max hfov vfov fps gpu:=^|true">
@@ -20,8 +19,8 @@
 
     <link name="${prefix}_base_link">
       <visual>
-      <!-- origin xyz="0 0 0" rpy="0 0 1.5708"/ -->
-      <origin
+        <!-- origin xyz="0 0 0" rpy="0 0 1.5708"/ -->
+        <origin
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
@@ -60,14 +59,13 @@
     </joint>
     <link name="${prefix}_link" />
 
-  <xacro:sensor_benewake_ce30_gazebo
+    <xacro:sensor_benewake_ce30_gazebo
       range_min="${range_min}"
       range_max="${range_max}"
       hfov="${hfov}"
       vfov="${vfov}"
       fps="${fps}"
       gpu="${gpu}" />
-
   </xacro:macro>
 
   <xacro:macro
@@ -82,7 +80,6 @@
         <xacro:property
           name="plugin_lib"
           value="libgazebo_ros_velodyne_gpu_laser.so" />
-
       </xacro:if>
       <xacro:unless value="${gpu}">
         <xacro:property
@@ -92,45 +89,44 @@
           name="plugin_lib"
           value="libgazebo_ros_velodyne_laser.so" />
       </xacro:unless>
-        <sensor
+      <sensor
         type="${ray_type}"
         name="${prefix}_sensor">
-          <pose>0 0 0 0 0 0.0</pose>
-          <visualize>false</visualize>
-          <update_rate>${fps}</update_rate>
-          <ray>
-            <scan>
-              <horizontal>
-				<!-- for a high quality simulation -->
-                <samples>320</samples>
-                <min_angle>-${radians(hfov)}</min_angle>
-                <max_angle>${radians(hfov)}</max_angle>
-              </horizontal>
-              <vertical>
-                <samples>20</samples>
-                <min_angle>-${radians(vfov)}</min_angle>
-                <max_angle>${radians(vfov)}</max_angle>
-              </vertical>
-            </scan>
-            <range>
-              <min>${range_min}</min>
-              <max>${range_max}</max>
-              <resolution>0.01</resolution>
-            </range>
-            <noise>
-              <type>none</type>
-            </noise>
-          </ray>
-          <plugin
+        <pose>0 0 0 0 0 0.0</pose>
+        <visualize>false</visualize>
+        <update_rate>${fps}</update_rate>
+        <ray>
+          <scan>
+            <horizontal>
+              <!-- for a high quality simulation -->
+              <samples>320</samples>
+              <min_angle>-${radians(hfov)}</min_angle>
+              <max_angle>${radians(hfov)}</max_angle>
+            </horizontal>
+            <vertical>
+              <samples>20</samples>
+              <min_angle>-${radians(vfov)}</min_angle>
+              <max_angle>${radians(vfov)}</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>${range_min}</min>
+            <max>${range_max}</max>
+            <resolution>0.01</resolution>
+          </range>
+          <noise>
+            <type>none</type>
+          </noise>
+        </ray>
+        <plugin
           name="${prefix}_controller"
           filename="${plugin_lib}">
-            <topicName>${prefix_topic}/points</topicName>
-            <frameName>/${prefix}_link</frameName>
-            <gaussianNoise>0.008</gaussianNoise>
-          </plugin>
-        </sensor>
+          <topicName>${prefix_topic}/points</topicName>
+          <frameName>/${prefix}_link</frameName>
+          <gaussianNoise>0.008</gaussianNoise>
+        </plugin>
+      </sensor>
     </gazebo>
-
   </xacro:macro>
 
   <xacro:macro
@@ -166,5 +162,4 @@
       <xacro:insert_block name="origin" />
     </xacro:sensor_benewake_ce30>
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/benewake_ce30d.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/benewake_ce30d.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_benewake_ce30d"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="sensor_benewake_ce30d"
     params="prefix parent prefix_topic:='lidar_3d' *origin range_min:=0.4 range_max:=28.0 hfov:=60.0 vfov:=4.0 fps:=30.0 gpu:=^|true">
@@ -20,8 +19,8 @@
 
     <link name="${prefix}_base_link">
       <visual>
-      <!-- origin xyz="0 0 0" rpy="0 0 1.5708"/ -->
-      <origin
+        <!-- origin xyz="0 0 0" rpy="0 0 1.5708"/ -->
+        <origin
           xyz="0 0 0"
           rpy="1.5708 0 1.5708" />
         <geometry>
@@ -63,14 +62,13 @@
     </joint>
     <link name="${prefix}_link" />
 
-  <xacro:sensor_benewake_ce30d_gazebo
+    <xacro:sensor_benewake_ce30d_gazebo
       range_min="${range_min}"
       range_max="${range_max}"
       hfov="${hfov}"
       vfov="${vfov}"
       fps="${fps}"
       gpu="${gpu}" />
-
   </xacro:macro>
 
   <xacro:macro
@@ -85,7 +83,6 @@
         <xacro:property
           name="plugin_lib"
           value="libgazebo_ros_velodyne_gpu_laser.so" />
-
       </xacro:if>
       <xacro:unless value="${gpu}">
         <xacro:property
@@ -95,45 +92,43 @@
           name="plugin_lib"
           value="libgazebo_ros_block_laser.so" />
       </xacro:unless>
-        <sensor
+      <sensor
         type="${ray_type}"
         name="${prefix}_sensor">
-          <pose>0 0 0 0 0 0.0</pose>
-          <visualize>false</visualize>
-          <update_rate>${fps}</update_rate>
-          <ray>
-            <scan>
-              <horizontal>
-				<!-- for a high quality simulation -->
-                <samples>320</samples>
-                <min_angle>-${radians(hfov)}</min_angle>
-                <max_angle>${radians(hfov)}</max_angle>
-              </horizontal>
-              <vertical>
-                <samples>20</samples>
-                <min_angle>-${radians(vfov)}</min_angle>
-                <max_angle>${radians(vfov)}</max_angle>
-              </vertical>
-            </scan>
-            <range>
-              <min>${range_min}</min>
-              <max>${range_max}</max>
-              <resolution>0.01</resolution>
-            </range>
-            <noise>
-              <type>none</type>
-            </noise>
-          </ray>
-          <plugin
+        <pose>0 0 0 0 0 0.0</pose>
+        <visualize>false</visualize>
+        <update_rate>${fps}</update_rate>
+        <ray>
+          <scan>
+            <horizontal>
+              <!-- for a high quality simulation -->
+              <samples>320</samples>
+              <min_angle>-${radians(hfov)}</min_angle>
+              <max_angle>${radians(hfov)}</max_angle>
+            </horizontal>
+            <vertical>
+              <samples>20</samples>
+              <min_angle>-${radians(vfov)}</min_angle>
+              <max_angle>${radians(vfov)}</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>${range_min}</min>
+            <max>${range_max}</max>
+            <resolution>0.01</resolution>
+          </range>
+          <noise>
+            <type>none</type>
+          </noise>
+        </ray>
+        <plugin
           name="${prefix}_controller"
           filename="${plugin_lib}">
-            <topicName>${prefix_topic}/points</topicName>
-            <frameName>/${prefix}_link</frameName>
-            <gaussianNoise>0.008</gaussianNoise>
-          </plugin>
-        </sensor>
+          <topicName>${prefix_topic}/points</topicName>
+          <frameName>/${prefix}_link</frameName>
+          <gaussianNoise>0.008</gaussianNoise>
+        </plugin>
+      </sensor>
     </gazebo>
-
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/benewake_ce30d.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/benewake_ce30d.urdf.xacro
@@ -1,67 +1,103 @@
-<?xml version="1.0"?>
-<robot name="sensor_benewake_ce30d" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_benewake_ce30d"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:property name="M_PI" value="3.1415926535897931" />
-
-  <xacro:macro name="sensor_benewake_ce30d" params="prefix parent prefix_topic:='lidar_3d' *origin range_min:=0.4 range_max:=28.0 hfov:=60.0 vfov:=4.0 fps:=30.0 gpu:=^|true">
+  <xacro:macro
+    name="sensor_benewake_ce30d"
+    params="prefix parent prefix_topic:='lidar_3d' *origin range_min:=0.4 range_max:=28.0 hfov:=60.0 vfov:=4.0 fps:=30.0 gpu:=^|true">
     <material name="black_alu">
-      <color rgba="0.9 0.9 0.9 1"/>
+      <color rgba="0.9 0.9 0.9 1" />
     </material>
 
-    <joint name="${prefix}_base_joint" type="fixed">
+    <joint
+      name="${prefix}_base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${prefix}_base_link" />
     </joint>
 
     <link name="${prefix}_base_link">
       <visual>
       <!-- origin xyz="0 0 0" rpy="0 0 1.5708"/ -->
-      <origin xyz="0 0 0" rpy="1.5708 0 1.5708"/>
+      <origin
+          xyz="0 0 0"
+          rpy="1.5708 0 1.5708" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/benewake_ce30d.stl" />
+          <mesh
+            filename="package://robotnik_sensors/meshes/benewake_ce30d.stl" />
           <!--box size="${ce30d_length} ${ce30d_width} ${ce30d_height}"/-->
         </geometry>
-        <material name="black_alu"/>
+        <material name="black_alu" />
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/benewake_ce30d.stl" />
+          <mesh
+            filename="package://robotnik_sensors/meshes/benewake_ce30d.stl" />
         </geometry>
       </collision>
       <inertial>
         <!-- The following are not reliable values, and should not be used for modeling -->
         <mass value="0.336" />
-        <origin xyz="0 0 0.027" rpy="0 0 ${M_PI/2}" />
-        <xacro:solid_cuboid_inertia m="0.336" w="0.057" h="0.083" d="0.054" />
+        <origin
+          xyz="0 0 0.027"
+          rpy="0 0 ${radians(90)}" />
+        <xacro:solid_cuboid_inertia
+          m="0.336"
+          w="0.057"
+          h="0.083"
+          d="0.054" />
       </inertial>
     </link>
 
-    <joint name="${prefix}_joint" type="fixed">
-      <parent link="${prefix}_base_link"/>
+    <joint
+      name="${prefix}_joint"
+      type="fixed">
+      <parent link="${prefix}_base_link" />
       <!-- default ce30d_driver_ros configuration -->
       <child link="${prefix}_link" />
     </joint>
-    <link name="${prefix}_link"/>
+    <link name="${prefix}_link" />
 
-  <xacro:sensor_benewake_ce30d_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" vfov="${vfov}" fps="${fps}" gpu="${gpu}"/>
+  <xacro:sensor_benewake_ce30d_gazebo
+      range_min="${range_min}"
+      range_max="${range_max}"
+      hfov="${hfov}"
+      vfov="${vfov}"
+      fps="${fps}"
+      gpu="${gpu}" />
 
   </xacro:macro>
 
-  <xacro:macro name="sensor_benewake_ce30d_gazebo" params="range_min range_max hfov vfov fps gpu">
+  <xacro:macro
+    name="sensor_benewake_ce30d_gazebo"
+    params="range_min range_max hfov vfov fps gpu">
     <gazebo reference="${prefix}_link">
       <xacro:if value="${gpu}">
         <!-- Using GPU needs: https://github.com/RobotnikAutomation/velodyne_simulator -->
-        <xacro:property name="ray_type" value="gpu_ray" />
-        <xacro:property name="plugin_lib" value="libgazebo_ros_velodyne_gpu_laser.so" />
+        <xacro:property
+          name="ray_type"
+          value="gpu_ray" />
+        <xacro:property
+          name="plugin_lib"
+          value="libgazebo_ros_velodyne_gpu_laser.so" />
 
       </xacro:if>
       <xacro:unless value="${gpu}">
-        <xacro:property name="ray_type" value="ray" />
-        <xacro:property name="plugin_lib" value="libgazebo_ros_block_laser.so" />
+        <xacro:property
+          name="ray_type"
+          value="ray" />
+        <xacro:property
+          name="plugin_lib"
+          value="libgazebo_ros_block_laser.so" />
       </xacro:unless>
-        <sensor type="${ray_type}" name="${prefix}_sensor">
+        <sensor
+        type="${ray_type}"
+        name="${prefix}_sensor">
           <pose>0 0 0 0 0 0.0</pose>
           <visualize>false</visualize>
           <update_rate>${fps}</update_rate>
@@ -70,13 +106,13 @@
               <horizontal>
 				<!-- for a high quality simulation -->
                 <samples>320</samples>
-                <min_angle>-${hfov/2.0*M_PI/180.0}</min_angle>
-                <max_angle>${hfov/2.0*M_PI/180.0}</max_angle>
+                <min_angle>-${radians(hfov)}</min_angle>
+                <max_angle>${radians(hfov)}</max_angle>
               </horizontal>
               <vertical>
                 <samples>20</samples>
-                <min_angle>-${vfov/2.0*M_PI/180.0}</min_angle>
-                <max_angle>${vfov/2.0*M_PI/180.0}</max_angle>
+                <min_angle>-${radians(vfov)}</min_angle>
+                <max_angle>${radians(vfov)}</max_angle>
               </vertical>
             </scan>
             <range>
@@ -88,7 +124,9 @@
               <type>none</type>
             </noise>
           </ray>
-          <plugin name="${prefix}_controller" filename="${plugin_lib}">
+          <plugin
+          name="${prefix}_controller"
+          filename="${plugin_lib}">
             <topicName>${prefix_topic}/points</topicName>
             <frameName>/${prefix}_link</frameName>
             <gaussianNoise>0.008</gaussianNoise>

--- a/robotnik_sensors/urdf/deprecated/embedded_s.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/embedded_s.urdf.xacro
@@ -1,49 +1,71 @@
-<?xml version="1.0"?>
-<robot name="sensor_orbbec_astra_embedded_s" xmlns:xacro="http://wiki.ros.org/Sensors/OrbbecAstra">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_orbbec_astra_embedded_s"
+  xmlns:xacro="http://wiki.ros.org/Sensors/OrbbecAstra">
 
-  <xacro:macro name="sensor_orbbec_astra_embedded_s" params="prefix parent prefix_topic:='front_rgbd_camera' *origin">
+  <xacro:macro
+    name="sensor_orbbec_astra_embedded_s"
+    params="prefix parent prefix_topic:='front_rgbd_camera' *origin">
 
-    <joint name="${prefix}_joint" type="fixed">
+    <joint
+      name="${prefix}_joint"
+      type="fixed">
 	  <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${prefix}_link" />
     </joint>
 
     <link name="${prefix}_link">
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/orbbec_astra_embedded_s.stl"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/orbbec_astra_embedded_s.stl" />
           <!--box size="0.0148 0.0686 0.02235"/-->
         </geometry>
         <material name="dark_grey">
-          <color rgba="0.4 0.4 0.4 1.0"/>
+          <color rgba="0.4 0.4 0.4 1.0" />
         </material>
       </visual>
       <collision>
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/orbbec_astra_embedded_s.stl"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/orbbec_astra_embedded_s.stl" />
           <!--box size="0.0148 0.0686 0.02235"/-->
         </geometry>
       </collision>
       <inertial>
         <mass value="0.001" />
         <origin xyz="0.0 0.0 0.0" />
-        <xacro:solid_cuboid_inertia m="0.001" w="0.04" h="0.165" d="0.03" />
+        <xacro:solid_cuboid_inertia
+          m="0.001"
+          w="0.04"
+          h="0.165"
+          d="0.03" />
       </inertial>
     </link>
 
-    <joint name="${prefix}_rgb_joint" type="fixed">
-      <origin xyz="0 0.0058 0" rpy="0.0 0 0"/>
-      <parent link="${prefix}_link"/>
-      <child link="${prefix}_rgb_frame"/>
+    <joint
+      name="${prefix}_rgb_joint"
+      type="fixed">
+      <origin
+        xyz="0 0.0058 0"
+        rpy="0.0 0 0" />
+      <parent link="${prefix}_link" />
+      <child link="${prefix}_rgb_frame" />
     </joint>
 
     <link name="${prefix}_rgb_frame">
     </link>
 
-    <joint name="${prefix}_rgb_optical_joint" type="fixed">
-      <origin xyz="0.0 0.0 0.0" rpy="${-M_PI/2} 0 ${-M_PI/2}"/>
+    <joint
+      name="${prefix}_rgb_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0.0 0.0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
       <parent link="${prefix}_rgb_frame" />
       <child link="${prefix}_rgb_optical_frame" />
     </joint>
@@ -51,8 +73,12 @@
     <link name="${prefix}_rgb_optical_frame">
     </link>
 
-    <joint name="${prefix}_depth_joint" type="fixed">
-      <origin xyz="0 0.02 0" rpy="0 0 0" />
+    <joint
+      name="${prefix}_depth_joint"
+      type="fixed">
+      <origin
+        xyz="0 0.02 0"
+        rpy="0 0 0" />
       <parent link="${prefix}_link" />
       <child link="${prefix}_depth_frame" />
     </joint>
@@ -60,8 +86,12 @@
     <link name="${prefix}_depth_frame">
     </link>
 
-    <joint name="${prefix}_depth_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+    <joint
+      name="${prefix}_depth_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
       <parent link="${prefix}_depth_frame" />
       <child link="${prefix}_depth_optical_frame" />
     </joint>
@@ -70,18 +100,20 @@
     </link>
 
   <!-- RGBD sensor for simulation, same as Kinect -->
-  <xacro:sensor_astra_embedded_s_gazebo/>
+  <xacro:sensor_astra_embedded_s_gazebo />
 
   </xacro:macro>
 
    <xacro:macro name="sensor_astra_embedded_s_gazebo">
 
     <gazebo reference="${prefix}_link">
-      <sensor type="depth" name="${prefix}_depth_sensor">
+      <sensor
+        type="depth"
+        name="${prefix}_depth_sensor">
         <always_on>true</always_on>
         <update_rate>20.0</update_rate>
         <camera>
-          <horizontal_fov>${67.9*M_PI/180.0}</horizontal_fov>
+          <horizontal_fov>${radians(67.9)}</horizontal_fov>
           <image>
             <format>R8G8B8</format>
             <width>640</width>
@@ -92,7 +124,9 @@
             <far>3.5</far>
           </clip>
         </camera>
-        <plugin name="${prefix}_controller" filename="libgazebo_ros_openni_kinect.so">
+        <plugin
+          name="${prefix}_controller"
+          filename="libgazebo_ros_openni_kinect.so">
 	        <cameraName>${prefix_topic}</cameraName>
           <alwaysOn>true</alwaysOn>
           <updateRate>10</updateRate>

--- a/robotnik_sensors/urdf/deprecated/embedded_s.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/embedded_s.urdf.xacro
@@ -2,15 +2,13 @@
 <robot
   name="sensor_orbbec_astra_embedded_s"
   xmlns:xacro="http://wiki.ros.org/Sensors/OrbbecAstra">
-
   <xacro:macro
     name="sensor_orbbec_astra_embedded_s"
     params="prefix parent prefix_topic:='front_rgbd_camera' *origin">
-
     <joint
       name="${prefix}_joint"
       type="fixed">
-	  <xacro:insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}" />
       <child link="${prefix}_link" />
     </joint>
@@ -57,8 +55,7 @@
       <child link="${prefix}_rgb_frame" />
     </joint>
 
-    <link name="${prefix}_rgb_frame">
-    </link>
+    <link name="${prefix}_rgb_frame" />
 
     <joint
       name="${prefix}_rgb_optical_joint"
@@ -70,8 +67,7 @@
       <child link="${prefix}_rgb_optical_frame" />
     </joint>
 
-    <link name="${prefix}_rgb_optical_frame">
-    </link>
+    <link name="${prefix}_rgb_optical_frame" />
 
     <joint
       name="${prefix}_depth_joint"
@@ -83,8 +79,7 @@
       <child link="${prefix}_depth_frame" />
     </joint>
 
-    <link name="${prefix}_depth_frame">
-    </link>
+    <link name="${prefix}_depth_frame" />
 
     <joint
       name="${prefix}_depth_optical_joint"
@@ -96,16 +91,13 @@
       <child link="${prefix}_depth_optical_frame" />
     </joint>
 
-    <link name="${prefix}_depth_optical_frame">
-    </link>
+    <link name="${prefix}_depth_optical_frame" />
 
-  <!-- RGBD sensor for simulation, same as Kinect -->
-  <xacro:sensor_astra_embedded_s_gazebo />
-
+    <!-- RGBD sensor for simulation, same as Kinect -->
+    <xacro:sensor_astra_embedded_s_gazebo />
   </xacro:macro>
 
-   <xacro:macro name="sensor_astra_embedded_s_gazebo">
-
+  <xacro:macro name="sensor_astra_embedded_s_gazebo">
     <gazebo reference="${prefix}_link">
       <sensor
         type="depth"
@@ -127,15 +119,25 @@
         <plugin
           name="${prefix}_controller"
           filename="libgazebo_ros_openni_kinect.so">
-	        <cameraName>${prefix_topic}</cameraName>
+          <cameraName>${prefix_topic}</cameraName>
           <alwaysOn>true</alwaysOn>
           <updateRate>10</updateRate>
           <imageTopicName>rgb/image_raw</imageTopicName>
-          <depthImageTopicName>depth/image_raw</depthImageTopicName>
-          <pointCloudTopicName>depth/points</pointCloudTopicName>
-          <cameraInfoTopicName>rgb/camera_info</cameraInfoTopicName>
-          <depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
-          <frameName>/${prefix}_depth_optical_frame</frameName>
+          <depthImageTopicName>
+            depth/image_raw
+          </depthImageTopicName>
+          <pointCloudTopicName>
+            depth/points
+          </pointCloudTopicName>
+          <cameraInfoTopicName>
+            rgb/camera_info
+          </cameraInfoTopicName>
+          <depthImageCameraInfoTopicName>
+            depth/camera_info
+          </depthImageCameraInfoTopicName>
+          <frameName>
+            /${prefix}_depth_optical_frame
+          </frameName>
           <baseline>0.1</baseline>
           <distortion_k1>0.0</distortion_k1>
           <distortion_k2>0.0</distortion_k2>

--- a/robotnik_sensors/urdf/deprecated/flir_ax8.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/flir_ax8.urdf.xacro
@@ -1,52 +1,76 @@
-<?xml version="1.0"?>
-<robot name="sensor_flir_ax8" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_flir_ax8"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="sensor_flir_ax8" params="prefix parent *origin">
+  <xacro:macro
+    name="sensor_flir_ax8"
+    params="prefix parent *origin">
 
-    <joint name="${prefix}_joint" type="fixed">
-      <xacro:insert_block name="origin"/>
-      <parent link="${parent}"/>
-      <child link="${prefix}_link"/>
+    <joint
+      name="${prefix}_joint"
+      type="fixed">
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${prefix}_link" />
     </joint>
 
     <link name="${prefix}_link">
       <inertial>
-        <origin xyz="0.0 0 0.0" rpy="0 0 0" />
+        <origin
+          xyz="0.0 0 0.0"
+          rpy="0 0 0" />
         <mass value="0.79" />
-        <xacro:solid_cuboid_inertia m="0.125" w="0.025" h="0.054" d="0.079" />
+        <xacro:solid_cuboid_inertia
+          m="0.125"
+          w="0.025"
+          h="0.054"
+          d="0.079" />
       </inertial>
       <visual>
-        <origin xyz="0.0125 0 0" rpy="0 0 0" /> <!-- to center the .dae model -->
+        <origin
+          xyz="0.0125 0 0"
+          rpy="0 0 0" /> <!-- to center the .dae model -->
         <material name="fotonic_color">
-          <color rgba="0.5 0.5 0.5 1"/>
+          <color rgba="0.5 0.5 0.5 1" />
         </material>
         <geometry>
-          <box size="0.025 0.054 0.079"/>
+          <box size="0.025 0.054 0.079" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0.0125 0 0" rpy="0 0 0" />
+        <origin
+          xyz="0.0125 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <box size="0.025 0.054 0.079"/>
+          <box size="0.025 0.054 0.079" />
         </geometry>
       </collision>
     </link>
 
-    <joint name="${prefix}_optical_joint" type="fixed">
-      <origin xyz="0.025 0 0.0115" rpy="0 0 0" />
-      <parent link="${prefix}_link"/>
-      <child link="${prefix}_optical_link"/>
+    <joint
+      name="${prefix}_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0.025 0 0.0115"
+        rpy="0 0 0" />
+      <parent link="${prefix}_link" />
+      <child link="${prefix}_optical_link" />
     </joint>
 
-    <link name="${prefix}_optical_link"/>
+    <link name="${prefix}_optical_link" />
 
-    <joint name="${prefix}_thermal_joint" type="fixed">
-      <origin xyz="0.025 0 0.0235" rpy="0 0 0" />
-      <parent link="${prefix}_link"/>
-      <child link="${prefix}_thermal_link"/>
+    <joint
+      name="${prefix}_thermal_joint"
+      type="fixed">
+      <origin
+        xyz="0.025 0 0.0235"
+        rpy="0 0 0" />
+      <parent link="${prefix}_link" />
+      <child link="${prefix}_thermal_link" />
     </joint>
 
-    <link name="${prefix}_thermal_link"/>
+    <link name="${prefix}_thermal_link" />
 
   </xacro:macro>
 

--- a/robotnik_sensors/urdf/deprecated/flir_ax8.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/flir_ax8.urdf.xacro
@@ -2,11 +2,9 @@
 <robot
   name="sensor_flir_ax8"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="sensor_flir_ax8"
     params="prefix parent *origin">
-
     <joint
       name="${prefix}_joint"
       type="fixed">
@@ -30,7 +28,8 @@
       <visual>
         <origin
           xyz="0.0125 0 0"
-          rpy="0 0 0" /> <!-- to center the .dae model -->
+          rpy="0 0 0" />
+        <!-- to center the .dae model -->
         <material name="fotonic_color">
           <color rgba="0.5 0.5 0.5 1" />
         </material>
@@ -71,7 +70,5 @@
     </joint>
 
     <link name="${prefix}_thermal_link" />
-
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/fotonic_e.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/fotonic_e.urdf.xacro
@@ -2,11 +2,9 @@
 <robot
   name="sensor_fotonic"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="sensor_fotonic"
     params="prefix parent *origin">
-
     <joint
       name="${prefix}_joint"
       type="fixed">
@@ -30,7 +28,8 @@
       <visual>
         <origin
           xyz="0.0 0.0 -0.04"
-          rpy="0 0 0" /> <!-- to center the .dae model -->
+          rpy="0 0 0" />
+        <!-- to center the .dae model -->
         <material name="fotonic_color">
           <color rgba="0.5 0.5 0.5 1" />
         </material>
@@ -94,17 +93,11 @@
       </inertial-->
     </link>
 
-
     <!-- Fotonic sensor for simulation -->
     <xacro:sensor_fotonic_gazebo />
-
   </xacro:macro>
 
-
-
-
   <xacro:macro name="sensor_fotonic_gazebo">
-
     <gazebo reference="${prefix}_base_link">
       <material>Gazebo/Grey</material>
     </gazebo>
@@ -115,15 +108,20 @@
         name="${prefix}_sensor">
         <update_rate>30.0</update_rate>
         <camera name="fotonic">
-          <horizontal_fov>1.221730476</horizontal_fov>  <!-- 70 deg -->
+          <horizontal_fov>1.221730476</horizontal_fov>
+          <!-- 70 deg -->
           <image>
-            <width>160</width>  <!-- 160 -->
-            <height>120</height> <!-- 120 -->
-            <format>L8</format> <!-- gray -->
+            <width>160</width>
+            <!-- 160 -->
+            <height>120</height>
+            <!-- 120 -->
+            <format>L8</format>
+            <!-- gray -->
           </image>
           <clip>
             <near>0.05</near>
-            <far>7.0</far>         <!-- outdoor down to 3m depending on luminosity -->
+            <far>7.0</far>
+            <!-- outdoor down to 3m depending on luminosity -->
           </clip>
           <noise>
             <type>gaussian</type>
@@ -139,11 +137,19 @@
           <updateRate>10.0</updateRate>
           <cameraName>${prefix}</cameraName>
           <imageTopicName>ir/image_raw</imageTopicName>
-          <cameraInfoTopicName>ir/camera_info</cameraInfoTopicName>
-          <depthImageTopicName>depth/image_raw</depthImageTopicName>
-          <depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
+          <cameraInfoTopicName>
+            ir/camera_info
+          </cameraInfoTopicName>
+          <depthImageTopicName>
+            depth/image_raw
+          </depthImageTopicName>
+          <depthImageCameraInfoTopicName>
+            depth/camera_info
+          </depthImageCameraInfoTopicName>
           <pointCloudTopicName>points</pointCloudTopicName>
-          <frameName>${prefix}_depth_optical_frame_link</frameName>
+          <frameName>
+            ${prefix}_depth_optical_frame_link
+          </frameName>
           <pointCloudCutoff>0.5</pointCloudCutoff>
           <distortionK1>0</distortionK1>
           <distortionK2>0</distortionK2>
@@ -159,7 +165,5 @@
         </plugin>
       </sensor>
     </gazebo>
-
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/fotonic_e.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/fotonic_e.urdf.xacro
@@ -1,53 +1,87 @@
-<?xml version="1.0"?>
-<robot name="sensor_fotonic" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_fotonic"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="sensor_fotonic" params="prefix parent *origin">
+  <xacro:macro
+    name="sensor_fotonic"
+    params="prefix parent *origin">
 
-    <joint name="${prefix}_joint" type="fixed">
-      <xacro:insert_block name="origin"/>
-      <parent link="${parent}"/>
-      <child link="${prefix}_base_link"/>
+    <joint
+      name="${prefix}_joint"
+      type="fixed">
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${prefix}_base_link" />
     </joint>
 
     <link name="${prefix}_base_link">
       <inertial>
-        <origin xyz="0.0 0 0.0" rpy="0 0 0" />
+        <origin
+          xyz="0.0 0 0.0"
+          rpy="0 0 0" />
         <mass value="0.79" />
-        <xacro:solid_cuboid_inertia m="0.79" w="0.08" h="0.0863" d="0.08" />
+        <xacro:solid_cuboid_inertia
+          m="0.79"
+          w="0.08"
+          h="0.0863"
+          d="0.08" />
       </inertial>
       <visual>
-        <origin xyz="0.0 0.0 -0.04" rpy="0 0 0" /> <!-- to center the .dae model -->
+        <origin
+          xyz="0.0 0.0 -0.04"
+          rpy="0 0 0" /> <!-- to center the .dae model -->
         <material name="fotonic_color">
-          <color rgba="0.5 0.5 0.5 1"/>
+          <color rgba="0.5 0.5 0.5 1" />
         </material>
         <geometry>
-          <mesh filename= "package://robotnik_sensors/meshes/fotonic_e.stl" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/fotonic_e.stl"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0.0 0 -0.04" rpy="0 0 0" />
+        <origin
+          xyz="0.0 0 -0.04"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename= "package://robotnik_sensors/meshes/fotonic_e.stl" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/fotonic_e.stl"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </collision>
     </link>
 
-    <joint name="${prefix}_depth_joint" type="fixed">
-      <origin xyz="0.0375 0 0" rpy="0 0 0" />
+    <joint
+      name="${prefix}_depth_joint"
+      type="fixed">
+      <origin
+        xyz="0.0375 0 0"
+        rpy="0 0 0" />
       <parent link="${prefix}_base_link" />
       <child link="${prefix}_depth_frame_link" />
     </joint>
 
     <link name="${prefix}_depth_frame_link">
       <inertial>
-        <origin xyz="-0.0375 0 0.0" rpy="0 0 0" />
+        <origin
+          xyz="-0.0375 0 0.0"
+          rpy="0 0 0" />
         <mass value="0.01" />
-        <xacro:solid_cuboid_inertia m="0.01" w="0.08" h="0.0863" d="0.08" />
+        <xacro:solid_cuboid_inertia
+          m="0.01"
+          w="0.08"
+          h="0.0863"
+          d="0.08" />
       </inertial>
     </link>
 
-    <joint name="${prefix}_depth_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="-1.5708 0 -1.5708" />
+    <joint
+      name="${prefix}_depth_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="-1.5708 0 -1.5708" />
       <parent link="${prefix}_depth_frame_link" />
       <child link="${prefix}_depth_optical_frame_link" />
     </joint>
@@ -62,7 +96,7 @@
 
 
     <!-- Fotonic sensor for simulation -->
-    <xacro:sensor_fotonic_gazebo/>
+    <xacro:sensor_fotonic_gazebo />
 
   </xacro:macro>
 
@@ -76,7 +110,9 @@
     </gazebo>
 
     <gazebo reference="${prefix}_depth_frame_link">
-      <sensor type="depth" name="${prefix}_sensor">
+      <sensor
+        type="depth"
+        name="${prefix}_sensor">
         <update_rate>30.0</update_rate>
         <camera name="fotonic">
           <horizontal_fov>1.221730476</horizontal_fov>  <!-- 70 deg -->
@@ -96,7 +132,9 @@
           </noise>
         </camera>
 
-        <plugin name="${prefix}_controller" filename="libgazebo_ros_openni_kinect.so">
+        <plugin
+          name="${prefix}_controller"
+          filename="libgazebo_ros_openni_kinect.so">
           <alwaysOn>true</alwaysOn>
           <updateRate>10.0</updateRate>
           <cameraName>${prefix}</cameraName>

--- a/robotnik_sensors/urdf/deprecated/hokuyo3d.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/hokuyo3d.urdf.xacro
@@ -2,11 +2,9 @@
 <robot
   name="sensor_hokuyo3d"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="sensor_hokuyo3d"
     params="prefix parent *origin gpu:=^|true">
-
     <joint
       name="${prefix}_fix_joint"
       type="fixed">
@@ -16,41 +14,39 @@
     </joint>
 
     <link name="${prefix}_base_link">
-        <collision>
-            <origin
+      <collision>
+        <origin
           xyz="0 0 0"
           rpy="0 0 0" />
-            <geometry>
-                <box size="0.05 0.05 0.08" />
-            </geometry>
-        </collision>
+        <geometry>
+          <box size="0.05 0.05 0.08" />
+        </geometry>
+      </collision>
 
-        <visual>
-            <origin
+      <visual>
+        <origin
           xyz="0 0 0"
           rpy="0 0 0" />
-            <geometry>
-                <mesh
+        <geometry>
+          <mesh
             filename="package://robotnik_sensors/meshes/hokuyo3d.stl" />
-            </geometry>
-        </visual>
+        </geometry>
+      </visual>
 
-        <inertial>
-            <mass value="0.65" />
-            <origin
+      <inertial>
+        <mass value="0.65" />
+        <origin
           xyz="0.0475 0.0 0.053"
           rpy="0 0 0" />
-            <xacro:solid_cuboid_inertia
+        <xacro:solid_cuboid_inertia
           m="0.65"
           w="0.095"
           h="0.07"
           d="0.106" />
-
-        </inertial>
+      </inertial>
     </link>
 
-    <link name="${prefix}_link">
-    </link>
+    <link name="${prefix}_link" />
     <joint
       name="${prefix}_joint"
       type="fixed">
@@ -61,12 +57,9 @@
         rpy="0 0 0" />
     </joint>
 
-
     <!-- Hokuyo sensor for simulation -->
     <xacro:sensor_hokuyo3d_gazebo gpu="${gpu}" />
-
   </xacro:macro>
-
 
   <xacro:macro
     name="sensor_hokuyo3d_gazebo"
@@ -93,44 +86,43 @@
       <sensor
         type="${ray_type}"
         name="${prefix}_sensor">
-          <pose>0 0 0 0 0 0</pose>
-          <visualize>false</visualize>
-          <update_rate>5</update_rate>
-          <ray>
-              <scan>
-                  <horizontal>
-                      <samples>144</samples>
-                      <resolution>1.0</resolution>
-                      <min_angle>-1.83591184</min_angle>
-                      <max_angle>1.83591184</max_angle>
-                  </horizontal>
-                  <vertical>
-                      <samples>74</samples>
-                      <resolution>1.0</resolution>
-                      <min_angle>-0.610865238</min_angle>
-                      <max_angle>0.0872664626</max_angle>
-                  </vertical>
-              </scan>
-              <range>
-                  <min>0.10</min>
-                  <max>20.0</max>
-                  <resolution>0.01</resolution>
-              </range>
-              <noise>
-                  <type>gaussian</type>
-                  <mean>0.0</mean>
-                  <stddev>0.01</stddev>
-              </noise>
-          </ray>
-          <plugin
+        <pose>0 0 0 0 0 0</pose>
+        <visualize>false</visualize>
+        <update_rate>5</update_rate>
+        <ray>
+          <scan>
+            <horizontal>
+              <samples>144</samples>
+              <resolution>1.0</resolution>
+              <min_angle>-1.83591184</min_angle>
+              <max_angle>1.83591184</max_angle>
+            </horizontal>
+            <vertical>
+              <samples>74</samples>
+              <resolution>1.0</resolution>
+              <min_angle>-0.610865238</min_angle>
+              <max_angle>0.0872664626</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>0.10</min>
+            <max>20.0</max>
+            <resolution>0.01</resolution>
+          </range>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </ray>
+        <plugin
           name="${prefix}_controller"
           filename="${plugin_lib}">
-                    <topicName>points</topicName>
-                    <frameName>${prefix}_link</frameName>
-                            <ignoreTfPrefix>1</ignoreTfPrefix>
-                </plugin>
-            </sensor>
-        </gazebo>
+          <topicName>points</topicName>
+          <frameName>${prefix}_link</frameName>
+          <ignoreTfPrefix>1</ignoreTfPrefix>
+        </plugin>
+      </sensor>
+    </gazebo>
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/hokuyo3d.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/hokuyo3d.urdf.xacro
@@ -1,65 +1,98 @@
-<?xml version="1.0"?>
-<robot name="sensor_hokuyo3d" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_hokuyo3d"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="sensor_hokuyo3d" params="prefix parent *origin gpu:=^|true">
+  <xacro:macro
+    name="sensor_hokuyo3d"
+    params="prefix parent *origin gpu:=^|true">
 
-    <joint name="${prefix}_fix_joint" type="fixed">
+    <joint
+      name="${prefix}_fix_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${prefix}_base_link"/>
+      <parent link="${parent}" />
+      <child link="${prefix}_base_link" />
     </joint>
 
     <link name="${prefix}_base_link">
         <collision>
-            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
             <geometry>
-                <box size="0.05 0.05 0.08"/>
+                <box size="0.05 0.05 0.08" />
             </geometry>
         </collision>
 
         <visual>
-            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
             <geometry>
-                <mesh filename="package://robotnik_sensors/meshes/hokuyo3d.stl"/>
+                <mesh
+            filename="package://robotnik_sensors/meshes/hokuyo3d.stl" />
             </geometry>
         </visual>
 
         <inertial>
             <mass value="0.65" />
-            <origin xyz="0.0475 0.0 0.053" rpy="0 0 0"/>
-            <xacro:solid_cuboid_inertia m="0.65" w="0.095" h="0.07" d="0.106" />
+            <origin
+          xyz="0.0475 0.0 0.053"
+          rpy="0 0 0" />
+            <xacro:solid_cuboid_inertia
+          m="0.65"
+          w="0.095"
+          h="0.07"
+          d="0.106" />
 
         </inertial>
     </link>
 
     <link name="${prefix}_link">
     </link>
-    <joint name="${prefix}_joint" type="fixed">
-      <parent link="${prefix}_base_link"/>
-      <child link="${prefix}_link"/>
-      <origin xyz="0.08 0 0.08" rpy="0 0 0"/>
+    <joint
+      name="${prefix}_joint"
+      type="fixed">
+      <parent link="${prefix}_base_link" />
+      <child link="${prefix}_link" />
+      <origin
+        xyz="0.08 0 0.08"
+        rpy="0 0 0" />
     </joint>
 
 
     <!-- Hokuyo sensor for simulation -->
-    <xacro:sensor_hokuyo3d_gazebo gpu="${gpu}"/>
+    <xacro:sensor_hokuyo3d_gazebo gpu="${gpu}" />
 
   </xacro:macro>
 
 
-  <xacro:macro name="sensor_hokuyo3d_gazebo" params="gpu">
+  <xacro:macro
+    name="sensor_hokuyo3d_gazebo"
+    params="gpu">
     <gazebo reference="${prefix}_link">
       <xacro:if value="${gpu}">
         <!-- Using GPU needs: https://github.com/RobotnikAutomation/velodyne_simulator -->
-        <xacro:property name="ray_type" value="gpu_ray" />
-        <xacro:property name="plugin_lib" value="libgazebo_ros_velodyne_gpu_laser.so" />
+        <xacro:property
+          name="ray_type"
+          value="gpu_ray" />
+        <xacro:property
+          name="plugin_lib"
+          value="libgazebo_ros_velodyne_gpu_laser.so" />
       </xacro:if>
       <xacro:unless value="${gpu}">
-        <xacro:property name="ray_type" value="ray" />
-        <xacro:property name="plugin_lib" value="libgazebo_ros_velodyne_laser.so" />
+        <xacro:property
+          name="ray_type"
+          value="ray" />
+        <xacro:property
+          name="plugin_lib"
+          value="libgazebo_ros_velodyne_laser.so" />
       </xacro:unless>
 
-      <sensor type="${ray_type}" name="${prefix}_sensor">
+      <sensor
+        type="${ray_type}"
+        name="${prefix}_sensor">
           <pose>0 0 0 0 0 0</pose>
           <visualize>false</visualize>
           <update_rate>5</update_rate>
@@ -89,7 +122,9 @@
                   <stddev>0.01</stddev>
               </noise>
           </ray>
-          <plugin name="${prefix}_controller" filename="${plugin_lib}">
+          <plugin
+          name="${prefix}_controller"
+          filename="${plugin_lib}">
                     <topicName>points</topicName>
                     <frameName>${prefix}_link</frameName>
                             <ignoreTfPrefix>1</ignoreTfPrefix>

--- a/robotnik_sensors/urdf/deprecated/imu.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/imu.urdf.xacro
@@ -2,83 +2,79 @@
 <robot
   name="sensor_imu"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="sensor_imu"
     params="prefix ns:='' topic:='imu/data' parent *origin">
-
-	  <joint
+    <joint
       name="${prefix}_joint"
       type="fixed">
-	      <axis xyz="1 0 0" />
-	      <!--origin xyz="0 0 0.2825"/-->
-	      <xacro:insert_block name="origin" />
-	      <parent link="${parent}" />
-	      <child link="${prefix}_link" />
-	  </joint>
+      <axis xyz="1 0 0" />
+      <!--origin xyz="0 0 0.2825"/-->
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${prefix}_link" />
+    </joint>
 
-	  <link name="${prefix}_link">
-	      <inertial>
-			<origin
+    <link name="${prefix}_link">
+      <inertial>
+        <origin
           xyz="0.0 0 0.01"
           rpy="0 0 0" />
-			<mass value="0.005" />
-			<xacro:solid_cuboid_inertia
+        <mass value="0.005" />
+        <xacro:solid_cuboid_inertia
           m="0.005"
           w="0.001"
           h="0.001"
           d="0.001" />
-		  </inertial>
-	      <visual>
-	        <origin
+      </inertial>
+      <visual>
+        <origin
           rpy="0 0 0"
           xyz="0 0 0" />
-	        <geometry>
-	          <box size="0.001 0.001 0.001" />
-	        </geometry>
-	      </visual>
-	      <!--collision>
+        <geometry>
+          <box size="0.001 0.001 0.001" />
+        </geometry>
+      </visual>
+      <!--collision>
 	        <origin rpy="0 0 0" xyz="0 0 0"/>
 	        <geometry>
 	          <box size="0.001 0.001 0.001"/>
 	        </geometry>
 	      </collision-->
-	  </link>
+    </link>
 
-	  <!--<gazebo>-->
-		<!--<plugin name="${prefix}_controller" filename="libgazebo_ros_imu.so">-->
-		   <!--<topicName>${ns}imu/data</topicName>-->
-		   <!--<serviceName>imu/service</serviceName>-->
-		   <!--<bodyName>${prefix}_link</bodyName>-->
-		   <!--<updateRateHZ>50.0</updateRateHZ>-->
-		   <!--<gaussianNoise>0.0</gaussianNoise>-->
-		<!--</plugin>-->
-	  <!--</gazebo>-->
+    <!--<gazebo>-->
+    <!--<plugin name="${prefix}_controller" filename="libgazebo_ros_imu.so">-->
+    <!--<topicName>${ns}imu/data</topicName>-->
+    <!--<serviceName>imu/service</serviceName>-->
+    <!--<bodyName>${prefix}_link</bodyName>-->
+    <!--<updateRateHZ>50.0</updateRateHZ>-->
+    <!--<gaussianNoise>0.0</gaussianNoise>-->
+    <!--</plugin>-->
+    <!--</gazebo>-->
 
- <gazebo reference="${prefix}_link">
-    <gravity>true</gravity>
-    <sensor
+    <gazebo reference="${prefix}_link">
+      <gravity>true</gravity>
+      <sensor
         name="${prefix}_imu_sensor"
         type="imu">
-      <always_on>true</always_on>
-      <update_rate>100</update_rate>
-      <visualize>true</visualize>
-      <topic>__default_topic__</topic>
-      <plugin
+        <always_on>true</always_on>
+        <update_rate>100</update_rate>
+        <visualize>true</visualize>
+        <topic>__default_topic__</topic>
+        <plugin
           filename="libgazebo_ros_imu_sensor.so"
           name="${prefix}_imu_plugin">
-        <topicName>${topic}</topicName>
-		<bodyName>${prefix}_link</bodyName>
-        <updateRateHZ>100.0</updateRateHZ>
-        <gaussianNoise>0.0</gaussianNoise>
-        <xyzOffset>0 0 0</xyzOffset>
-        <rpyOffset>0 0 0</rpyOffset>
-		<frameName>${prefix}_link</frameName>
-      </plugin>
-      <pose>0 0 0 0 0 0</pose>
-    </sensor>
-  </gazebo>
-
+          <topicName>${topic}</topicName>
+          <bodyName>${prefix}_link</bodyName>
+          <updateRateHZ>100.0</updateRateHZ>
+          <gaussianNoise>0.0</gaussianNoise>
+          <xyzOffset>0 0 0</xyzOffset>
+          <rpyOffset>0 0 0</rpyOffset>
+          <frameName>${prefix}_link</frameName>
+        </plugin>
+        <pose>0 0 0 0 0 0</pose>
+      </sensor>
+    </gazebo>
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/imu.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/imu.urdf.xacro
@@ -1,26 +1,40 @@
-<?xml version="1.0"?>
-<robot name="sensor_imu" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_imu"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="sensor_imu" params="prefix ns:='' topic:='imu/data' parent *origin">
+  <xacro:macro
+    name="sensor_imu"
+    params="prefix ns:='' topic:='imu/data' parent *origin">
 
-	  <joint name="${prefix}_joint" type="fixed">
-	      <axis xyz="1 0 0"/>
+	  <joint
+      name="${prefix}_joint"
+      type="fixed">
+	      <axis xyz="1 0 0" />
 	      <!--origin xyz="0 0 0.2825"/-->
-	      <xacro:insert_block name="origin"/>
-	      <parent link="${parent}"/>
-	      <child link="${prefix}_link"/>
+	      <xacro:insert_block name="origin" />
+	      <parent link="${parent}" />
+	      <child link="${prefix}_link" />
 	  </joint>
 
 	  <link name="${prefix}_link">
 	      <inertial>
-			<origin xyz="0.0 0 0.01" rpy="0 0 0" />
+			<origin
+          xyz="0.0 0 0.01"
+          rpy="0 0 0" />
 			<mass value="0.005" />
-			<xacro:solid_cuboid_inertia m="0.005" w="0.001" h="0.001" d="0.001" />
+			<xacro:solid_cuboid_inertia
+          m="0.005"
+          w="0.001"
+          h="0.001"
+          d="0.001" />
 		  </inertial>
 	      <visual>
-	        <origin rpy="0 0 0" xyz="0 0 0"/>
+	        <origin
+          rpy="0 0 0"
+          xyz="0 0 0" />
 	        <geometry>
-	          <box size="0.001 0.001 0.001"/>
+	          <box size="0.001 0.001 0.001" />
 	        </geometry>
 	      </visual>
 	      <!--collision>
@@ -43,12 +57,16 @@
 
  <gazebo reference="${prefix}_link">
     <gravity>true</gravity>
-    <sensor name="${prefix}_imu_sensor" type="imu">
+    <sensor
+        name="${prefix}_imu_sensor"
+        type="imu">
       <always_on>true</always_on>
       <update_rate>100</update_rate>
       <visualize>true</visualize>
       <topic>__default_topic__</topic>
-      <plugin filename="libgazebo_ros_imu_sensor.so" name="${prefix}_imu_plugin">
+      <plugin
+          filename="libgazebo_ros_imu_sensor.so"
+          name="${prefix}_imu_plugin">
         <topicName>${topic}</topicName>
 		<bodyName>${prefix}_link</bodyName>
         <updateRateHZ>100.0</updateRateHZ>

--- a/robotnik_sensors/urdf/deprecated/imu_hector_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/imu_hector_plugin.urdf.xacro
@@ -58,70 +58,82 @@
           <angular_velocity>
             <x>
               <noise type="gaussian">
-	    					<type>gaussian</type>
+                <type>gaussian</type>
                 <mean>0</mean>
                 <stddev>0.2</stddev>
                 <bias_mean>0</bias_mean>
                 <bias_stddev>0</bias_stddev>
                 <dynamic_bias_stddev>0</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>0</dynamic_bias_correlation_time>
+                <dynamic_bias_correlation_time>
+                  0
+                </dynamic_bias_correlation_time>
               </noise>
             </x>
             <y>
               <noise type="gaussian">
-	    					<type>gaussian</type>
+                <type>gaussian</type>
                 <mean>0</mean>
                 <stddev>0.2</stddev>
                 <bias_mean>0</bias_mean>
                 <bias_stddev>0</bias_stddev>
                 <dynamic_bias_stddev>0</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>0</dynamic_bias_correlation_time>
+                <dynamic_bias_correlation_time>
+                  0
+                </dynamic_bias_correlation_time>
               </noise>
             </y>
             <z>
               <noise type="gaussian">
-	    					<type>gaussian</type>
+                <type>gaussian</type>
                 <mean>0</mean>
                 <stddev>0.2</stddev>
                 <bias_mean>0</bias_mean>
                 <bias_stddev>0</bias_stddev>
                 <dynamic_bias_stddev>0</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>0</dynamic_bias_correlation_time>
+                <dynamic_bias_correlation_time>
+                  0
+                </dynamic_bias_correlation_time>
               </noise>
             </z>
           </angular_velocity>
           <linear_acceleration>
             <x>
               <noise type="gaussian">
-	    					<type>gaussian</type>
+                <type>gaussian</type>
                 <mean>0</mean>
                 <stddev>0.2</stddev>
                 <bias_mean>0</bias_mean>
                 <bias_stddev>0</bias_stddev>
                 <dynamic_bias_stddev>0</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>0</dynamic_bias_correlation_time>
+                <dynamic_bias_correlation_time>
+                  0
+                </dynamic_bias_correlation_time>
               </noise>
             </x>
             <y>
               <noise type="gaussian">
-	    					<type>gaussian</type>
+                <type>gaussian</type>
                 <mean>0</mean>
                 <stddev>0.2</stddev>
                 <bias_mean>0</bias_mean>
                 <bias_stddev>0</bias_stddev>
                 <dynamic_bias_stddev>0</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>0</dynamic_bias_correlation_time>
+                <dynamic_bias_correlation_time>
+                  0
+                </dynamic_bias_correlation_time>
               </noise>
             </y>
             <z>
               <noise type="gaussian">
-	    					<type>gaussian</type>
+                <type>gaussian</type>
                 <mean>0</mean>
                 <stddev>0.2</stddev>
                 <bias_mean>0</bias_mean>
                 <bias_stddev>0</bias_stddev>
                 <dynamic_bias_stddev>0</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>0</dynamic_bias_correlation_time>
+                <dynamic_bias_correlation_time>
+                  0
+                </dynamic_bias_correlation_time>
               </noise>
             </z>
           </linear_acceleration>
@@ -133,7 +145,9 @@
             <namespace>${ns}</namespace>
             <remapping>~/out:=~/data</remapping>
           </ros>
-          <initial_orientation_as_reference>initial_orientation_as_reference</initial_orientation_as_reference>
+          <initial_orientation_as_reference>
+            initial_orientation_as_reference
+          </initial_orientation_as_reference>
         </plugin>
       </sensor>
     </gazebo>

--- a/robotnik_sensors/urdf/deprecated/imu_hector_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/imu_hector_plugin.urdf.xacro
@@ -1,37 +1,55 @@
-<?xml version="1.0"?>
-<robot name="sensor_imu" xmlns:xacro="http://wiki.ros.org/xacro">
-  <xacro:macro name="sensor_imu_hector" params="ns prefix topic:='imu/data' parent *origin">
-    <joint name="${prefix}_joint" type="fixed">
-      <axis xyz="1 0 0"/>
-      <xacro:insert_block name="origin"/>
-      <parent link="${parent}"/>
-      <child link="${prefix}_link"/>
+<?xml version="1.0" ?>
+<robot
+  name="sensor_imu"
+  xmlns:xacro="http://wiki.ros.org/xacro">
+  <xacro:macro
+    name="sensor_imu_hector"
+    params="ns prefix topic:='imu/data' parent *origin">
+    <joint
+      name="${prefix}_joint"
+      type="fixed">
+      <axis xyz="1 0 0" />
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${prefix}_link" />
     </joint>
     <link name="${prefix}_link">
       <inertial>
-        <origin xyz="0 0 0" rpy="0 0 0" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <mass value="0.05" />
-        <xacro:solid_cuboid_inertia m="0.05" w="0.021" h="0.027" d="0.003" />
+        <xacro:solid_cuboid_inertia
+          m="0.05"
+          w="0.021"
+          h="0.027"
+          d="0.003" />
       </inertial>
       <visual>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <origin
+          rpy="0 0 0"
+          xyz="0 0 0" />
         <geometry>
-          <box size="0.021 0.027 0.003"/>
+          <box size="0.021 0.027 0.003" />
         </geometry>
       </visual>
       <collision>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <origin
+          rpy="0 0 0"
+          xyz="0 0 0" />
         <geometry>
-          <box size=".001 .001 .001"/>
+          <box size=".001 .001 .001" />
         </geometry>
       </collision>
     </link>
-    <xacro:sensor_imu_hector_gazebo/>
+    <xacro:sensor_imu_hector_gazebo />
   </xacro:macro>
   <xacro:macro name="sensor_imu_hector_gazebo">
     <gazebo reference="${prefix}_link">
       <gravity>true</gravity>
-      <sensor name="imu_sensor" type="imu">
+      <sensor
+        name="imu_sensor"
+        type="imu">
         <pose>0 0 0 0 0 0</pose>
         <visualize>true</visualize>
         <update_rate>100</update_rate>
@@ -108,7 +126,9 @@
             </z>
           </linear_acceleration>
         </imu>
-        <plugin name="imu" filename="libgazebo_ros_imu_sensor.so">
+        <plugin
+          name="imu"
+          filename="libgazebo_ros_imu_sensor.so">
           <ros>
             <namespace>${ns}</namespace>
             <remapping>~/out:=~/data</remapping>

--- a/robotnik_sensors/urdf/deprecated/intel_d435.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/intel_d435.urdf.xacro
@@ -12,7 +12,6 @@ Copyright(c) 2020 Robotnik Automation. All Rights Reserved
   <xacro:macro
     name="sensor_intel_d435"
     params="prefix parent *origin prefix_topic:='front_rgbd_camera' use_nominal_extrinsics:=false">
-
     <!-- The following values are approximate, and the camera node
      publishing TF values with actual calibrated camera extrinsic values -->
     <xacro:property
@@ -75,8 +74,8 @@ Copyright(c) 2020 Robotnik Automation. All Rights Reserved
       <child link="${prefix}_link" />
     </joint>
 
-    <link
-      name="${prefix}_link"> <!-- camera link is aligned with the infrared sensor 1 that is "in the middle of the camera", not the one in the edge -->
+    <link name="${prefix}_link">
+      <!-- camera link is aligned with the infrared sensor 1 that is "in the middle of the camera", not the one in the edge -->
       <visual>
         <origin
           xyz="${d435_cam_mount_from_center_offset} ${-d435_cam_depth_py} 0"
@@ -217,147 +216,181 @@ Copyright(c) 2020 Robotnik Automation. All Rights Reserved
   <xacro:macro
     name="gazebo_d435"
     params="camera_name reference_link topics_ns depth_optical_frame color_optical_frame infrared1_optical_frame infrared2_optical_frame">
-   <!-- Load parameters to model's main link-->
-   <xacro:property
+    <!-- Load parameters to model's main link-->
+    <xacro:property
       name="deg_to_rad"
       value="0.01745329251994329577" />
-   <gazebo reference="${reference_link}">
-     <self_collide>0</self_collide>
-     <enable_wind>0</enable_wind>
-     <kinematic>0</kinematic>
-     <gravity>1</gravity>
-     <!--<mu>1</mu>-->
-     <mu2>1</mu2>
-     <fdir1>0 0 0</fdir1>
-     <!--<slip1>0</slip1>
+    <gazebo reference="${reference_link}">
+      <self_collide>0</self_collide>
+      <enable_wind>0</enable_wind>
+      <kinematic>0</kinematic>
+      <gravity>1</gravity>
+      <!--<mu>1</mu>-->
+      <mu2>1</mu2>
+      <fdir1>0 0 0</fdir1>
+      <!--<slip1>0</slip1>
      <slip2>0</slip2>-->
-     <kp>1e+13</kp>
-     <kd>1</kd>
-     <!--<max_vel>0.01</max_vel>
+      <kp>1e+13</kp>
+      <kd>1</kd>
+      <!--<max_vel>0.01</max_vel>
      <min_depth>0</min_depth>-->
-     <sensor
+      <sensor
         name="${camera_name}color"
         type="camera">
-       <camera name="${camera_name}">
-         <horizontal_fov>${69.4*deg_to_rad}</horizontal_fov>
-         <image>
-           <width>1920</width>
-           <height>1080</height>
-           <format>RGB_INT8</format>
-         </image>
-         <clip>
-           <near>0.1</near>
-           <far>100</far>
-         </clip>
-         <noise>
-           <type>gaussian</type>
-           <mean>0.0</mean>
-           <stddev>0.007</stddev>
-         </noise>
-       </camera>
-       <always_on>1</always_on>
-       <update_rate>30</update_rate>
-       <visualize>false</visualize>
-     </sensor>
-     <sensor
+        <camera name="${camera_name}">
+          <horizontal_fov>
+            ${69.4*deg_to_rad}
+          </horizontal_fov>
+          <image>
+            <width>1920</width>
+            <height>1080</height>
+            <format>RGB_INT8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.007</stddev>
+          </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <visualize>false</visualize>
+      </sensor>
+      <sensor
         name="${camera_name}ired1"
         type="camera">
-       <camera name="${camera_name}">
-         <horizontal_fov>${85.2*deg_to_rad}</horizontal_fov>
-         <image>
-           <width>1280</width>
-           <height>720</height>
-           <format>L_INT8</format>
-         </image>
-         <clip>
-           <near>0.1</near>
-           <far>100</far>
-         </clip>
-         <noise>
-           <type>gaussian</type>
-           <mean>0.0</mean>
-           <stddev>0.05</stddev>
-         </noise>
-       </camera>
-       <always_on>1</always_on>
-       <update_rate>90</update_rate>
-       <visualize>false</visualize>
-     </sensor>
-     <sensor
+        <camera name="${camera_name}">
+          <horizontal_fov>
+            ${85.2*deg_to_rad}
+          </horizontal_fov>
+          <image>
+            <width>1280</width>
+            <height>720</height>
+            <format>L_INT8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.05</stddev>
+          </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>90</update_rate>
+        <visualize>false</visualize>
+      </sensor>
+      <sensor
         name="${camera_name}ired2"
         type="camera">
-       <camera name="${camera_name}">
-         <horizontal_fov>${85.2*deg_to_rad}</horizontal_fov>
-         <image>
-           <width>1280</width>
-           <height>720</height>
-           <format>L_INT8</format>
-         </image>
-         <clip>
-           <near>0.1</near>
-           <far>100</far>
-         </clip>
-         <noise>
-           <type>gaussian</type>
-           <mean>0.0</mean>
-           <stddev>0.05</stddev>
-         </noise>
-       </camera>
-       <always_on>1</always_on>
-       <update_rate>90</update_rate>
-       <visualize>false</visualize>
-     </sensor>
-     <sensor
+        <camera name="${camera_name}">
+          <horizontal_fov>
+            ${85.2*deg_to_rad}
+          </horizontal_fov>
+          <image>
+            <width>1280</width>
+            <height>720</height>
+            <format>L_INT8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.05</stddev>
+          </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>90</update_rate>
+        <visualize>false</visualize>
+      </sensor>
+      <sensor
         name="${camera_name}depth"
         type="depth">
-       <camera name="${camera_name}">
-         <horizontal_fov>${85.2*deg_to_rad}</horizontal_fov>
-         <image>
-           <width>1280</width>
-           <height>720</height>
-         </image>
-         <clip>
-           <near>0.1</near>
-           <far>100</far>
-         </clip>
-         <noise>
-           <type>gaussian</type>
-           <mean>0.0</mean>
-           <stddev>0.100</stddev>
-         </noise>
-       </camera>
-       <always_on>1</always_on>
-       <update_rate>90</update_rate>
-       <visualize>false</visualize>
-     </sensor>
-   </gazebo>
+        <camera name="${camera_name}">
+          <horizontal_fov>
+            ${85.2*deg_to_rad}
+          </horizontal_fov>
+          <image>
+            <width>1280</width>
+            <height>720</height>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.100</stddev>
+          </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>90</update_rate>
+        <visualize>false</visualize>
+      </sensor>
+    </gazebo>
 
-   <gazebo>
-     <plugin
+    <gazebo>
+      <plugin
         name="${topics_ns}"
         filename="librealsense_gazebo_plugin.so">
-       <prefix>${camera_name}</prefix>
-       <depthUpdateRate>60.0</depthUpdateRate>
-       <colorUpdateRate>60.0</colorUpdateRate>
-       <infraredUpdateRate>60.0</infraredUpdateRate>
-       <depthTopicName>${prefix_topic}/depth/image_raw</depthTopicName>
-       <depthCameraInfoTopicName>${prefix_topic}/depth/camera_info</depthCameraInfoTopicName>
-       <colorTopicName>${prefix_topic}/color/image_raw</colorTopicName>
-       <colorCameraInfoTopicName>${prefix_topic}/color/camera_info</colorCameraInfoTopicName>
-       <infrared1TopicName>${prefix_topic}/infra1/image_rect_raw</infrared1TopicName>
-       <infrared1CameraInfoTopicName>${prefix_topic}/infra1/camera_info</infrared1CameraInfoTopicName>
-       <infrared2TopicName>${prefix_topic}/infra2/image_rect_raw</infrared2TopicName>
-       <infrared2CameraInfoTopicName>${prefix_topic}/infra2/camera_info</infrared2CameraInfoTopicName>
-       <colorOpticalframeName>${color_optical_frame}</colorOpticalframeName>
-       <depthOpticalframeName>${depth_optical_frame}</depthOpticalframeName>
-       <infrared1OpticalframeName>${infrared1_optical_frame}</infrared1OpticalframeName>
-       <infrared2OpticalframeName>${infrared2_optical_frame}</infrared2OpticalframeName>
-       <rangeMinDepth>0.2</rangeMinDepth>
-       <rangeMaxDepth>10.0</rangeMaxDepth>
-       <pointCloud>false</pointCloud>
-       <pointCloudTopicName>${prefix_topic}/depth/color/points</pointCloudTopicName>
-       <pointCloudCutoff>0.5</pointCloudCutoff>
-     </plugin>
-   </gazebo>
+        <prefix>${camera_name}</prefix>
+        <depthUpdateRate>60.0</depthUpdateRate>
+        <colorUpdateRate>60.0</colorUpdateRate>
+        <infraredUpdateRate>60.0</infraredUpdateRate>
+        <depthTopicName>
+          ${prefix_topic}/depth/image_raw
+        </depthTopicName>
+        <depthCameraInfoTopicName>
+          ${prefix_topic}/depth/camera_info
+        </depthCameraInfoTopicName>
+        <colorTopicName>
+          ${prefix_topic}/color/image_raw
+        </colorTopicName>
+        <colorCameraInfoTopicName>
+          ${prefix_topic}/color/camera_info
+        </colorCameraInfoTopicName>
+        <infrared1TopicName>
+          ${prefix_topic}/infra1/image_rect_raw
+        </infrared1TopicName>
+        <infrared1CameraInfoTopicName>
+          ${prefix_topic}/infra1/camera_info
+        </infrared1CameraInfoTopicName>
+        <infrared2TopicName>
+          ${prefix_topic}/infra2/image_rect_raw
+        </infrared2TopicName>
+        <infrared2CameraInfoTopicName>
+          ${prefix_topic}/infra2/camera_info
+        </infrared2CameraInfoTopicName>
+        <colorOpticalframeName>
+          ${color_optical_frame}
+        </colorOpticalframeName>
+        <depthOpticalframeName>
+          ${depth_optical_frame}
+        </depthOpticalframeName>
+        <infrared1OpticalframeName>
+          ${infrared1_optical_frame}
+        </infrared1OpticalframeName>
+        <infrared2OpticalframeName>
+          ${infrared2_optical_frame}
+        </infrared2OpticalframeName>
+        <rangeMinDepth>0.2</rangeMinDepth>
+        <rangeMaxDepth>10.0</rangeMaxDepth>
+        <pointCloud>false</pointCloud>
+        <pointCloudTopicName>
+          ${prefix_topic}/depth/color/points
+        </pointCloudTopicName>
+        <pointCloudCutoff>0.5</pointCloudCutoff>
+      </plugin>
+    </gazebo>
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/deprecated/intel_d435.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/intel_d435.urdf.xacro
@@ -1,150 +1,226 @@
-<?xml version="1.0"?>
-
+<?xml version="1.0" ?>
 <!--
 License: Apache 2.0. See LICENSE file in root directory.
 Copyright(c) 2017 Intel Corporation. All Rights Reserved
 Copyright(c) 2020 Robotnik Automation. All Rights Reserved
 -->
-
-<robot name="sensor_intel_d435"
+<robot
+  name="sensor_intel_d435"
   xmlns:xacro="http://wiki.ros.org/xacro">
   <!-- Includes -->
-  
-  <xacro:macro name="sensor_intel_d435" params="prefix parent *origin prefix_topic:='front_rgbd_camera' use_nominal_extrinsics:=false">
-    <xacro:property name="M_PI" value="3.1415926535897931" />
-  
+
+  <xacro:macro
+    name="sensor_intel_d435"
+    params="prefix parent *origin prefix_topic:='front_rgbd_camera' use_nominal_extrinsics:=false">
+
     <!-- The following values are approximate, and the camera node
      publishing TF values with actual calibrated camera extrinsic values -->
-    <xacro:property name="d435_cam_depth_to_infra1_offset" value="0.0"/>
-    <xacro:property name="d435_cam_depth_to_infra2_offset" value="-0.050"/>
-    <xacro:property name="d435_cam_depth_to_color_offset" value="0.015"/>
+    <xacro:property
+      name="d435_cam_depth_to_infra1_offset"
+      value="0.0" />
+    <xacro:property
+      name="d435_cam_depth_to_infra2_offset"
+      value="-0.050" />
+    <xacro:property
+      name="d435_cam_depth_to_color_offset"
+      value="0.015" />
 
     <!-- The following values model the aluminum peripherial case for the
     D435 camera, with the camera joint represented by the actual
     peripherial camera tripod mount -->
-    <xacro:property name="d435_cam_width" value="0.090"/>
-    <xacro:property name="d435_cam_height" value="0.025"/>
-    <xacro:property name="d435_cam_depth" value="0.02505"/>
-    <xacro:property name="d435_cam_mount_from_center_offset" value="0.0149"/>
+    <xacro:property
+      name="d435_cam_width"
+      value="0.090" />
+    <xacro:property
+      name="d435_cam_height"
+      value="0.025" />
+    <xacro:property
+      name="d435_cam_depth"
+      value="0.02505" />
+    <xacro:property
+      name="d435_cam_mount_from_center_offset"
+      value="0.0149" />
 
     <!-- The following offset is relative the the physical D435 camera peripherial
     camera tripod mount -->
-    <xacro:property name="d435_cam_depth_px" value="${d435_cam_mount_from_center_offset}"/>
-    <xacro:property name="d435_cam_depth_py" value="0.0175"/>
-    <xacro:property name="d435_cam_depth_pz" value="${d435_cam_height/2}"/>
+    <xacro:property
+      name="d435_cam_depth_px"
+      value="${d435_cam_mount_from_center_offset}" />
+    <xacro:property
+      name="d435_cam_depth_py"
+      value="0.0175" />
+    <xacro:property
+      name="d435_cam_depth_pz"
+      value="${d435_cam_height/2}" />
 
-    <joint name="${prefix}_base_joint" type="fixed">
+    <joint
+      name="${prefix}_base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${prefix}_base_link" />
     </joint>
 
     <link name="${prefix}_base_link" />
 
     <!-- camera body, with origin at bottom screw mount -->
-    <joint name="${prefix}_joint" type="fixed">
+    <joint
+      name="${prefix}_joint"
+      type="fixed">
       <parent link="${prefix}_base_link" />
       <child link="${prefix}_link" />
-      <origin xyz="0.01 0.02 0" rpy="0 0 0"/>
+      <origin
+        xyz="0.01 0.02 0"
+        rpy="0 0 0" />
       <child link="${prefix}_link" />
     </joint>
 
-    <link name="${prefix}_link"> <!-- camera link is aligned with the infrared sensor 1 that is "in the middle of the camera", not the one in the edge -->
+    <link
+      name="${prefix}_link"> <!-- camera link is aligned with the infrared sensor 1 that is "in the middle of the camera", not the one in the edge -->
       <visual>
-        <origin xyz="${d435_cam_mount_from_center_offset} ${-d435_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
+        <origin
+          xyz="${d435_cam_mount_from_center_offset} ${-d435_cam_depth_py} 0"
+          rpy="${radians(90)} 0 ${radians(90)}" />
         <geometry>
           <!-- <box size="${d435_cam_width} ${d435_cam_height} ${d435_cam_depth}"/> -->
-          <mesh filename="package://robotnik_sensors/meshes/intel_d435_color.dae" />
+          <mesh
+            filename="package://robotnik_sensors/meshes/intel_d435_color.dae" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0 ${-d435_cam_depth_py} 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 ${-d435_cam_depth_py} 0"
+          rpy="0 0 0" />
         <geometry>
-          <box size="${d435_cam_depth} ${d435_cam_width} ${d435_cam_height}"/>
+          <box
+            size="${d435_cam_depth} ${d435_cam_width} ${d435_cam_height}" />
         </geometry>
       </collision>
       <inertial>
-        <origin xyz="0.0025 -0.015 0.0" rpy="0 0 0" />
+        <origin
+          xyz="0.0025 -0.015 0.0"
+          rpy="0 0 0" />
         <mass value="0.1" />
-        <xacro:solid_cuboid_inertia m="0.1" w="0.025" h="0.09" d="0.025" />
+        <xacro:solid_cuboid_inertia
+          m="0.1"
+          w="0.025"
+          h="0.09"
+          d="0.025" />
       </inertial>
     </link>
 
     <!-- Use the nominal extrinsics between camera frames if the calibrated extrinsics aren't being published. e.g. running the device in simulation  -->
     <xacro:if value="${use_nominal_extrinsics}">
       <!-- camera depth joints and links -->
-      <joint name="${prefix}_depth_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <parent link="${prefix}_link"/>
+      <joint
+        name="${prefix}_depth_joint"
+        type="fixed">
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <parent link="${prefix}_link" />
         <child link="${prefix}_depth_frame" />
       </joint>
-      <link name="${prefix}_depth_frame"/>
+      <link name="${prefix}_depth_frame" />
 
-      <joint name="${prefix}_depth_optical_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+      <joint
+        name="${prefix}_depth_optical_joint"
+        type="fixed">
+        <origin
+          xyz="0 0 0"
+          rpy="${-radians(90)} 0 ${-radians(90)}" />
         <parent link="${prefix}_depth_frame" />
         <child link="${prefix}_depth_optical_frame" />
       </joint>
-      <link name="${prefix}_depth_optical_frame"/>
+      <link name="${prefix}_depth_optical_frame" />
 
       <!-- camera left IR joints and links -->
-      <joint name="${prefix}_infra1_joint" type="fixed">
-        <origin xyz="0 ${d435_cam_depth_to_infra1_offset} 0" rpy="0 0 0" />
+      <joint
+        name="${prefix}_infra1_joint"
+        type="fixed">
+        <origin
+          xyz="0 ${d435_cam_depth_to_infra1_offset} 0"
+          rpy="0 0 0" />
         <parent link="${prefix}_link" />
         <child link="${prefix}_infra1_frame" />
       </joint>
-      <link name="${prefix}_infra1_frame"/>
+      <link name="${prefix}_infra1_frame" />
 
-      <joint name="${prefix}_infra1_optical_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+      <joint
+        name="${prefix}_infra1_optical_joint"
+        type="fixed">
+        <origin
+          xyz="0 0 0"
+          rpy="${-radians(90)} 0 ${-radians(90)}" />
         <parent link="${prefix}_infra1_frame" />
         <child link="${prefix}_infra1_optical_frame" />
       </joint>
-      <link name="${prefix}_infra1_optical_frame"/>
+      <link name="${prefix}_infra1_optical_frame" />
 
       <!-- camera right IR joints and links -->
-      <joint name="${prefix}_infra2_joint" type="fixed">
-        <origin xyz="0 ${d435_cam_depth_to_infra2_offset} 0" rpy="0 0 0" />
+      <joint
+        name="${prefix}_infra2_joint"
+        type="fixed">
+        <origin
+          xyz="0 ${d435_cam_depth_to_infra2_offset} 0"
+          rpy="0 0 0" />
         <parent link="${prefix}_link" />
         <child link="${prefix}_infra2_frame" />
       </joint>
-      <link name="${prefix}_infra2_frame"/>
+      <link name="${prefix}_infra2_frame" />
 
-      <joint name="${prefix}_infra2_optical_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+      <joint
+        name="${prefix}_infra2_optical_joint"
+        type="fixed">
+        <origin
+          xyz="0 0 0"
+          rpy="${-radians(90)} 0 ${-radians(90)}" />
         <parent link="${prefix}_infra2_frame" />
         <child link="${prefix}_infra2_optical_frame" />
       </joint>
-      <link name="${prefix}_infra2_optical_frame"/>
+      <link name="${prefix}_infra2_optical_frame" />
 
       <!-- camera color joints and links -->
-      <joint name="${prefix}_color_joint" type="fixed">
-        <origin xyz="0 ${d435_cam_depth_to_color_offset} 0" rpy="0 0 0" />
+      <joint
+        name="${prefix}_color_joint"
+        type="fixed">
+        <origin
+          xyz="0 ${d435_cam_depth_to_color_offset} 0"
+          rpy="0 0 0" />
         <parent link="${prefix}_link" />
         <child link="${prefix}_color_frame" />
       </joint>
-      <link name="${prefix}_color_frame"/>
+      <link name="${prefix}_color_frame" />
 
-      <joint name="${prefix}_color_optical_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+      <joint
+        name="${prefix}_color_optical_joint"
+        type="fixed">
+        <origin
+          xyz="0 0 0"
+          rpy="${-radians(90)} 0 ${-radians(90)}" />
         <parent link="${prefix}_color_frame" />
         <child link="${prefix}_color_optical_frame" />
       </joint>
-      <link name="${prefix}_color_optical_frame"/>
+      <link name="${prefix}_color_optical_frame" />
     </xacro:if>
 
-    <xacro:gazebo_d435 camera_name="${prefix}" 
-                       reference_link="${prefix}_link" 
-                       topics_ns="${prefix_topic}" 
-                       depth_optical_frame="${prefix}_depth_optical_frame" 
-                       color_optical_frame="${prefix}_color_optical_frame" 
-                       infrared1_optical_frame="${prefix}_left_ir_optical_frame" 
-                       infrared2_optical_frame="${prefix}_right_ir_optical_frame"/>
+    <xacro:gazebo_d435
+      camera_name="${prefix}"
+      reference_link="${prefix}_link"
+      topics_ns="${prefix_topic}"
+      depth_optical_frame="${prefix}_depth_optical_frame"
+      color_optical_frame="${prefix}_color_optical_frame"
+      infrared1_optical_frame="${prefix}_left_ir_optical_frame"
+      infrared2_optical_frame="${prefix}_right_ir_optical_frame" />
   </xacro:macro>
 
-  <xacro:macro name="gazebo_d435" params="camera_name reference_link topics_ns depth_optical_frame color_optical_frame infrared1_optical_frame infrared2_optical_frame" >
+  <xacro:macro
+    name="gazebo_d435"
+    params="camera_name reference_link topics_ns depth_optical_frame color_optical_frame infrared1_optical_frame infrared2_optical_frame">
    <!-- Load parameters to model's main link-->
-   <xacro:property name="deg_to_rad" value="0.01745329251994329577" />
+   <xacro:property
+      name="deg_to_rad"
+      value="0.01745329251994329577" />
    <gazebo reference="${reference_link}">
      <self_collide>0</self_collide>
      <enable_wind>0</enable_wind>
@@ -159,7 +235,9 @@ Copyright(c) 2020 Robotnik Automation. All Rights Reserved
      <kd>1</kd>
      <!--<max_vel>0.01</max_vel>
      <min_depth>0</min_depth>-->
-     <sensor name="${camera_name}color" type="camera">
+     <sensor
+        name="${camera_name}color"
+        type="camera">
        <camera name="${camera_name}">
          <horizontal_fov>${69.4*deg_to_rad}</horizontal_fov>
          <image>
@@ -181,7 +259,9 @@ Copyright(c) 2020 Robotnik Automation. All Rights Reserved
        <update_rate>30</update_rate>
        <visualize>false</visualize>
      </sensor>
-     <sensor name="${camera_name}ired1" type="camera">
+     <sensor
+        name="${camera_name}ired1"
+        type="camera">
        <camera name="${camera_name}">
          <horizontal_fov>${85.2*deg_to_rad}</horizontal_fov>
          <image>
@@ -203,7 +283,9 @@ Copyright(c) 2020 Robotnik Automation. All Rights Reserved
        <update_rate>90</update_rate>
        <visualize>false</visualize>
      </sensor>
-     <sensor name="${camera_name}ired2" type="camera">
+     <sensor
+        name="${camera_name}ired2"
+        type="camera">
        <camera name="${camera_name}">
          <horizontal_fov>${85.2*deg_to_rad}</horizontal_fov>
          <image>
@@ -225,7 +307,9 @@ Copyright(c) 2020 Robotnik Automation. All Rights Reserved
        <update_rate>90</update_rate>
        <visualize>false</visualize>
      </sensor>
-     <sensor name="${camera_name}depth" type="depth">
+     <sensor
+        name="${camera_name}depth"
+        type="depth">
        <camera name="${camera_name}">
          <horizontal_fov>${85.2*deg_to_rad}</horizontal_fov>
          <image>
@@ -249,7 +333,9 @@ Copyright(c) 2020 Robotnik Automation. All Rights Reserved
    </gazebo>
 
    <gazebo>
-     <plugin name="${topics_ns}" filename="librealsense_gazebo_plugin.so">
+     <plugin
+        name="${topics_ns}"
+        filename="librealsense_gazebo_plugin.so">
        <prefix>${camera_name}</prefix>
        <depthUpdateRate>60.0</depthUpdateRate>
        <colorUpdateRate>60.0</colorUpdateRate>

--- a/robotnik_sensors/urdf/deprecated/intel_r430.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/intel_r430.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_r430"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <!-- The following values are approximate, and the camera node
    publishing TF values with actual calibrated camera extrinsic values -->
   <xacro:property
@@ -46,7 +45,6 @@
   <xacro:macro
     name="sensor_r430"
     params="prefix parent prefix_topic:='front_rgbd_camera' *origin">
-
     <!-- camera body, with origin at bottom screw mount -->
     <joint
       name="${prefix}_camera_joint"
@@ -58,8 +56,8 @@
 
     <link name="${prefix}_camera_link">
       <visual>
-      <!-- origin xyz="0 ${-r430_cam_mount_from_center_offset} ${r430_cam_height/2}" rpy="${radians(90)} 0 ${radians(90)}"/ -->
-      <origin
+        <!-- origin xyz="0 ${-r430_cam_mount_from_center_offset} ${r430_cam_height/2}" rpy="${radians(90)} 0 ${radians(90)}"/ -->
+        <origin
           xyz="0 ${-r430_cam_mount_from_center_offset} 0"
           rpy="0 0 0" />
         <geometry>
@@ -76,7 +74,7 @@
           xyz="${-r430_cam_depth/2} 0.0 0.0"
           rpy="0 0 0" />
         <geometry>
-        <box
+          <box
             size="${r430_cam_depth} ${r430_cam_width} ${r430_cam_height}" />
         </geometry>
       </collision>
@@ -188,14 +186,11 @@
     </joint>
     <link name="${prefix}_camera_fisheye_optical_frame" />
 
-
-  <!-- RGBD sensor for simulation, same as Kinect -->
-  <xacro:sensor_r430_gazebo />
-
+    <!-- RGBD sensor for simulation, same as Kinect -->
+    <xacro:sensor_r430_gazebo />
   </xacro:macro>
 
-   <xacro:macro name="sensor_r430_gazebo">
-
+  <xacro:macro name="sensor_r430_gazebo">
     <!-- gazebo reference="${prefix}_rgb_base_link" -->
     <gazebo reference="${prefix}_camera_link">
       <sensor
@@ -222,11 +217,21 @@
           <alwaysOn>true</alwaysOn>
           <updateRate>10</updateRate>
           <imageTopicName>rgb/image_raw</imageTopicName>
-          <depthImageTopicName>depth/image_raw</depthImageTopicName>
-          <pointCloudTopicName>depth/points</pointCloudTopicName>
-          <cameraInfoTopicName>rgb/camera_info</cameraInfoTopicName>
-          <depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
-          <frameName>/${prefix}_camera_depth_optical_frame</frameName>
+          <depthImageTopicName>
+            depth/image_raw
+          </depthImageTopicName>
+          <pointCloudTopicName>
+            depth/points
+          </pointCloudTopicName>
+          <cameraInfoTopicName>
+            rgb/camera_info
+          </cameraInfoTopicName>
+          <depthImageCameraInfoTopicName>
+            depth/camera_info
+          </depthImageCameraInfoTopicName>
+          <frameName>
+            /${prefix}_camera_depth_optical_frame
+          </frameName>
           <baseline>0.1</baseline>
           <distortion_k1>0.0</distortion_k1>
           <distortion_k2>0.0</distortion_k2>
@@ -238,6 +243,4 @@
       </sensor>
     </gazebo>
   </xacro:macro>
-
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/intel_r430.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/intel_r430.urdf.xacro
@@ -1,125 +1,196 @@
-<?xml version="1.0"?>
-<robot name="sensor_r430" xmlns:xacro="http://wiki.ros.org/xacro">
-
-  <xacro:property name="M_PI" value="3.1415926535897931" />
+<?xml version="1.0" ?>
+<robot
+  name="sensor_r430"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
   <!-- The following values are approximate, and the camera node
    publishing TF values with actual calibrated camera extrinsic values -->
-  <xacro:property name="r430_cam_depth_to_left_ir_offset" value="-0.021"/>
-  <xacro:property name="r430_cam_depth_to_right_ir_offset" value="0.029"/>
-  <xacro:property name="r430_cam_depth_to_fisheye_offset" value="0.044"/>
+  <xacro:property
+    name="r430_cam_depth_to_left_ir_offset"
+    value="-0.021" />
+  <xacro:property
+    name="r430_cam_depth_to_right_ir_offset"
+    value="0.029" />
+  <xacro:property
+    name="r430_cam_depth_to_fisheye_offset"
+    value="0.044" />
 
   <!-- The following values model the aluminum peripherial case for the
     R430 camera, with the camera joint represented by the actual
     peripherial camera tripod mount -->
-  <xacro:property name="r430_cam_width" value="0.100"/>
-  <xacro:property name="r430_cam_depth" value="0.025"/>
-  <xacro:property name="r430_cam_height" value="0.025"/>
-  <xacro:property name="r430_cam_mount_from_center_offset" value="0.0"/>
+  <xacro:property
+    name="r430_cam_width"
+    value="0.100" />
+  <xacro:property
+    name="r430_cam_depth"
+    value="0.025" />
+  <xacro:property
+    name="r430_cam_height"
+    value="0.025" />
+  <xacro:property
+    name="r430_cam_mount_from_center_offset"
+    value="0.0" />
 
   <!-- The following offset is relative the the physical R430 camera peripherial
     camera tripod mount -->
-  <xacro:property name="r430_cam_depth_px" value="0.00"/>
-  <xacro:property name="r430_cam_depth_py" value="-0.0115"/>
-  <xacro:property name="r430_cam_depth_pz" value="0.0"/>
+  <xacro:property
+    name="r430_cam_depth_px"
+    value="0.00" />
+  <xacro:property
+    name="r430_cam_depth_py"
+    value="-0.0115" />
+  <xacro:property
+    name="r430_cam_depth_pz"
+    value="0.0" />
 
-  <xacro:macro name="sensor_r430" params="prefix parent prefix_topic:='front_rgbd_camera' *origin">
+  <xacro:macro
+    name="sensor_r430"
+    params="prefix parent prefix_topic:='front_rgbd_camera' *origin">
 
     <!-- camera body, with origin at bottom screw mount -->
-    <joint name="${prefix}_camera_joint" type="fixed">
+    <joint
+      name="${prefix}_camera_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${prefix}_camera_link" />
     </joint>
 
     <link name="${prefix}_camera_link">
       <visual>
-      <!-- origin xyz="0 ${-r430_cam_mount_from_center_offset} ${r430_cam_height/2}" rpy="${M_PI/2} 0 ${M_PI/2}"/ -->
-      <origin xyz="0 ${-r430_cam_mount_from_center_offset} 0" rpy="0 0 0"/>
+      <!-- origin xyz="0 ${-r430_cam_mount_from_center_offset} ${r430_cam_height/2}" rpy="${radians(90)} 0 ${radians(90)}"/ -->
+      <origin
+          xyz="0 ${-r430_cam_mount_from_center_offset} 0"
+          rpy="0 0 0" />
         <geometry>
           <!-- box size="${r430_cam_width} ${r430_cam_height} ${r430_cam_depth}"/ -->
-          <mesh filename="package://robotnik_sensors/meshes/intel_r430.dae" />
+          <mesh
+            filename="package://robotnik_sensors/meshes/intel_r430.dae" />
         </geometry>
         <material name="aluminum">
-          <color rgba="0.5 0.5 0.5 1"/>
+          <color rgba="0.5 0.5 0.5 1" />
         </material>
       </visual>
       <collision>
-        <origin xyz="${-r430_cam_depth/2} 0.0 0.0" rpy="0 0 0"/>
+        <origin
+          xyz="${-r430_cam_depth/2} 0.0 0.0"
+          rpy="0 0 0" />
         <geometry>
-        <box size="${r430_cam_depth} ${r430_cam_width} ${r430_cam_height}"/>
+        <box
+            size="${r430_cam_depth} ${r430_cam_width} ${r430_cam_height}" />
         </geometry>
       </collision>
       <inertial>
-        <origin xyz="-0.0125 0.0 0.0" rpy="0 0 0" />
+        <origin
+          xyz="-0.0125 0.0 0.0"
+          rpy="0 0 0" />
         <mass value="0.1" />
-        <xacro:solid_cuboid_inertia m="0.1" w="0.025" h="0.09" d="0.025" />
+        <xacro:solid_cuboid_inertia
+          m="0.1"
+          w="0.025"
+          h="0.09"
+          d="0.025" />
       </inertial>
     </link>
 
     <!-- camera depth joints and links -->
-    <joint name="${prefix}_camera_depth_joint" type="fixed">
-      <origin xyz="${r430_cam_depth_px} ${r430_cam_depth_py} ${r430_cam_depth_pz}" rpy="0 0 0"/>
-      <parent link="${prefix}_camera_link"/>
+    <joint
+      name="${prefix}_camera_depth_joint"
+      type="fixed">
+      <origin
+        xyz="${r430_cam_depth_px} ${r430_cam_depth_py} ${r430_cam_depth_pz}"
+        rpy="0 0 0" />
+      <parent link="${prefix}_camera_link" />
       <child link="${prefix}_camera_depth_frame" />
     </joint>
-    <link name="${prefix}_camera_depth_frame"/>
+    <link name="${prefix}_camera_depth_frame" />
 
-    <joint name="${prefix}_camera_depth_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+    <joint
+      name="${prefix}_camera_depth_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
       <parent link="${prefix}_camera_depth_frame" />
       <child link="${prefix}_camera_depth_optical_frame" />
     </joint>
-    <link name="${prefix}_camera_depth_optical_frame"/>
+    <link name="${prefix}_camera_depth_optical_frame" />
 
     <!-- camera left IR joints and links -->
-    <joint name="${prefix}_camera_left_ir_joint" type="fixed">
-      <origin xyz="0 ${r430_cam_depth_to_left_ir_offset} 0" rpy="0 0 0" />
+    <joint
+      name="${prefix}_camera_left_ir_joint"
+      type="fixed">
+      <origin
+        xyz="0 ${r430_cam_depth_to_left_ir_offset} 0"
+        rpy="0 0 0" />
       <parent link="${prefix}_camera_depth_frame" />
       <child link="${prefix}_camera_left_ir_frame" />
     </joint>
-    <link name="${prefix}_camera_left_ir_frame"/>
+    <link name="${prefix}_camera_left_ir_frame" />
 
-    <joint name="${prefix}_camera_left_ir_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+    <joint
+      name="${prefix}_camera_left_ir_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
       <parent link="${prefix}_camera_left_ir_frame" />
-      <child link="${prefix}_camera_left_ir_optical_frame" />
+      <child
+        link="${prefix}_camera_left_ir_optical_frame" />
     </joint>
-    <link name="${prefix}_camera_left_ir_optical_frame"/>
+    <link name="${prefix}_camera_left_ir_optical_frame" />
 
     <!-- camera right IR joints and links -->
-    <joint name="${prefix}_camera_right_ir_joint" type="fixed">
-      <origin xyz="0 ${r430_cam_depth_to_right_ir_offset} 0" rpy="0 0 0" />
+    <joint
+      name="${prefix}_camera_right_ir_joint"
+      type="fixed">
+      <origin
+        xyz="0 ${r430_cam_depth_to_right_ir_offset} 0"
+        rpy="0 0 0" />
       <parent link="${prefix}_camera_depth_frame" />
       <child link="${prefix}_camera_right_ir_frame" />
     </joint>
-    <link name="${prefix}_camera_right_ir_frame"/>
+    <link name="${prefix}_camera_right_ir_frame" />
 
-    <joint name="${prefix}_camera_right_ir_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+    <joint
+      name="${prefix}_camera_right_ir_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
       <parent link="${prefix}_camera_right_ir_frame" />
-      <child link="${prefix}_camera_right_ir_optical_frame" />
+      <child
+        link="${prefix}_camera_right_ir_optical_frame" />
     </joint>
-    <link name="${prefix}_camera_right_ir_optical_frame"/>
+    <link name="${prefix}_camera_right_ir_optical_frame" />
 
     <!-- camera fisheye joints and links -->
-    <joint name="${prefix}_camera_fisheye_joint" type="fixed">
-      <origin xyz="0 ${r430_cam_depth_to_fisheye_offset} 0" rpy="0 0 0" />
+    <joint
+      name="${prefix}_camera_fisheye_joint"
+      type="fixed">
+      <origin
+        xyz="0 ${r430_cam_depth_to_fisheye_offset} 0"
+        rpy="0 0 0" />
       <parent link="${prefix}_camera_depth_frame" />
       <child link="${prefix}_camera_fisheye_frame" />
     </joint>
-    <link name="${prefix}_camera_fisheye_frame"/>
+    <link name="${prefix}_camera_fisheye_frame" />
 
-    <joint name="${prefix}_camera_fisheye_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+    <joint
+      name="${prefix}_camera_fisheye_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
       <parent link="${prefix}_camera_fisheye_frame" />
-      <child link="${prefix}_camera_fisheye_optical_frame" />
+      <child
+        link="${prefix}_camera_fisheye_optical_frame" />
     </joint>
-    <link name="${prefix}_camera_fisheye_optical_frame"/>
+    <link name="${prefix}_camera_fisheye_optical_frame" />
 
 
   <!-- RGBD sensor for simulation, same as Kinect -->
-  <xacro:sensor_r430_gazebo/>
+  <xacro:sensor_r430_gazebo />
 
   </xacro:macro>
 
@@ -127,11 +198,13 @@
 
     <!-- gazebo reference="${prefix}_rgb_base_link" -->
     <gazebo reference="${prefix}_camera_link">
-      <sensor type="depth" name="${prefix}_depth_sensor">
+      <sensor
+        type="depth"
+        name="${prefix}_depth_sensor">
         <always_on>true</always_on>
         <update_rate>15.0</update_rate>
         <camera>
-          <horizontal_fov>${91.2*M_PI/180.0}</horizontal_fov>
+          <horizontal_fov>${radians(91.2)}</horizontal_fov>
           <image>
             <format>R8G8B8</format>
             <width>640</width>
@@ -142,7 +215,9 @@
             <far>10.0</far>
           </clip>
         </camera>
-        <plugin name="${prefix}_controller" filename="libgazebo_ros_openni_kinect.so">
+        <plugin
+          name="${prefix}_controller"
+          filename="libgazebo_ros_openni_kinect.so">
           <cameraName>${prefix_topic}</cameraName>
           <alwaysOn>true</alwaysOn>
           <updateRate>10</updateRate>

--- a/robotnik_sensors/urdf/deprecated/kinect.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/kinect.urdf.xacro
@@ -1,70 +1,114 @@
-<?xml version="1.0"?>
-<robot name="sensor_kinect" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_kinect"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:property name="M_PI" value="3.1415926535897931" />
-	<xacro:property name="cam_px" value="-0.087" />
-	<xacro:property name="cam_py" value="-0.0125" />
-	<xacro:property name="cam_pz" value="0.2870" />
-	<xacro:property name="cam_or" value="0" />
-	<xacro:property name="cam_op" value="0" />
-	<xacro:property name="cam_oy" value="0" />
+	<xacro:property
+    name="cam_px"
+    value="-0.087" />
+	<xacro:property
+    name="cam_py"
+    value="-0.0125" />
+	<xacro:property
+    name="cam_pz"
+    value="0.2870" />
+	<xacro:property
+    name="cam_or"
+    value="0" />
+	<xacro:property
+    name="cam_op"
+    value="0" />
+	<xacro:property
+    name="cam_oy"
+    value="0" />
 
-  <xacro:macro name="sensor_kinect" params="prefix parent *origin">
+  <xacro:macro
+    name="sensor_kinect"
+    params="prefix parent *origin">
 
-    <joint name="${prefix}_rgb_joint" type="fixed">
+    <joint
+      name="${prefix}_rgb_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${prefix}_rgb_base_link" />
     </joint>
     <link name="${prefix}_rgb_base_link">
     </link>
 
 
-    <joint name="${prefix}_rgb_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+    <joint
+      name="${prefix}_rgb_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
       <parent link="${prefix}_rgb_base_link" />
       <child link="${prefix}_rgb_optical_frame" />
     </joint>
     <link name="${prefix}_rgb_optical_frame">
     </link>
 
-  <joint name="${prefix}_joint" type="fixed">
-    <origin xyz="-0.031 ${-cam_py} -0.016" rpy="0 0 0"/>
-    <parent link="${prefix}_rgb_base_link"/>
-    <child link="${prefix}_link"/>
+  <joint
+      name="${prefix}_joint"
+      type="fixed">
+    <origin
+        xyz="-0.031 ${-cam_py} -0.016"
+        rpy="0 0 0" />
+    <parent link="${prefix}_rgb_base_link" />
+    <child link="${prefix}_link" />
   </joint>
     <link name="${prefix}_link">
     <visual>
-     <origin xyz="0 0 0" rpy="0 0 ${M_PI/2}"/>
+     <origin
+          xyz="0 0 0"
+          rpy="0 0 ${radians(90)}" />
       <geometry>
-       <mesh filename="package://robotnik_sensors/meshes/kinect.dae"/>
+       <mesh
+            filename="package://robotnik_sensors/meshes/kinect.dae" />
       </geometry>
     </visual>
 	  <collision>
-      <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+      <origin
+          xyz="0.0 0.0 0.0"
+          rpy="0 0 0" />
 	    <geometry>
-	      <box size="0.07271 0.27794 0.073"/>
+	      <box size="0.07271 0.27794 0.073" />
 	    </geometry>
 	  </collision>
     <inertial>
-      <origin xyz="-0.0 0.0 0.015" rpy="0 0 0" />
+      <origin
+          xyz="-0.0 0.0 0.015"
+          rpy="0 0 0" />
       <mass value="0.2" />
-      <xacro:solid_cuboid_inertia m="0.2" w="0.06" h="0.24" d="0.04" />
+      <xacro:solid_cuboid_inertia
+          m="0.2"
+          w="0.06"
+          h="0.24"
+          d="0.04" />
     </inertial>
   </link>
 
   <!-- The fixed joints & links below are usually published by static_transformers launched by the OpenNi launch
        files. However, for Gazebo simulation we need them, so we add them here.
        (Hence, don't publish them additionally!) -->
-	<joint name="${prefix}_depth_joint" type="fixed">
-	  <origin xyz="0 ${2 * -cam_py} 0" rpy="0 0 0" />
+	<joint
+      name="${prefix}_depth_joint"
+      type="fixed">
+	  <origin
+        xyz="0 ${2 * -cam_py} 0"
+        rpy="0 0 0" />
 	  <parent link="${prefix}_rgb_base_link" />
 	  <child link="${prefix}_depth_link" />
 	</joint>
 	<link name="${prefix}_depth_link">
 	</link>
-	<joint name="${prefix}_depth_optical_joint" type="fixed">
-	  <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+	<joint
+      name="${prefix}_depth_optical_joint"
+      type="fixed">
+	  <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
 	  <parent link="${prefix}_depth_link" />
 	  <child link="${prefix}_depth_optical_frame" />
 	</joint>
@@ -72,7 +116,7 @@
 	</link>
 
 		<!-- Kinect sensor for simulation -->
-	  <xacro:sensor_kinect_gazebo/>
+	  <xacro:sensor_kinect_gazebo />
 
   </xacro:macro>
 
@@ -80,11 +124,13 @@
   <xacro:macro name="sensor_kinect_gazebo">
 
     <gazebo reference="${prefix}_link">
-      <sensor type="depth" name="${prefix}_sensor">
+      <sensor
+        type="depth"
+        name="${prefix}_sensor">
         <always_on>true</always_on>
         <update_rate>20.0</update_rate>
         <camera>
-          <horizontal_fov>${60.0*M_PI/180.0}</horizontal_fov>
+          <horizontal_fov>${radians(60)}</horizontal_fov>
           <image>
             <format>R8G8B8</format>
             <width>640</width>
@@ -95,7 +141,9 @@
             <far>8.0</far>
           </clip>
         </camera>
-        <plugin name="${prefix}_controller" filename="libgazebo_ros_openni_kinect.so">
+        <plugin
+          name="${prefix}_controller"
+          filename="libgazebo_ros_openni_kinect.so">
           <cameraName>${prefix}</cameraName>
           <alwaysOn>true</alwaysOn>
           <updateRate>10</updateRate>

--- a/robotnik_sensors/urdf/deprecated/kinect.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/kinect.urdf.xacro
@@ -2,30 +2,28 @@
 <robot
   name="sensor_kinect"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
-	<xacro:property
+  <xacro:property
     name="cam_px"
     value="-0.087" />
-	<xacro:property
+  <xacro:property
     name="cam_py"
     value="-0.0125" />
-	<xacro:property
+  <xacro:property
     name="cam_pz"
     value="0.2870" />
-	<xacro:property
+  <xacro:property
     name="cam_or"
     value="0" />
-	<xacro:property
+  <xacro:property
     name="cam_op"
     value="0" />
-	<xacro:property
+  <xacro:property
     name="cam_oy"
     value="0" />
 
   <xacro:macro
     name="sensor_kinect"
     params="prefix parent *origin">
-
     <joint
       name="${prefix}_rgb_joint"
       type="fixed">
@@ -33,9 +31,7 @@
       <parent link="${parent}" />
       <child link="${prefix}_rgb_base_link" />
     </joint>
-    <link name="${prefix}_rgb_base_link">
-    </link>
-
+    <link name="${prefix}_rgb_base_link" />
 
     <joint
       name="${prefix}_rgb_optical_joint"
@@ -46,83 +42,77 @@
       <parent link="${prefix}_rgb_base_link" />
       <child link="${prefix}_rgb_optical_frame" />
     </joint>
-    <link name="${prefix}_rgb_optical_frame">
-    </link>
+    <link name="${prefix}_rgb_optical_frame" />
 
-  <joint
+    <joint
       name="${prefix}_joint"
       type="fixed">
-    <origin
+      <origin
         xyz="-0.031 ${-cam_py} -0.016"
         rpy="0 0 0" />
-    <parent link="${prefix}_rgb_base_link" />
-    <child link="${prefix}_link" />
-  </joint>
+      <parent link="${prefix}_rgb_base_link" />
+      <child link="${prefix}_link" />
+    </joint>
     <link name="${prefix}_link">
-    <visual>
-     <origin
+      <visual>
+        <origin
           xyz="0 0 0"
           rpy="0 0 ${radians(90)}" />
-      <geometry>
-       <mesh
+        <geometry>
+          <mesh
             filename="package://robotnik_sensors/meshes/kinect.dae" />
-      </geometry>
-    </visual>
-	  <collision>
-      <origin
+        </geometry>
+      </visual>
+      <collision>
+        <origin
           xyz="0.0 0.0 0.0"
           rpy="0 0 0" />
-	    <geometry>
-	      <box size="0.07271 0.27794 0.073" />
-	    </geometry>
-	  </collision>
-    <inertial>
-      <origin
+        <geometry>
+          <box size="0.07271 0.27794 0.073" />
+        </geometry>
+      </collision>
+      <inertial>
+        <origin
           xyz="-0.0 0.0 0.015"
           rpy="0 0 0" />
-      <mass value="0.2" />
-      <xacro:solid_cuboid_inertia
+        <mass value="0.2" />
+        <xacro:solid_cuboid_inertia
           m="0.2"
           w="0.06"
           h="0.24"
           d="0.04" />
-    </inertial>
-  </link>
+      </inertial>
+    </link>
 
-  <!-- The fixed joints & links below are usually published by static_transformers launched by the OpenNi launch
+    <!-- The fixed joints & links below are usually published by static_transformers launched by the OpenNi launch
        files. However, for Gazebo simulation we need them, so we add them here.
        (Hence, don't publish them additionally!) -->
-	<joint
+    <joint
       name="${prefix}_depth_joint"
       type="fixed">
-	  <origin
+      <origin
         xyz="0 ${2 * -cam_py} 0"
         rpy="0 0 0" />
-	  <parent link="${prefix}_rgb_base_link" />
-	  <child link="${prefix}_depth_link" />
-	</joint>
-	<link name="${prefix}_depth_link">
-	</link>
-	<joint
+      <parent link="${prefix}_rgb_base_link" />
+      <child link="${prefix}_depth_link" />
+    </joint>
+    <link name="${prefix}_depth_link" />
+    <joint
       name="${prefix}_depth_optical_joint"
       type="fixed">
-	  <origin
+      <origin
         xyz="0 0 0"
         rpy="${-radians(90)} 0 ${-radians(90)}" />
-	  <parent link="${prefix}_depth_link" />
-	  <child link="${prefix}_depth_optical_frame" />
-	</joint>
-	<link name="${prefix}_depth_optical_frame">
-	</link>
+      <parent link="${prefix}_depth_link" />
+      <child link="${prefix}_depth_optical_frame" />
+    </joint>
+    <link name="${prefix}_depth_optical_frame" />
 
-		<!-- Kinect sensor for simulation -->
-	  <xacro:sensor_kinect_gazebo />
-
+    <!-- Kinect sensor for simulation -->
+    <xacro:sensor_kinect_gazebo />
   </xacro:macro>
 
-
   <xacro:macro name="sensor_kinect_gazebo">
-
     <gazebo reference="${prefix}_link">
       <sensor
         type="depth"
@@ -148,11 +138,21 @@
           <alwaysOn>true</alwaysOn>
           <updateRate>10</updateRate>
           <imageTopicName>rgb/image_raw</imageTopicName>
-          <depthImageTopicName>depth/image_raw</depthImageTopicName>
-          <pointCloudTopicName>depth/points</pointCloudTopicName>
-          <cameraInfoTopicName>rgb/camera_info</cameraInfoTopicName>
-          <depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
-          <frameName>/${prefix}_depth_optical_frame</frameName>
+          <depthImageTopicName>
+            depth/image_raw
+          </depthImageTopicName>
+          <pointCloudTopicName>
+            depth/points
+          </pointCloudTopicName>
+          <cameraInfoTopicName>
+            rgb/camera_info
+          </cameraInfoTopicName>
+          <depthImageCameraInfoTopicName>
+            depth/camera_info
+          </depthImageCameraInfoTopicName>
+          <frameName>
+            /${prefix}_depth_optical_frame
+          </frameName>
           <baseline>0.1</baseline>
           <distortion_k1>0.0</distortion_k1>
           <distortion_k2>0.0</distortion_k2>
@@ -164,7 +164,5 @@
         </plugin>
       </sensor>
     </gazebo>
-
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/kinectv2.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/kinectv2.urdf.xacro
@@ -2,31 +2,28 @@
 <robot
   name="sensor_kinectv2"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
-    <xacro:property
+  <xacro:property
     name="cam_px"
     value="-0.087" />
-    <xacro:property
+  <xacro:property
     name="cam_py"
     value="-0.0125" />
-    <xacro:property
+  <xacro:property
     name="cam_pz"
     value="0.2870" />
-    <xacro:property
+  <xacro:property
     name="cam_or"
     value="0" />
-    <xacro:property
+  <xacro:property
     name="cam_op"
     value="0" />
-    <xacro:property
+  <xacro:property
     name="cam_oy"
     value="0" />
-
 
   <xacro:macro
     name="sensor_kinectv2"
     params="prefix parent base:=true *origin cloudCutoffMax:=5.0 far:=8.0">
-
     <joint
       name="${prefix}_rgb_joint"
       type="fixed">
@@ -34,9 +31,7 @@
       <parent link="${parent}" />
       <child link="${prefix}_rgb_base_link" />
     </joint>
-    <link name="${prefix}_rgb_base_link">
-    </link>
-
+    <link name="${prefix}_rgb_base_link" />
 
     <joint
       name="${prefix}_rgb_optical_joint"
@@ -47,76 +42,76 @@
       <parent link="${prefix}_rgb_base_link" />
       <child link="${prefix}_rgb_optical_frame" />
     </joint>
-    <link name="${prefix}_rgb_optical_frame">
-    </link>
+    <link name="${prefix}_rgb_optical_frame" />
 
-  <joint
+    <joint
       name="${prefix}_joint"
       type="fixed">
-    <!--<origin xyz="-0.031 ${-cam_py} -0.016" rpy="0 0 0"/>--> <!-- with base -->
-    <xacro:if value="${base}">
-        <origin
-          xyz="-0.031 ${-cam_py} -0.016"
-          rpy="0 0 0" />
-    </xacro:if>
-    <xacro:unless value="${base}">
-        <origin
-          xyz="-0.031 ${-cam_py} -0.016"
-          rpy="0 0 0" />
-    </xacro:unless>
-
-    <parent link="${prefix}_rgb_base_link" />
-    <child link="${prefix}_link" />
-  </joint>
-    <link name="${prefix}_link">
-    <visual>
-      <origin
-          xyz="0 0 0"
-          rpy="0 0 ${radians(90)}" />
-      <geometry>
-        <xacro:if value="${base}">
-          <mesh
-              filename="package://robotnik_sensors/meshes/kinectv2.dae" />
-        </xacro:if>
-        <xacro:unless value="${base}">
-          <mesh
-              filename="package://robotnik_sensors/meshes/kinectv2_nobase.dae" />
-        </xacro:unless>
-      </geometry>
-    </visual>
-    <!-- with base -->
-    <collision>
+      <!--<origin xyz="-0.031 ${-cam_py} -0.016" rpy="0 0 0"/>-->
+      <!-- with base -->
       <xacro:if value="${base}">
         <origin
-            xyz="-0.015 0.0 0.03225"
-            rpy="0 0 0" />
-        <geometry>
-          <box size="0.0943 0.25 0.0645" />
-        </geometry>
+          xyz="-0.031 ${-cam_py} -0.016"
+          rpy="0 0 0" />
       </xacro:if>
       <xacro:unless value="${base}">
         <origin
+          xyz="-0.031 ${-cam_py} -0.016"
+          rpy="0 0 0" />
+      </xacro:unless>
+
+      <parent link="${prefix}_rgb_base_link" />
+      <child link="${prefix}_link" />
+    </joint>
+    <link name="${prefix}_link">
+      <visual>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 ${radians(90)}" />
+        <geometry>
+          <xacro:if value="${base}">
+            <mesh
+              filename="package://robotnik_sensors/meshes/kinectv2.dae" />
+          </xacro:if>
+          <xacro:unless value="${base}">
+            <mesh
+              filename="package://robotnik_sensors/meshes/kinectv2_nobase.dae" />
+          </xacro:unless>
+        </geometry>
+      </visual>
+      <!-- with base -->
+      <collision>
+        <xacro:if value="${base}">
+          <origin
+            xyz="-0.015 0.0 0.03225"
+            rpy="0 0 0" />
+          <geometry>
+            <box size="0.0943 0.25 0.0645" />
+          </geometry>
+        </xacro:if>
+        <xacro:unless value="${base}">
+          <origin
             xyz="-0.015 0.0 0.020"
             rpy="0 0 0" />
-        <geometry>
-          <box size="0.0943 0.25 0.045" />
-        </geometry>
-      </xacro:unless>
-    </collision>
-    <inertial>
-      <origin
+          <geometry>
+            <box size="0.0943 0.25 0.045" />
+          </geometry>
+        </xacro:unless>
+      </collision>
+      <inertial>
+        <origin
           xyz="-0.0 0.0 0.025"
           rpy="0 0 0" />
-      <mass value="0.2" />
-      <xacro:solid_cuboid_inertia
+        <mass value="0.2" />
+        <xacro:solid_cuboid_inertia
           m="0.2"
           w="0.06"
           h="0.24"
           d="0.04" />
-    </inertial>
-  </link>
+      </inertial>
+    </link>
 
-  <!-- The fixed joints & links below are usually published by static_transformers launched by the OpenNi launch
+    <!-- The fixed joints & links below are usually published by static_transformers launched by the OpenNi launch
        files. However, for Gazebo simulation we need them, so we add them here.
        (Hence, don't publish them additionally!) -->
     <joint
@@ -128,8 +123,7 @@
       <parent link="${prefix}_rgb_base_link" />
       <child link="${prefix}_depth_link" />
     </joint>
-    <link name="${prefix}_depth_link">
-    </link>
+    <link name="${prefix}_depth_link" />
     <joint
       name="${prefix}_depth_optical_joint"
       type="fixed">
@@ -139,21 +133,17 @@
       <parent link="${prefix}_depth_link" />
       <child link="${prefix}_depth_optical_frame" />
     </joint>
-    <link name="${prefix}_depth_optical_frame">
-    </link>
+    <link name="${prefix}_depth_optical_frame" />
 
-        <!-- Kinect sensor for simulation -->
-      <xacro:sensor_kinectv2_gazebo
+    <!-- Kinect sensor for simulation -->
+    <xacro:sensor_kinectv2_gazebo
       cloudCutoffMax="${cloudCutoffMax}"
       far="${far}" />
-
   </xacro:macro>
-
 
   <xacro:macro
     name="sensor_kinectv2_gazebo"
     params="cloudCutoffMax:=5.0 far:=8.0">
-
     <gazebo reference="${prefix}_link">
       <sensor
         type="depth"
@@ -179,11 +169,21 @@
           <alwaysOn>true</alwaysOn>
           <updateRate>10</updateRate>
           <imageTopicName>rgb/image_raw</imageTopicName>
-          <depthImageTopicName>depth/image_raw</depthImageTopicName>
-          <pointCloudTopicName>depth/points</pointCloudTopicName>
-          <cameraInfoTopicName>rgb/camera_info</cameraInfoTopicName>
-          <depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
-          <frameName>/${prefix}_depth_optical_frame</frameName>
+          <depthImageTopicName>
+            depth/image_raw
+          </depthImageTopicName>
+          <pointCloudTopicName>
+            depth/points
+          </pointCloudTopicName>
+          <cameraInfoTopicName>
+            rgb/camera_info
+          </cameraInfoTopicName>
+          <depthImageCameraInfoTopicName>
+            depth/camera_info
+          </depthImageCameraInfoTopicName>
+          <frameName>
+            /${prefix}_depth_optical_frame
+          </frameName>
           <baseline>0.1</baseline>
           <distortion_k1>0.0</distortion_k1>
           <distortion_k2>0.0</distortion_k2>
@@ -191,11 +191,11 @@
           <distortion_t1>0.0</distortion_t1>
           <distortion_t2>0.0</distortion_t2>
           <pointCloudCutoff>0.4</pointCloudCutoff>
-          <pointCloudCutoffMax>${cloudCutoffMax}</pointCloudCutoffMax>
+          <pointCloudCutoffMax>
+            ${cloudCutoffMax}
+          </pointCloudCutoffMax>
         </plugin>
       </sensor>
     </gazebo>
-
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/kinectv2.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/kinectv2.urdf.xacro
@@ -1,92 +1,141 @@
-<?xml version="1.0"?>
-<robot name="sensor_kinectv2" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_kinectv2"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:property name="M_PI" value="3.1415926535897931" />
-    <xacro:property name="cam_px" value="-0.087" />
-    <xacro:property name="cam_py" value="-0.0125" />
-    <xacro:property name="cam_pz" value="0.2870" />
-    <xacro:property name="cam_or" value="0" />
-    <xacro:property name="cam_op" value="0" />
-    <xacro:property name="cam_oy" value="0" />
+    <xacro:property
+    name="cam_px"
+    value="-0.087" />
+    <xacro:property
+    name="cam_py"
+    value="-0.0125" />
+    <xacro:property
+    name="cam_pz"
+    value="0.2870" />
+    <xacro:property
+    name="cam_or"
+    value="0" />
+    <xacro:property
+    name="cam_op"
+    value="0" />
+    <xacro:property
+    name="cam_oy"
+    value="0" />
 
 
-  <xacro:macro name="sensor_kinectv2" params="prefix parent base:=true *origin cloudCutoffMax:=5.0 far:=8.0">
+  <xacro:macro
+    name="sensor_kinectv2"
+    params="prefix parent base:=true *origin cloudCutoffMax:=5.0 far:=8.0">
 
-    <joint name="${prefix}_rgb_joint" type="fixed">
+    <joint
+      name="${prefix}_rgb_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${prefix}_rgb_base_link" />
     </joint>
     <link name="${prefix}_rgb_base_link">
     </link>
 
 
-    <joint name="${prefix}_rgb_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+    <joint
+      name="${prefix}_rgb_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
       <parent link="${prefix}_rgb_base_link" />
       <child link="${prefix}_rgb_optical_frame" />
     </joint>
     <link name="${prefix}_rgb_optical_frame">
     </link>
 
-  <joint name="${prefix}_joint" type="fixed">
+  <joint
+      name="${prefix}_joint"
+      type="fixed">
     <!--<origin xyz="-0.031 ${-cam_py} -0.016" rpy="0 0 0"/>--> <!-- with base -->
     <xacro:if value="${base}">
-        <origin xyz="-0.031 ${-cam_py} -0.016" rpy="0 0 0"/>
+        <origin
+          xyz="-0.031 ${-cam_py} -0.016"
+          rpy="0 0 0" />
     </xacro:if>
     <xacro:unless value="${base}">
-        <origin xyz="-0.031 ${-cam_py} -0.016" rpy="0 0 0"/>
+        <origin
+          xyz="-0.031 ${-cam_py} -0.016"
+          rpy="0 0 0" />
     </xacro:unless>
 
-    <parent link="${prefix}_rgb_base_link"/>
-    <child link="${prefix}_link"/>
+    <parent link="${prefix}_rgb_base_link" />
+    <child link="${prefix}_link" />
   </joint>
     <link name="${prefix}_link">
     <visual>
-      <origin xyz="0 0 0" rpy="0 0 ${M_PI/2}"/>
+      <origin
+          xyz="0 0 0"
+          rpy="0 0 ${radians(90)}" />
       <geometry>
         <xacro:if value="${base}">
-          <mesh filename="package://robotnik_sensors/meshes/kinectv2.dae"/>
+          <mesh
+              filename="package://robotnik_sensors/meshes/kinectv2.dae" />
         </xacro:if>
         <xacro:unless value="${base}">
-          <mesh filename="package://robotnik_sensors/meshes/kinectv2_nobase.dae"/>
+          <mesh
+              filename="package://robotnik_sensors/meshes/kinectv2_nobase.dae" />
         </xacro:unless>
       </geometry>
     </visual>
     <!-- with base -->
     <collision>
       <xacro:if value="${base}">
-        <origin xyz="-0.015 0.0 0.03225" rpy="0 0 0"/>
+        <origin
+            xyz="-0.015 0.0 0.03225"
+            rpy="0 0 0" />
         <geometry>
-          <box size="0.0943 0.25 0.0645"/>
+          <box size="0.0943 0.25 0.0645" />
         </geometry>
       </xacro:if>
       <xacro:unless value="${base}">
-        <origin xyz="-0.015 0.0 0.020" rpy="0 0 0"/>
+        <origin
+            xyz="-0.015 0.0 0.020"
+            rpy="0 0 0" />
         <geometry>
-          <box size="0.0943 0.25 0.045"/>
+          <box size="0.0943 0.25 0.045" />
         </geometry>
       </xacro:unless>
     </collision>
     <inertial>
-      <origin xyz="-0.0 0.0 0.025" rpy="0 0 0" />
+      <origin
+          xyz="-0.0 0.0 0.025"
+          rpy="0 0 0" />
       <mass value="0.2" />
-      <xacro:solid_cuboid_inertia m="0.2" w="0.06" h="0.24" d="0.04" />
+      <xacro:solid_cuboid_inertia
+          m="0.2"
+          w="0.06"
+          h="0.24"
+          d="0.04" />
     </inertial>
   </link>
 
   <!-- The fixed joints & links below are usually published by static_transformers launched by the OpenNi launch
        files. However, for Gazebo simulation we need them, so we add them here.
        (Hence, don't publish them additionally!) -->
-    <joint name="${prefix}_depth_joint" type="fixed">
-      <origin xyz="0 ${2 * -cam_py} 0" rpy="0 0 0" />
+    <joint
+      name="${prefix}_depth_joint"
+      type="fixed">
+      <origin
+        xyz="0 ${2 * -cam_py} 0"
+        rpy="0 0 0" />
       <parent link="${prefix}_rgb_base_link" />
       <child link="${prefix}_depth_link" />
     </joint>
     <link name="${prefix}_depth_link">
     </link>
-    <joint name="${prefix}_depth_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="${-M_PI/2} 0 ${-M_PI/2}" />
+    <joint
+      name="${prefix}_depth_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
       <parent link="${prefix}_depth_link" />
       <child link="${prefix}_depth_optical_frame" />
     </joint>
@@ -94,19 +143,25 @@
     </link>
 
         <!-- Kinect sensor for simulation -->
-      <xacro:sensor_kinectv2_gazebo cloudCutoffMax="${cloudCutoffMax}" far="${far}"/>
+      <xacro:sensor_kinectv2_gazebo
+      cloudCutoffMax="${cloudCutoffMax}"
+      far="${far}" />
 
   </xacro:macro>
 
 
-  <xacro:macro name="sensor_kinectv2_gazebo" params="cloudCutoffMax:=5.0 far:=8.0">
+  <xacro:macro
+    name="sensor_kinectv2_gazebo"
+    params="cloudCutoffMax:=5.0 far:=8.0">
 
     <gazebo reference="${prefix}_link">
-      <sensor type="depth" name="${prefix}_sensor">
+      <sensor
+        type="depth"
+        name="${prefix}_sensor">
         <always_on>true</always_on>
         <update_rate>20.0</update_rate>
         <camera>
-          <horizontal_fov>${60.0*M_PI/180.0}</horizontal_fov>
+          <horizontal_fov>${radians(60)}</horizontal_fov>
           <image>
             <format>R8G8B8</format>
             <width>640</width>
@@ -117,7 +172,9 @@
             <far>${far}</far>
           </clip>
         </camera>
-        <plugin name="${prefix}_controller" filename="libgazebo_ros_openni_kinect.so">
+        <plugin
+          name="${prefix}_controller"
+          filename="libgazebo_ros_openni_kinect.so">
           <cameraName>${prefix}</cameraName>
           <alwaysOn>true</alwaysOn>
           <updateRate>10</updateRate>

--- a/robotnik_sensors/urdf/deprecated/lidar_mast.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/lidar_mast.urdf.xacro
@@ -1,29 +1,39 @@
-<?xml version="1.0"?>
+<?xml version="1.0" ?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="lidar_mast"
+  <xacro:macro
+    name="lidar_mast"
     params="prefix:=lidar_mast parent *origin">
 
-    <joint name="${prefix}_base_joint" type="fixed">
+    <joint
+      name="${prefix}_base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${prefix}_base_link" />
     </joint>
 
     <link name="${prefix}_base_link">
        <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/lidar_mast.STL"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/lidar_mast.STL" />
         </geometry>
         <material name="light_zed_grey">
-          <color rgba="0.35 0.35 0.35 1"/>
+          <color rgba="0.35 0.35 0.35 1" />
         </material>
       </visual>
       <collision>
-        <origin xyz="-0.03 -0.015 0.30" rpy="0 0 0" />
+        <origin
+          xyz="-0.03 -0.015 0.30"
+          rpy="0 0 0" />
         <geometry>
-          <cylinder radius="0.1" length="0.6"/>
+          <cylinder
+            radius="0.1"
+            length="0.6" />
         </geometry>
       </collision>
     </link>

--- a/robotnik_sensors/urdf/deprecated/lidar_mast.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/lidar_mast.urdf.xacro
@@ -1,10 +1,8 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="lidar_mast"
     params="prefix:=lidar_mast parent *origin">
-
     <joint
       name="${prefix}_base_joint"
       type="fixed">
@@ -14,7 +12,7 @@
     </joint>
 
     <link name="${prefix}_base_link">
-       <visual>
+      <visual>
         <origin
           xyz="0 0 0"
           rpy="0 0 0" />
@@ -38,5 +36,4 @@
       </collision>
     </link>
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/pantilt.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/pantilt.urdf.xacro
@@ -20,7 +20,6 @@
   <xacro:macro
     name="sensor_pantilt"
     params="prefix parent *origin far:=^|8.0 near:=^|0.05">
-    
     <joint
       name="${prefix}_joint"
       type="fixed">
@@ -29,7 +28,7 @@
       <parent link="${parent}" />
       <child link="${prefix}_base_link" />
     </joint>
-    
+
     <link name="${prefix}_base_link">
       <inertial>
         <origin
@@ -63,7 +62,7 @@
         </geometry>
       </collision-->
     </link>
-    
+
     <joint
       name="pan"
       type="revolute">
@@ -83,7 +82,7 @@
         damping="${ptz_joint_damping}"
         friction="{ptz_joint_friction}" />
     </joint>
-    
+
     <link name="pan_link">
       <inertial>
         <mass value="0.1" />
@@ -103,14 +102,20 @@
     <transmission name="${prefix}_pan_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="pan">
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
+        <hardwareInterface>
+          hardware_interface/VelocityJointInterface
+        </hardwareInterface>
       </joint>
       <actuator name="pan_motor">
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
-        <mechanicalReduction>${ptz_mechanical_reduction}</mechanicalReduction>
+        <hardwareInterface>
+          hardware_interface/VelocityJointInterface
+        </hardwareInterface>
+        <mechanicalReduction>
+          ${ptz_mechanical_reduction}
+        </mechanicalReduction>
       </actuator>
     </transmission>
-    
+
     <joint
       name="tilt"
       type="revolute">
@@ -127,7 +132,7 @@
         damping="${ptz_joint_damping}"
         friction="{ptz_joint_friction}" />
     </joint>
-    
+
     <link name="tilt_link">
       <inertial>
         <mass value="0.1" />
@@ -143,18 +148,22 @@
           izz="0.1" />
       </inertial>
     </link>
-    
+
     <transmission name="${prefix}_tilt_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="tilt">
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
+        <hardwareInterface>
+          hardware_interface/VelocityJointInterface
+        </hardwareInterface>
       </joint>
       <actuator name="tilt_motor">
-        <hardwareInterface>hardware_interface/VelocityJointInterface</hardwareInterface>
-        <mechanicalReduction>${ptz_mechanical_reduction}</mechanicalReduction>
+        <hardwareInterface>
+          hardware_interface/VelocityJointInterface
+        </hardwareInterface>
+        <mechanicalReduction>
+          ${ptz_mechanical_reduction}
+        </mechanicalReduction>
       </actuator>
     </transmission>
-    
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/pantilt.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/pantilt.urdf.xacro
@@ -1,25 +1,51 @@
-<?xml version="1.0"?>
-<robot xmlns:xacro="http://wiki.ros.org/xacro" name="sensor_axis">
-  <xacro:property name="ptz_joint_effort_limit" value="100.0"/>
-  <xacro:property name="ptz_joint_velocity_limit" value="100.0"/>
-  <xacro:property name="ptz_joint_friction" value="0.1"/>
-  <xacro:property name="ptz_joint_damping" value="0.1"/>
-  <xacro:property name="ptz_mechanical_reduction" value="1.0"/>
-  <xacro:macro name="sensor_pantilt" params="prefix parent *origin far:=^|8.0 near:=^|0.05">
+<?xml version="1.0" ?>
+<robot
+  xmlns:xacro="http://wiki.ros.org/xacro"
+  name="sensor_axis">
+  <xacro:property
+    name="ptz_joint_effort_limit"
+    value="100.0" />
+  <xacro:property
+    name="ptz_joint_velocity_limit"
+    value="100.0" />
+  <xacro:property
+    name="ptz_joint_friction"
+    value="0.1" />
+  <xacro:property
+    name="ptz_joint_damping"
+    value="0.1" />
+  <xacro:property
+    name="ptz_mechanical_reduction"
+    value="1.0" />
+  <xacro:macro
+    name="sensor_pantilt"
+    params="prefix parent *origin far:=^|8.0 near:=^|0.05">
     
-    <joint name="${prefix}_joint" type="fixed">
-      <axis xyz="0 1 0"/>
-      <xacro:insert_block name="origin"/>
-      <parent link="${parent}"/>
-      <child link="${prefix}_base_link"/>
+    <joint
+      name="${prefix}_joint"
+      type="fixed">
+      <axis xyz="0 1 0" />
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${prefix}_base_link" />
     </joint>
     
     <link name="${prefix}_base_link">
       <inertial>
-        <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
-        <mass value="0.1"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
+        <origin
+          xyz="0.0 0.0 0.0"
+          rpy="0 0 0" />
+        <mass value="0.1" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <inertia
+          ixx="0.1"
+          ixy="0"
+          ixz="0"
+          iyy="0.1"
+          iyz="0"
+          izz="0.1" />
       </inertial>
       <!--visual>
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
@@ -38,21 +64,39 @@
       </collision-->
     </link>
     
-    <joint name="pan" type="revolute">
-      <axis xyz="0 0 1"/>
-      <origin xyz="0.0 0.0 0.0" rpy="0 0 -1.134"/>
+    <joint
+      name="pan"
+      type="revolute">
+      <axis xyz="0 0 1" />
+      <origin
+        xyz="0.0 0.0 0.0"
+        rpy="0 0 -1.134" />
       <!-- check the displacement -->
-      <parent link="${prefix}_base_link"/>
-      <child link="pan_link"/>
-      <limit effort="${ptz_joint_effort_limit}" velocity="${ptz_joint_velocity_limit}" lower="-3.1415" upper="3.1415"/>
-      <joint_properties damping="${ptz_joint_damping}" friction="{ptz_joint_friction}"/>
+      <parent link="${prefix}_base_link" />
+      <child link="pan_link" />
+      <limit
+        effort="${ptz_joint_effort_limit}"
+        velocity="${ptz_joint_velocity_limit}"
+        lower="-3.1415"
+        upper="3.1415" />
+      <joint_properties
+        damping="${ptz_joint_damping}"
+        friction="{ptz_joint_friction}" />
     </joint>
     
     <link name="pan_link">
       <inertial>
-        <mass value="0.1"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
+        <mass value="0.1" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <inertia
+          ixx="0.1"
+          ixy="0"
+          ixz="0"
+          iyy="0.1"
+          iyz="0"
+          izz="0.1" />
       </inertial>
     </link>
 
@@ -67,20 +111,36 @@
       </actuator>
     </transmission>
     
-    <joint name="tilt" type="revolute">
-      <axis xyz="0 1 0"/>
-      <origin xyz="0.0 0.0 0.049"/>
-      <parent link="pan_link"/>
-      <child link="tilt_link"/>
-      <limit effort="${ptz_joint_effort_limit}" velocity="${ptz_joint_velocity_limit}" lower="-1.5708" upper="1.5708"/>
-      <joint_properties damping="${ptz_joint_damping}" friction="{ptz_joint_friction}"/>
+    <joint
+      name="tilt"
+      type="revolute">
+      <axis xyz="0 1 0" />
+      <origin xyz="0.0 0.0 0.049" />
+      <parent link="pan_link" />
+      <child link="tilt_link" />
+      <limit
+        effort="${ptz_joint_effort_limit}"
+        velocity="${ptz_joint_velocity_limit}"
+        lower="-1.5708"
+        upper="1.5708" />
+      <joint_properties
+        damping="${ptz_joint_damping}"
+        friction="{ptz_joint_friction}" />
     </joint>
     
     <link name="tilt_link">
       <inertial>
-        <mass value="0.1"/>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
+        <mass value="0.1" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <inertia
+          ixx="0.1"
+          ixy="0"
+          ixz="0"
+          iyy="0.1"
+          iyz="0"
+          izz="0.1" />
       </inertial>
     </link>
     

--- a/robotnik_sensors/urdf/deprecated/pointgrey_bumblebee2.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/pointgrey_bumblebee2.urdf.xacro
@@ -1,10 +1,8 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="stereo_camera"
     params="prefix fps baseline hfov width height format near far">
-
     <gazebo reference="${prefix}_frame">
       <sensor
         type="multicamera"
@@ -52,7 +50,9 @@
           <alwaysOn>true</alwaysOn>
           <cameraName>${prefix}</cameraName>
           <imageTopicName>image_raw</imageTopicName>
-          <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+          <cameraInfoTopicName>
+            camera_info
+          </cameraInfoTopicName>
           <frameName>/${prefix}_frame</frameName>
           <hackBaseline>${baseline}</hackBaseline>
           <!-- NOTE: Distortion is currently unused -->
@@ -70,7 +70,6 @@
   <xacro:macro
     name="pointgrey_bumblebee2"
     params="prefix:=bumblebee hfov format:=R8G8B8 near:=0.5 far:=300 high_res:=false">
-
     <link name="${prefix}_base_link">
       <visual>
         <origin
@@ -102,8 +101,7 @@
       </inertial>
     </link>
 
-    <link name="${prefix}_optical_frame">
-    </link>
+    <link name="${prefix}_optical_frame" />
 
     <joint
       name="${frame}_optical_joint"

--- a/robotnik_sensors/urdf/deprecated/pointgrey_bumblebee2.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/pointgrey_bumblebee2.urdf.xacro
@@ -1,11 +1,14 @@
-<?xml version="1.0"?>
+<?xml version="1.0" ?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="stereo_camera"
+  <xacro:macro
+    name="stereo_camera"
     params="prefix fps baseline hfov width height format near far">
 
     <gazebo reference="${prefix}_frame">
-      <sensor type="multicamera" name="stereo_camera">
+      <sensor
+        type="multicamera"
+        name="stereo_camera">
         <update_rate>${fps}</update_rate>
         <camera name="left">
           <pose>0 0 0 0 -1.5707 1.5707</pose>
@@ -43,7 +46,9 @@
             <stddev>0.007</stddev>
           </noise>
         </camera>
-        <plugin name="stereo_camera_controller" filename="libgazebo_ros_multicamera.so">
+        <plugin
+          name="stereo_camera_controller"
+          filename="libgazebo_ros_multicamera.so">
           <alwaysOn>true</alwaysOn>
           <cameraName>${prefix}</cameraName>
           <imageTopicName>image_raw</imageTopicName>
@@ -62,34 +67,50 @@
     </gazebo>
   </xacro:macro>
 
-  <xacro:macro name="pointgrey_bumblebee2"
+  <xacro:macro
+    name="pointgrey_bumblebee2"
     params="prefix:=bumblebee hfov format:=R8G8B8 near:=0.5 far:=300 high_res:=false">
 
     <link name="${prefix}_base_link">
       <visual>
-        <origin xyz="0 0 0" rpy="-1.5707 0 -1.5707"/>
+        <origin
+          xyz="0 0 0"
+          rpy="-1.5707 0 -1.5707" />
         <geometry>
-          <mesh filename="package://pointgrey_camera_description/meshes/pointgrey_bumblebee2.dae"/>
+          <mesh
+            filename="package://pointgrey_camera_description/meshes/pointgrey_bumblebee2.dae" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <box size="0.04740 0.157 0.036"/>
+          <box size="0.04740 0.157 0.036" />
         </geometry>
       </collision>
       <inertial>
-        <origin xyz="-0.0 0.0 0.0" rpy="0 0 0" />
+        <origin
+          xyz="-0.0 0.0 0.0"
+          rpy="0 0 0" />
         <mass value="2.0" />
-        <xacro:solid_cuboid_inertia m="2.0" w="0.0474" h="0.157" d="0.036" />
+        <xacro:solid_cuboid_inertia
+          m="2.0"
+          w="0.0474"
+          h="0.157"
+          d="0.036" />
       </inertial>
     </link>
 
     <link name="${prefix}_optical_frame">
     </link>
 
-    <joint name="${frame}_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="-1.570796 0 -1.570796" />
+    <joint
+      name="${frame}_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="-1.570796 0 -1.570796" />
       <parent link="${prefix}_base_link" />
       <child link="${prefix}_optical_frame" />
     </joint>
@@ -105,7 +126,7 @@
         height="768"
         format="${format}"
         near="${near}"
-        far="${far}"/>
+        far="${far}" />
     </xacro:if>
 
     <xacro:unless value="${high_res}">
@@ -119,31 +140,58 @@
         height="480"
         format="${format}"
         near="${near}"
-        far="${far}"/>
+        far="${far}" />
     </xacro:unless>
   </xacro:macro>
 
-  <xacro:macro name="BB2-03S2C-25" params="prefix:=bumblebee" >
-    <pointgrey_bumblebee2 prefix="${prefix}" hfov="1.69296937443" />
+  <xacro:macro
+    name="BB2-03S2C-25"
+    params="prefix:=bumblebee">
+    <pointgrey_bumblebee2
+      prefix="${prefix}"
+      hfov="1.69296937443" />
   </xacro:macro>
 
-  <xacro:macro name="BB2-03S2C-38" params="prefix:=bumblebee" >
-    <pointgrey_bumblebee2 prefix="${prefix}" hfov="1.15191730632" />
+  <xacro:macro
+    name="BB2-03S2C-38"
+    params="prefix:=bumblebee">
+    <pointgrey_bumblebee2
+      prefix="${prefix}"
+      hfov="1.15191730632" />
   </xacro:macro>
 
-  <xacro:macro name="BB2-03S2C-60" params="prefix=bumblebee" >
-    <pointgrey_bumblebee2 prefix="${prefix}" hfov="0.75049157835" />
+  <xacro:macro
+    name="BB2-03S2C-60"
+    params="prefix=bumblebee">
+    <pointgrey_bumblebee2
+      prefix="${prefix}"
+      hfov="0.75049157835" />
   </xacro:macro>
 
-  <xacro:macro name="BB2-08S2C-25" params="frame:=bumblebee name:=bumblebee" >
-    <pointgrey_bumblebee2 prefix="${prefix}" hfov="1.69296937443" high_res="true" />
+  <xacro:macro
+    name="BB2-08S2C-25"
+    params="frame:=bumblebee name:=bumblebee">
+    <pointgrey_bumblebee2
+      prefix="${prefix}"
+      hfov="1.69296937443"
+      high_res="true" />
   </xacro:macro>
 
-  <xacro:macro name="BB2-08S2C-38" params="frame:=bumblebee name:=bumblebee" >
-    <pointgrey_bumblebee2 prefix="${prefix}" hfov="1.15191730632" high_res="true" />
+  <xacro:macro
+    name="BB2-08S2C-38"
+    params="frame:=bumblebee name:=bumblebee">
+    <pointgrey_bumblebee2
+      prefix="${prefix}"
+      hfov="1.15191730632"
+      high_res="true" />
   </xacro:macro>
 
-  <xacro:macro name="BB2-08S2C-60" params="frame:=bumblebee name:=bumblebee" >
-    <pointgrey_bumblebee2 prefix="${prefix}" hfov="0.75049157835" high_res="true" />
+  <xacro:macro
+    name="BB2-08S2C-60"
+    params="frame:=bumblebee name:=bumblebee">
+    <pointgrey_bumblebee2
+      prefix="${prefix}"
+      hfov="0.75049157835"
+      high_res="true" />
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/deprecated/roboteq_mgs.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/roboteq_mgs.urdf.xacro
@@ -2,12 +2,10 @@
 <robot
   name="roboteq_mgs"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="roboteq_mgs"
     params="prefix parent *origin">
-
-		<joint
+    <joint
       name="${prefix}_base_joint"
       type="fixed">
       <xacro:insert_block name="origin" />
@@ -26,7 +24,5 @@
           d="0.025" />
       </inertial>
     </link>
-
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/roboteq_mgs.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/roboteq_mgs.urdf.xacro
@@ -1,11 +1,17 @@
-<?xml version="1.0"?>
-<robot name="roboteq_mgs" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="roboteq_mgs"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="roboteq_mgs" params="prefix parent *origin">
+  <xacro:macro
+    name="roboteq_mgs"
+    params="prefix parent *origin">
 
-		<joint name="${prefix}_base_joint" type="fixed">
+		<joint
+      name="${prefix}_base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${prefix}_base_link" />
     </joint>
 
@@ -13,7 +19,11 @@
       <inertial>
         <mass value="0.255" />
         <origin xyz="0 0 0" />
-        <xacro:solid_cuboid_inertia m="0.255" w="0.025" h="0.165" d="0.025" />
+        <xacro:solid_cuboid_inertia
+          m="0.255"
+          w="0.025"
+          h="0.165"
+          d="0.025" />
       </inertial>
     </link>
 

--- a/robotnik_sensors/urdf/deprecated/rplidar.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/rplidar.urdf.xacro
@@ -1,41 +1,61 @@
-<?xml version="1.0"?>
+<?xml version="1.0" ?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="sensor_rplidar" params="prefix parent prefix_topic:='front_laser' *origin min_angle:=3.14159 max_angle:=-3.14159 gpu:=^|false">
+  <xacro:macro
+    name="sensor_rplidar"
+    params="prefix parent prefix_topic:='front_laser' *origin min_angle:=3.14159 max_angle:=-3.14159 gpu:=^|false">
 
-    <joint name="${prefix}_laser_base_joint" type="fixed">
+    <joint
+      name="${prefix}_laser_base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${prefix}_laser_base_link"/>
+      <parent link="${parent}" />
+      <child link="${prefix}_laser_base_link" />
     </joint>
 
 
     <link name="${prefix}_laser_base_link">
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-         <mesh filename="package://robotnik_sensors/meshes/rplidar.dae"/>
+         <mesh
+            filename="package://robotnik_sensors/meshes/rplidar.dae" />
         </geometry>
       </collision>
 
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-            <mesh filename="package://robotnik_sensors/meshes/rplidar.dae"/>
+            <mesh
+            filename="package://robotnik_sensors/meshes/rplidar.dae" />
         </geometry>
       </visual>
 
       <inertial>
         <mass value="0.190" />
-        <origin xyz="0.01 0 0.028" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.190" w="0.09674" h="0.056" d="0.056" />
+        <origin
+          xyz="0.01 0 0.028"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.190"
+          w="0.09674"
+          h="0.056"
+          d="0.056" />
       </inertial>
     </link>
 
-    <joint name="${prefix}_laser_joint" type="fixed">
-      <origin xyz="0 0 0.0461" rpy="0 0 0"/>
-      <parent link="${prefix}_laser_base_link"/>
-      <child link="${prefix}_laser_link"/>
+    <joint
+      name="${prefix}_laser_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0.0461"
+        rpy="0 0 0" />
+      <parent link="${prefix}_laser_base_link" />
+      <child link="${prefix}_laser_link" />
     </joint>
 
 
@@ -43,7 +63,7 @@
     </link>
 
 
-    <xacro:sensor_rplidar_gazebo/>
+    <xacro:sensor_rplidar_gazebo />
 
   </xacro:macro>
 
@@ -51,14 +71,24 @@
   <xacro:macro name="${prefix}_sensor_rplidar_gazebo">
     <gazebo reference="${prefix}_laser_link">
 			<xacro:if value="${gpu}">
-        <xacro:property name="ray_type" value="gpu_ray" />
-        <xacro:property name="plugin_lib" value="libgazebo_ros_gpu_laser.so" />
+        <xacro:property
+          name="ray_type"
+          value="gpu_ray" />
+        <xacro:property
+          name="plugin_lib"
+          value="libgazebo_ros_gpu_laser.so" />
       </xacro:if>
       <xacro:unless value="${gpu}">
-        <xacro:property name="ray_type" value="ray" />
-        <xacro:property name="plugin_lib" value="libgazebo_ros_laser.so" />
+        <xacro:property
+          name="ray_type"
+          value="ray" />
+        <xacro:property
+          name="plugin_lib"
+          value="libgazebo_ros_laser.so" />
       </xacro:unless>
-			<sensor type="${ray_type}" name="${prefix}_rplidar_sensor">
+			<sensor
+        type="${ray_type}"
+        name="${prefix}_rplidar_sensor">
 				<pose>0 0 0 0 0 0</pose>
 				<visualize>false</visualize>
 				<update_rate>10</update_rate>
@@ -82,7 +112,9 @@
 						<stddev>0.01</stddev>
 					</noise>
 				</ray>
-				<plugin name="${prefix}_controller" filename="${plugin_lib}">
+				<plugin
+          name="${prefix}_controller"
+          filename="${plugin_lib}">
 					<topicName>${prefix_topic}/scan</topicName>
 					<frameName>/${prefix}_laser_link</frameName>
 				</plugin>

--- a/robotnik_sensors/urdf/deprecated/rplidar.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/rplidar.urdf.xacro
@@ -1,10 +1,8 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="sensor_rplidar"
     params="prefix parent prefix_topic:='front_laser' *origin min_angle:=3.14159 max_angle:=-3.14159 gpu:=^|false">
-
     <joint
       name="${prefix}_laser_base_joint"
       type="fixed">
@@ -13,14 +11,13 @@
       <child link="${prefix}_laser_base_link" />
     </joint>
 
-
     <link name="${prefix}_laser_base_link">
       <collision>
         <origin
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
-         <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/rplidar.dae" />
         </geometry>
       </collision>
@@ -30,7 +27,7 @@
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
-            <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/rplidar.dae" />
         </geometry>
       </visual>
@@ -58,19 +55,14 @@
       <child link="${prefix}_laser_link" />
     </joint>
 
-
-    <link name="${prefix}_laser_link">
-    </link>
-
+    <link name="${prefix}_laser_link" />
 
     <xacro:sensor_rplidar_gazebo />
-
   </xacro:macro>
-
 
   <xacro:macro name="${prefix}_sensor_rplidar_gazebo">
     <gazebo reference="${prefix}_laser_link">
-			<xacro:if value="${gpu}">
+      <xacro:if value="${gpu}">
         <xacro:property
           name="ray_type"
           value="gpu_ray" />
@@ -86,40 +78,39 @@
           name="plugin_lib"
           value="libgazebo_ros_laser.so" />
       </xacro:unless>
-			<sensor
+      <sensor
         type="${ray_type}"
         name="${prefix}_rplidar_sensor">
-				<pose>0 0 0 0 0 0</pose>
-				<visualize>false</visualize>
-				<update_rate>10</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>361</samples>
-							<resolution>1</resolution>
-							<min_angle>${min_angle}</min_angle>
-							<max_angle>${max_angle}</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.15</min>
-						<max>6.0</max>
-						<resolution>0.0174</resolution>
-					</range>
-					<noise>
-						<type>gaussian</type>
-						<mean>0.0</mean>
-						<stddev>0.01</stddev>
-					</noise>
-				</ray>
-				<plugin
+        <pose>0 0 0 0 0 0</pose>
+        <visualize>false</visualize>
+        <update_rate>10</update_rate>
+        <ray>
+          <scan>
+            <horizontal>
+              <samples>361</samples>
+              <resolution>1</resolution>
+              <min_angle>${min_angle}</min_angle>
+              <max_angle>${max_angle}</max_angle>
+            </horizontal>
+          </scan>
+          <range>
+            <min>0.15</min>
+            <max>6.0</max>
+            <resolution>0.0174</resolution>
+          </range>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </ray>
+        <plugin
           name="${prefix}_controller"
           filename="${plugin_lib}">
-					<topicName>${prefix_topic}/scan</topicName>
-					<frameName>/${prefix}_laser_link</frameName>
-				</plugin>
-			</sensor>
-	</gazebo>
+          <topicName>${prefix_topic}/scan</topicName>
+          <frameName>/${prefix}_laser_link</frameName>
+        </plugin>
+      </sensor>
+    </gazebo>
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/rplidar_a2.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/rplidar_a2.urdf.xacro
@@ -1,48 +1,68 @@
-<?xml version="1.0"?>
+<?xml version="1.0" ?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="sensor_rplidar_a2" params="prefix parent prefix_topic:='front_laser' *origin min_angle:=-3.14159 max_angle:=3.14159 gpu:=^|true">
+  <xacro:macro
+    name="sensor_rplidar_a2"
+    params="prefix parent prefix_topic:='front_laser' *origin min_angle:=-3.14159 max_angle:=3.14159 gpu:=^|true">
 
-    <joint name="${prefix}_base_joint" type="fixed">
+    <joint
+      name="${prefix}_base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${prefix}_base_link"/>
+      <parent link="${parent}" />
+      <child link="${prefix}_base_link" />
     </joint>
 
 
     <link name="${prefix}_base_link">
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-         <mesh filename="package://robotnik_sensors/meshes/rplidar_a2.dae"/>
+         <mesh
+            filename="package://robotnik_sensors/meshes/rplidar_a2.dae" />
         </geometry>
       </collision>
 
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-            <mesh filename="package://robotnik_sensors/meshes/rplidar_a2.dae"/>
+            <mesh
+            filename="package://robotnik_sensors/meshes/rplidar_a2.dae" />
         </geometry>
       </visual>
 
       <inertial>
         <mass value="0.190" />
-        <origin xyz="0 0 0.02040" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.190" w="0.07570" h="0.07570" d="0.04080" />
+        <origin
+          xyz="0 0 0.02040"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.190"
+          w="0.07570"
+          h="0.07570"
+          d="0.04080" />
       </inertial>
     </link>
 
 
-    <joint name="${prefix}_laser_joint" type="fixed">
-      <origin xyz="0 0 0.03086" rpy="0 0 3.1415"/>
-      <parent link="${prefix}_base_link"/>
-      <child link="${prefix}_link"/>
+    <joint
+      name="${prefix}_laser_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0.03086"
+        rpy="0 0 3.1415" />
+      <parent link="${prefix}_base_link" />
+      <child link="${prefix}_link" />
     </joint>
     <link name="${prefix}_link">
     </link>
 
 
-    <xacro:sensor_rplidar_a2_gazebo/>
+    <xacro:sensor_rplidar_a2_gazebo />
 
   </xacro:macro>
 
@@ -50,14 +70,24 @@
   <xacro:macro name="sensor_rplidar_a2_gazebo">
     <gazebo reference="${prefix}_link">
 			<xacro:if value="${gpu}">
-        <xacro:property name="ray_type" value="gpu_ray" />
-        <xacro:property name="plugin_lib" value="libgazebo_ros_gpu_laser.so" />
+        <xacro:property
+          name="ray_type"
+          value="gpu_ray" />
+        <xacro:property
+          name="plugin_lib"
+          value="libgazebo_ros_gpu_laser.so" />
       </xacro:if>
       <xacro:unless value="${gpu}">
-        <xacro:property name="ray_type" value="ray" />
-        <xacro:property name="plugin_lib" value="libgazebo_ros_laser.so" />
+        <xacro:property
+          name="ray_type"
+          value="ray" />
+        <xacro:property
+          name="plugin_lib"
+          value="libgazebo_ros_laser.so" />
       </xacro:unless>
-			<sensor type="${ray_type}" name="${prefix}_rplidar_a2_sensor">
+			<sensor
+        type="${ray_type}"
+        name="${prefix}_rplidar_a2_sensor">
 				<pose>0 0 0 0 0 0</pose>
 				<visualize>false</visualize>
 				<update_rate>10</update_rate>
@@ -81,7 +111,9 @@
 						<stddev>0.01</stddev>
 					</noise>
 				</ray>
-				<plugin name="${prefix}_controller" filename="${plugin_lib}">
+				<plugin
+          name="${prefix}_controller"
+          filename="${plugin_lib}">
 					<topicName>${prefix_topic}/scan</topicName>
 					<frameName>/${prefix}_link</frameName>
 				</plugin>

--- a/robotnik_sensors/urdf/deprecated/rplidar_a2.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/rplidar_a2.urdf.xacro
@@ -1,10 +1,8 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="sensor_rplidar_a2"
     params="prefix parent prefix_topic:='front_laser' *origin min_angle:=-3.14159 max_angle:=3.14159 gpu:=^|true">
-
     <joint
       name="${prefix}_base_joint"
       type="fixed">
@@ -13,14 +11,13 @@
       <child link="${prefix}_base_link" />
     </joint>
 
-
     <link name="${prefix}_base_link">
       <collision>
         <origin
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
-         <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/rplidar_a2.dae" />
         </geometry>
       </collision>
@@ -30,7 +27,7 @@
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
-            <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/rplidar_a2.dae" />
         </geometry>
       </visual>
@@ -48,7 +45,6 @@
       </inertial>
     </link>
 
-
     <joint
       name="${prefix}_laser_joint"
       type="fixed">
@@ -58,18 +54,14 @@
       <parent link="${prefix}_base_link" />
       <child link="${prefix}_link" />
     </joint>
-    <link name="${prefix}_link">
-    </link>
-
+    <link name="${prefix}_link" />
 
     <xacro:sensor_rplidar_a2_gazebo />
-
   </xacro:macro>
-
 
   <xacro:macro name="sensor_rplidar_a2_gazebo">
     <gazebo reference="${prefix}_link">
-			<xacro:if value="${gpu}">
+      <xacro:if value="${gpu}">
         <xacro:property
           name="ray_type"
           value="gpu_ray" />
@@ -85,40 +77,39 @@
           name="plugin_lib"
           value="libgazebo_ros_laser.so" />
       </xacro:unless>
-			<sensor
+      <sensor
         type="${ray_type}"
         name="${prefix}_rplidar_a2_sensor">
-				<pose>0 0 0 0 0 0</pose>
-				<visualize>false</visualize>
-				<update_rate>10</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>361</samples>
-							<resolution>0.9</resolution>
-							<min_angle>${min_angle}</min_angle>
-							<max_angle>${max_angle}</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.15</min>
-						<max>6.0</max>
-						<resolution>0.0174</resolution>
-					</range>
-					<noise>
-						<type>gaussian</type>
-						<mean>0.0</mean>
-						<stddev>0.01</stddev>
-					</noise>
-				</ray>
-				<plugin
+        <pose>0 0 0 0 0 0</pose>
+        <visualize>false</visualize>
+        <update_rate>10</update_rate>
+        <ray>
+          <scan>
+            <horizontal>
+              <samples>361</samples>
+              <resolution>0.9</resolution>
+              <min_angle>${min_angle}</min_angle>
+              <max_angle>${max_angle}</max_angle>
+            </horizontal>
+          </scan>
+          <range>
+            <min>0.15</min>
+            <max>6.0</max>
+            <resolution>0.0174</resolution>
+          </range>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </ray>
+        <plugin
           name="${prefix}_controller"
           filename="${plugin_lib}">
-					<topicName>${prefix_topic}/scan</topicName>
-					<frameName>/${prefix}_link</frameName>
-				</plugin>
-			</sensor>
-	</gazebo>
+          <topicName>${prefix_topic}/scan</topicName>
+          <frameName>/${prefix}_link</frameName>
+        </plugin>
+      </sensor>
+    </gazebo>
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/rslidar.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/rslidar.urdf.xacro
@@ -1,65 +1,103 @@
-<?xml version="1.0"?>
-<robot name="sensor_rslidar" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_rslidar"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:property name="M_PI" value="3.1415926535897931" />
-
-  <xacro:macro name="sensor_rslidar" params="prefix parent prefix_topic *origin range_min range_max hfov hres vfov vres fps gpu:=^|true">
+  <xacro:macro
+    name="sensor_rslidar"
+    params="prefix parent prefix_topic *origin range_min range_max hfov hres vfov vres fps gpu:=^|true">
 
     <material name="black_alu">
-      <color rgba="0.9 0.9 0.9 1"/>
+      <color rgba="0.9 0.9 0.9 1" />
     </material>
 
-    <joint name="${prefix}_base_joint" type="fixed">
+    <joint
+      name="${prefix}_base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${prefix}_base_link" />
     </joint>
 
     <link name="${prefix}_base_link">
       <visual>
       <!-- origin xyz="0 0 0" rpy="0 0 1.5708"/ -->
-      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/rslidar.stl" />
+          <mesh
+            filename="package://robotnik_sensors/meshes/rslidar.stl" />
         </geometry>
-        <material name="black_alu"/>
+        <material name="black_alu" />
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/rslidar.stl" />
+          <mesh
+            filename="package://robotnik_sensors/meshes/rslidar.stl" />
         </geometry>
       </collision>
       <inertial>
         <mass value="0.840" />
         <origin xyz="0 0 0.04135" />
-				<xacro:solid_cuboid_inertia m="0.840" w="0.109" h="0.109" d="0.0827" />
+				<xacro:solid_cuboid_inertia
+          m="0.840"
+          w="0.109"
+          h="0.109"
+          d="0.0827" />
       </inertial>
     </link>
 
-    <joint name="${prefix}_joint" type="fixed">
-      <parent link="${prefix}_base_link"/>
+    <joint
+      name="${prefix}_joint"
+      type="fixed">
+      <parent link="${prefix}_base_link" />
       <child link="${prefix}_link" />
-      <origin xyz="0.0 0 0.038" rpy="0 0 0"/>
+      <origin
+        xyz="0.0 0 0.038"
+        rpy="0 0 0" />
     </joint>
-    <link name="${prefix}_link"/>
+    <link name="${prefix}_link" />
 
-  <xacro:sensor_rslidar_gazebo range_min="${range_min}" range_max="${range_max}" hfov="${hfov}" hres="${hres}" vfov="${vfov}" vres="${vres}" fps="${fps}" gpu="${gpu}"/>
+  <xacro:sensor_rslidar_gazebo
+      range_min="${range_min}"
+      range_max="${range_max}"
+      hfov="${hfov}"
+      hres="${hres}"
+      vfov="${vfov}"
+      vres="${vres}"
+      fps="${fps}"
+      gpu="${gpu}" />
 
   </xacro:macro>
 
-  <xacro:macro name="sensor_rslidar_gazebo" params="range_min range_max hfov hres vfov vres fps gpu">
+  <xacro:macro
+    name="sensor_rslidar_gazebo"
+    params="range_min range_max hfov hres vfov vres fps gpu">
     <gazebo reference="${prefix}_link">
       <xacro:if value="${gpu}">
         <!-- Using GPU needs: https://github.com/RobotnikAutomation/velodyne_simulator -->
-        <xacro:property name="ray_type" value="gpu_ray" />
-        <xacro:property name="plugin_lib" value="libgazebo_ros_velodyne_gpu_laser.so" />
+        <xacro:property
+          name="ray_type"
+          value="gpu_ray" />
+        <xacro:property
+          name="plugin_lib"
+          value="libgazebo_ros_velodyne_gpu_laser.so" />
       </xacro:if>
       <xacro:unless value="${gpu}">
-        <xacro:property name="ray_type" value="ray" />
-        <xacro:property name="plugin_lib" value="libgazebo_ros_velodyne_laser.so" />
+        <xacro:property
+          name="ray_type"
+          value="ray" />
+        <xacro:property
+          name="plugin_lib"
+          value="libgazebo_ros_velodyne_laser.so" />
       </xacro:unless>
-        <sensor type="${ray_type}" name="${prefix}_sensor">
+        <sensor
+        type="${ray_type}"
+        name="${prefix}_sensor">
           <pose>0 0 0 0 0 0.0</pose>
           <visualize>false</visualize>
           <update_rate>${fps}</update_rate>
@@ -68,13 +106,13 @@
               <horizontal>
 				<!-- for a high quality simulation -->
                 <samples>${hfov/hres}</samples>
-                <min_angle>-${hfov/2.0*M_PI/180.0}</min_angle>
-                <max_angle>${hfov/2.0*M_PI/180.0}</max_angle>
+                <min_angle>-${radians(hfov)}</min_angle>
+                <max_angle>${radians(hfov)}</max_angle>
               </horizontal>
               <vertical>
                 <samples>${vfov/vres}</samples>
-                <min_angle>-${vfov/2.0*M_PI/180.0}</min_angle>
-                <max_angle>${vfov/2.0*M_PI/180.0}</max_angle>
+                <min_angle>-${radians(vfov)}</min_angle>
+                <max_angle>${radians(vfov)}</max_angle>
               </vertical>
             </scan>
             <range>
@@ -86,7 +124,9 @@
               <type>none</type>
             </noise>
           </ray>
-          <plugin name="${prefix}_controller" filename="${plugin_lib}">
+          <plugin
+          name="${prefix}_controller"
+          filename="${plugin_lib}">
             <topicName>${prefix_topic}/points</topicName>
             <frameName>/${prefix}_link</frameName>
             <gaussianNoise>0.008</gaussianNoise>
@@ -96,20 +136,59 @@
 
   </xacro:macro>
 
-  <xacro:macro name="sensor_rslidar_16" params="prefix parent prefix_topic:='lidar_3d' *origin gpu:=false">
-    <xacro:sensor_rslidar prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.4" range_max="150.0" hfov="360.0" hres="0.1" vfov="30.0" vres="2.0" fps="20.0" gpu="${gpu}" >
+  <xacro:macro
+    name="sensor_rslidar_16"
+    params="prefix parent prefix_topic:='lidar_3d' *origin gpu:=false">
+    <xacro:sensor_rslidar
+      prefix="${prefix}"
+      parent="${parent}"
+      prefix_topic="${prefix_topic}"
+      range_min="0.4"
+      range_max="150.0"
+      hfov="360.0"
+      hres="0.1"
+      vfov="30.0"
+      vres="2.0"
+      fps="20.0"
+      gpu="${gpu}">
       <xacro:insert_block name="origin" />
     </xacro:sensor_rslidar>
   </xacro:macro>
 
-  <xacro:macro name="sensor_rslidar_32" params="prefix parent prefix_topic:='lidar_3d' *origin gpu:=false">
-    <xacro:sensor_rslidar prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.4" range_max="200.0" hfov="360.0" hres="0.1" vfov="40.0" vres="0.33" fps="20.0" gpu="${gpu}" >
+  <xacro:macro
+    name="sensor_rslidar_32"
+    params="prefix parent prefix_topic:='lidar_3d' *origin gpu:=false">
+    <xacro:sensor_rslidar
+      prefix="${prefix}"
+      parent="${parent}"
+      prefix_topic="${prefix_topic}"
+      range_min="0.4"
+      range_max="200.0"
+      hfov="360.0"
+      hres="0.1"
+      vfov="40.0"
+      vres="0.33"
+      fps="20.0"
+      gpu="${gpu}">
       <xacro:insert_block name="origin" />
     </xacro:sensor_rslidar>
   </xacro:macro>
 
-  <xacro:macro name="sensor_rslidar_ruby" params="prefix parent prefix_topic:='lidar_3d' *origin gpu:=false">
-    <xacro:sensor_rslidar prefix="${prefix}" parent="${parent}" prefix_topic="${prefix_topic}" range_min="0.4" range_max="250.0" hfov="360.0" hres="0.1" vfov="40.0" vres="0.1" fps="20.0" gpu="${gpu}" >
+  <xacro:macro
+    name="sensor_rslidar_ruby"
+    params="prefix parent prefix_topic:='lidar_3d' *origin gpu:=false">
+    <xacro:sensor_rslidar
+      prefix="${prefix}"
+      parent="${parent}"
+      prefix_topic="${prefix_topic}"
+      range_min="0.4"
+      range_max="250.0"
+      hfov="360.0"
+      hres="0.1"
+      vfov="40.0"
+      vres="0.1"
+      fps="20.0"
+      gpu="${gpu}">
       <xacro:insert_block name="origin" />
     </xacro:sensor_rslidar>
   </xacro:macro>

--- a/robotnik_sensors/urdf/deprecated/rslidar.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/rslidar.urdf.xacro
@@ -2,11 +2,9 @@
 <robot
   name="sensor_rslidar"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="sensor_rslidar"
     params="prefix parent prefix_topic *origin range_min range_max hfov hres vfov vres fps gpu:=^|true">
-
     <material name="black_alu">
       <color rgba="0.9 0.9 0.9 1" />
     </material>
@@ -21,8 +19,8 @@
 
     <link name="${prefix}_base_link">
       <visual>
-      <!-- origin xyz="0 0 0" rpy="0 0 1.5708"/ -->
-      <origin
+        <!-- origin xyz="0 0 0" rpy="0 0 1.5708"/ -->
+        <origin
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
@@ -43,7 +41,7 @@
       <inertial>
         <mass value="0.840" />
         <origin xyz="0 0 0.04135" />
-				<xacro:solid_cuboid_inertia
+        <xacro:solid_cuboid_inertia
           m="0.840"
           w="0.109"
           h="0.109"
@@ -62,7 +60,7 @@
     </joint>
     <link name="${prefix}_link" />
 
-  <xacro:sensor_rslidar_gazebo
+    <xacro:sensor_rslidar_gazebo
       range_min="${range_min}"
       range_max="${range_max}"
       hfov="${hfov}"
@@ -71,7 +69,6 @@
       vres="${vres}"
       fps="${fps}"
       gpu="${gpu}" />
-
   </xacro:macro>
 
   <xacro:macro
@@ -95,45 +92,44 @@
           name="plugin_lib"
           value="libgazebo_ros_velodyne_laser.so" />
       </xacro:unless>
-        <sensor
+      <sensor
         type="${ray_type}"
         name="${prefix}_sensor">
-          <pose>0 0 0 0 0 0.0</pose>
-          <visualize>false</visualize>
-          <update_rate>${fps}</update_rate>
-          <ray>
-            <scan>
-              <horizontal>
-				<!-- for a high quality simulation -->
-                <samples>${hfov/hres}</samples>
-                <min_angle>-${radians(hfov)}</min_angle>
-                <max_angle>${radians(hfov)}</max_angle>
-              </horizontal>
-              <vertical>
-                <samples>${vfov/vres}</samples>
-                <min_angle>-${radians(vfov)}</min_angle>
-                <max_angle>${radians(vfov)}</max_angle>
-              </vertical>
-            </scan>
-            <range>
-              <min>${range_min}</min>
-              <max>${range_max}</max>
-              <resolution>0.01</resolution>
-            </range>
-            <noise>
-              <type>none</type>
-            </noise>
-          </ray>
-          <plugin
+        <pose>0 0 0 0 0 0.0</pose>
+        <visualize>false</visualize>
+        <update_rate>${fps}</update_rate>
+        <ray>
+          <scan>
+            <horizontal>
+              <!-- for a high quality simulation -->
+              <samples>${hfov/hres}</samples>
+              <min_angle>-${radians(hfov)}</min_angle>
+              <max_angle>${radians(hfov)}</max_angle>
+            </horizontal>
+            <vertical>
+              <samples>${vfov/vres}</samples>
+              <min_angle>-${radians(vfov)}</min_angle>
+              <max_angle>${radians(vfov)}</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>${range_min}</min>
+            <max>${range_max}</max>
+            <resolution>0.01</resolution>
+          </range>
+          <noise>
+            <type>none</type>
+          </noise>
+        </ray>
+        <plugin
           name="${prefix}_controller"
           filename="${plugin_lib}">
-            <topicName>${prefix_topic}/points</topicName>
-            <frameName>/${prefix}_link</frameName>
-            <gaussianNoise>0.008</gaussianNoise>
-          </plugin>
-        </sensor>
+          <topicName>${prefix_topic}/points</topicName>
+          <frameName>/${prefix}_link</frameName>
+          <gaussianNoise>0.008</gaussianNoise>
+        </plugin>
+      </sensor>
     </gazebo>
-
   </xacro:macro>
 
   <xacro:macro

--- a/robotnik_sensors/urdf/deprecated/rslidar_mems.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/rslidar_mems.urdf.xacro
@@ -2,11 +2,9 @@
 <robot
   name="sensor_benewake_ce30"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="sensor_rslidar_mems"
     params="prefix parent *origin">
-
     <material name="black_alu">
       <color rgba="0.9 0.9 0.9 1" />
     </material>
@@ -69,14 +67,12 @@
       range_min="1"
       range_max="180"
       gpu="false" />
-
   </xacro:macro>
 
   <xacro:macro
     name="sensor_rslidar_mems_gazebo"
     params="range_min range_max gpu">
     <gazebo reference="${prefix}_link">
-
       <xacro:if value="${gpu}">
         <!-- Using GPU needs: https://github.com/RobotnikAutomation/velodyne_simulator -->
         <xacro:property
@@ -98,45 +94,45 @@
       <sensor
         type="${ray_type}"
         name="${prefix}_sensor">
-          <pose>0 0 0 0 0 0</pose>
-          <visualize>false</visualize>
-          <update_rate>15</update_rate>
-          <ray>
-              <scan>
-                  <horizontal>
-                      <samples>100</samples>
-                      <resolution>1.0</resolution>
-                      <min_angle>-1.0472</min_angle>
-                      <max_angle>1.0472</max_angle>
-                  </horizontal>
-                  <vertical>
-                      <samples>100</samples>
-                      <resolution>1.0</resolution>
-                      <min_angle>-0.610865238</min_angle>
-                      <max_angle>1.83591184</max_angle>
-                  </vertical>
-              </scan>
-              <range>
-              <min>${range_min}</min>
-              <max>${range_max}</max>
-                  <resolution>0.0035</resolution>
-              </range>
-              <noise>
-                  <type>gaussian</type>
-                  <mean>0.0</mean>
-                  <stddev>0.01</stddev>
-              </noise>
-          </ray>
-          <plugin
+        <pose>0 0 0 0 0 0</pose>
+        <visualize>false</visualize>
+        <update_rate>15</update_rate>
+        <ray>
+          <scan>
+            <horizontal>
+              <samples>100</samples>
+              <resolution>1.0</resolution>
+              <min_angle>-1.0472</min_angle>
+              <max_angle>1.0472</max_angle>
+            </horizontal>
+            <vertical>
+              <samples>100</samples>
+              <resolution>1.0</resolution>
+              <min_angle>-0.610865238</min_angle>
+              <max_angle>1.83591184</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>${range_min}</min>
+            <max>${range_max}</max>
+            <resolution>0.0035</resolution>
+          </range>
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </ray>
+        <plugin
           name="${prefix}_controller"
           filename="${plugin_lib}">
-              <topicName>/robot/front_3d_laser/point_cloud</topicName>
-              <frameName>/${prefix}_link</frameName>
-              <ignoreTfPrefix>1</ignoreTfPrefix>
-
-          </plugin>
+          <topicName>
+            /robot/front_3d_laser/point_cloud
+          </topicName>
+          <frameName>/${prefix}_link</frameName>
+          <ignoreTfPrefix>1</ignoreTfPrefix>
+        </plugin>
       </sensor>
     </gazebo>
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/rslidar_mems.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/rslidar_mems.urdf.xacro
@@ -1,68 +1,103 @@
-<?xml version="1.0"?>
-<robot name="sensor_benewake_ce30" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_benewake_ce30"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:property name="M_PI" value="3.1415926535897931" />
-
-  <xacro:macro name="sensor_rslidar_mems" params="prefix parent *origin">
+  <xacro:macro
+    name="sensor_rslidar_mems"
+    params="prefix parent *origin">
 
     <material name="black_alu">
-      <color rgba="0.9 0.9 0.9 1"/>
+      <color rgba="0.9 0.9 0.9 1" />
     </material>
 
-    <joint name="${prefix}_base_joint" type="fixed">
+    <joint
+      name="${prefix}_base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${prefix}_base_link" />
     </joint>
 
     <link name="${prefix}_base_link">
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/rslidar_mems.stl" />
+          <mesh
+            filename="package://robotnik_sensors/meshes/rslidar_mems.stl" />
           <!--box size="${sensor_length} ${sensor_width} ${sensor_height}"/-->
         </geometry>
-        <material name="black_alu"/>
+        <material name="black_alu" />
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/rslidar_mems.stl" />
+          <mesh
+            filename="package://robotnik_sensors/meshes/rslidar_mems.stl" />
         </geometry>
       </collision>
       <inertial>
         <mass value="0.8" />
-        <origin xyz="0 0 0.025" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.8" w="0.12" h="0.110" d="0.05" />
+        <origin
+          xyz="0 0 0.025"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.8"
+          w="0.12"
+          h="0.110"
+          d="0.05" />
       </inertial>
     </link>
 
-    <joint name="${prefix}_joint" type="fixed">
-      <origin xyz="0 0 0.03" rpy="0 0 0"/>
-      <parent link="${prefix}_base_link"/>
+    <joint
+      name="${prefix}_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0.03"
+        rpy="0 0 0" />
+      <parent link="${prefix}_base_link" />
       <child link="${prefix}_link" />
     </joint>
-    <link name="${prefix}_link"/>
+    <link name="${prefix}_link" />
 
     <!-- sensor for simulation -->
-    <xacro:sensor_rslidar_mems_gazebo range_min="1" range_max="180" gpu="false" />
+    <xacro:sensor_rslidar_mems_gazebo
+      range_min="1"
+      range_max="180"
+      gpu="false" />
 
   </xacro:macro>
 
-  <xacro:macro name="sensor_rslidar_mems_gazebo" params="range_min range_max gpu">
+  <xacro:macro
+    name="sensor_rslidar_mems_gazebo"
+    params="range_min range_max gpu">
     <gazebo reference="${prefix}_link">
 
       <xacro:if value="${gpu}">
         <!-- Using GPU needs: https://github.com/RobotnikAutomation/velodyne_simulator -->
-        <xacro:property name="ray_type" value="gpu_ray" />
-        <xacro:property name="plugin_lib" value="libgazebo_ros_velodyne_gpu_laser.so" />
+        <xacro:property
+          name="ray_type"
+          value="gpu_ray" />
+        <xacro:property
+          name="plugin_lib"
+          value="libgazebo_ros_velodyne_gpu_laser.so" />
       </xacro:if>
       <xacro:unless value="${gpu}">
-        <xacro:property name="ray_type" value="ray" />
-        <xacro:property name="plugin_lib" value="libgazebo_ros_velodyne_laser.so" />
+        <xacro:property
+          name="ray_type"
+          value="ray" />
+        <xacro:property
+          name="plugin_lib"
+          value="libgazebo_ros_velodyne_laser.so" />
       </xacro:unless>
 
-      <sensor type="${ray_type}" name="${prefix}_sensor">
+      <sensor
+        type="${ray_type}"
+        name="${prefix}_sensor">
           <pose>0 0 0 0 0 0</pose>
           <visualize>false</visualize>
           <update_rate>15</update_rate>
@@ -92,7 +127,9 @@
                   <stddev>0.01</stddev>
               </noise>
           </ray>
-          <plugin name="${prefix}_controller" filename="${plugin_lib}">
+          <plugin
+          name="${prefix}_controller"
+          filename="${plugin_lib}">
               <topicName>/robot/front_3d_laser/point_cloud</topicName>
               <frameName>/${prefix}_link</frameName>
               <ignoreTfPrefix>1</ignoreTfPrefix>

--- a/robotnik_sensors/urdf/deprecated/rubedos_viper.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/rubedos_viper.urdf.xacro
@@ -1,6 +1,5 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:property
     name="rubedos_viper_width"
     value="0.246" />
@@ -14,14 +13,13 @@
   <xacro:macro
     name="stereo_camera"
     params="prefix fps baseline hfov width height format near far">
-
     <gazebo reference="${prefix}_base_link">
       <sensor
         type="multicamera"
         name="stereo_camera">
         <update_rate>${fps}</update_rate>
         <camera name="left">
-          <pose>0 0 0 0 0 0 </pose>
+          <pose>0 0 0 0 0 0</pose>
           <horizontal_fov>${hfov}</horizontal_fov>
           <image>
             <width>${width}</width>
@@ -62,7 +60,9 @@
           <alwaysOn>true</alwaysOn>
           <cameraName>${prefix}</cameraName>
           <imageTopicName>image_raw</imageTopicName>
-          <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+          <cameraInfoTopicName>
+            camera_info
+          </cameraInfoTopicName>
           <frameName>/${prefix}_optical_frame</frameName>
           <hackBaseline>${baseline}</hackBaseline>
           <!-- NOTE: Distortion is currently unused -->
@@ -80,7 +80,6 @@
   <xacro:macro
     name="rubedos_viper"
     params="prefix:=bumblebee parent *origin format:=R8G8B8 near:=0.05 far:=300">
-
     <joint
       name="${prefix}_base_joint"
       type="fixed">
@@ -95,7 +94,7 @@
           xyz="0 0 0"
           rpy="0 0 0" />
         <geometry>
-          <!--box size="${rubedos_viper_depth} ${rubedos_viper_width} ${rubedos_viper_height}"/--> 
+          <!--box size="${rubedos_viper_depth} ${rubedos_viper_width} ${rubedos_viper_height}"/-->
           <mesh
             filename="package://robotnik_sensors/meshes/viper.dae" />
         </geometry>
@@ -145,7 +144,7 @@
       </inertial-->
     </link>
 
-      <xacro:stereo_camera
+    <xacro:stereo_camera
       prefix="${prefix}"
       hfov="1.2217"
       baseline="0.20"
@@ -166,5 +165,4 @@
       <xacro:insert_block name="origin" />
     </rubedos_viper>
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/rubedos_viper.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/rubedos_viper.urdf.xacro
@@ -1,15 +1,24 @@
-<?xml version="1.0"?>
+<?xml version="1.0" ?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:property name="rubedos_viper_width" value="0.246"/>
-  <xacro:property name="rubedos_viper_height" value="0.035"/>
-  <xacro:property name="rubedos_viper_depth" value="0.09"/>
+  <xacro:property
+    name="rubedos_viper_width"
+    value="0.246" />
+  <xacro:property
+    name="rubedos_viper_height"
+    value="0.035" />
+  <xacro:property
+    name="rubedos_viper_depth"
+    value="0.09" />
 
-  <xacro:macro name="stereo_camera"
+  <xacro:macro
+    name="stereo_camera"
     params="prefix fps baseline hfov width height format near far">
 
     <gazebo reference="${prefix}_base_link">
-      <sensor type="multicamera" name="stereo_camera">
+      <sensor
+        type="multicamera"
+        name="stereo_camera">
         <update_rate>${fps}</update_rate>
         <camera name="left">
           <pose>0 0 0 0 0 0 </pose>
@@ -47,7 +56,9 @@
             <stddev>0.007</stddev>
           </noise>
         </camera>
-        <plugin name="stereo_camera_controller" filename="libgazebo_ros_multicamera.so">
+        <plugin
+          name="stereo_camera_controller"
+          filename="libgazebo_ros_multicamera.so">
           <alwaysOn>true</alwaysOn>
           <cameraName>${prefix}</cameraName>
           <imageTopicName>image_raw</imageTopicName>
@@ -66,39 +77,60 @@
     </gazebo>
   </xacro:macro>
 
-  <xacro:macro name="rubedos_viper"
+  <xacro:macro
+    name="rubedos_viper"
     params="prefix:=bumblebee parent *origin format:=R8G8B8 near:=0.05 far:=300">
 
-    <joint name="${prefix}_base_joint" type="fixed">
+    <joint
+      name="${prefix}_base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${prefix}_base_link" />
     </joint>
 
     <link name="${prefix}_base_link">
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
           <!--box size="${rubedos_viper_depth} ${rubedos_viper_width} ${rubedos_viper_height}"/--> 
-          <mesh filename="package://robotnik_sensors/meshes/viper.dae"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/viper.dae" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <box size="${rubedos_viper_depth} ${rubedos_viper_width} ${rubedos_viper_height}"/>
+          <box
+            size="${rubedos_viper_depth} ${rubedos_viper_width} ${rubedos_viper_height}" />
         </geometry>
       </collision>
       <inertial>
-        <origin xyz="-0.0 0.0 0.0" rpy="0 0 0" />
+        <origin
+          xyz="-0.0 0.0 0.0"
+          rpy="0 0 0" />
         <mass value="0.8" />
-        <xacro:solid_cuboid_inertia m="0.8" w="0.0574" h="0.187" d="0.036" />
+        <xacro:solid_cuboid_inertia
+          m="0.8"
+          w="0.0574"
+          h="0.187"
+          d="0.036" />
       </inertial>
     </link>
 
-    <joint name="${prefix}_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="-1.570796 0 -1.570796" />
-      <origin xyz="0 0 0" rpy="0 0 0" />
+    <joint
+      name="${prefix}_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="-1.570796 0 -1.570796" />
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
       <parent link="${prefix}_base_link" />
       <child link="${prefix}_optical_frame" />
     </joint>
@@ -114,19 +146,23 @@
     </link>
 
       <xacro:stereo_camera
-        prefix="${prefix}"
-        hfov="1.2217"
-        baseline="0.20"
-        fps="60"
-        width="2304"
-        height="1535"
-        format="${format}"
-        near="${near}"
-        far="${far}"/>
+      prefix="${prefix}"
+      hfov="1.2217"
+      baseline="0.20"
+      fps="60"
+      width="2304"
+      height="1535"
+      format="${format}"
+      near="${near}"
+      far="${far}" />
   </xacro:macro>
 
-  <xacro:macro name="sensor_rubedos_viper" params="prefix:=myviper parent *origin" >
-    <rubedos_viper prefix="${prefix}" parent="${parent}">
+  <xacro:macro
+    name="sensor_rubedos_viper"
+    params="prefix:=myviper parent *origin">
+    <rubedos_viper
+      prefix="${prefix}"
+      parent="${parent}">
       <xacro:insert_block name="origin" />
     </rubedos_viper>
   </xacro:macro>

--- a/robotnik_sensors/urdf/deprecated/sick_mls.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/sick_mls.urdf.xacro
@@ -1,11 +1,17 @@
-<?xml version="1.0"?>
-<robot name="sick_mls" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sick_mls"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="sick_mls" params="prefix parent *origin">
+  <xacro:macro
+    name="sick_mls"
+    params="prefix parent *origin">
 
-		<joint name="${prefix}_base_joint" type="fixed">
+		<joint
+      name="${prefix}_base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${prefix}_base_link" />
     </joint>
 
@@ -13,7 +19,13 @@
       <inertial>
         <mass value="0.5" />
         <origin xyz="0 0 0" />
-        <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
+        <inertia
+          ixx="0.1"
+          ixy="0"
+          ixz="0"
+          iyy="0.1"
+          iyz="0"
+          izz="0.1" />
       </inertial>
     </link>
 

--- a/robotnik_sensors/urdf/deprecated/sick_mls.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/sick_mls.urdf.xacro
@@ -2,12 +2,10 @@
 <robot
   name="sick_mls"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="sick_mls"
     params="prefix parent *origin">
-
-		<joint
+    <joint
       name="${prefix}_base_joint"
       type="fixed">
       <xacro:insert_block name="origin" />
@@ -28,7 +26,5 @@
           izz="0.1" />
       </inertial>
     </link>
-
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/teraranger_tr_duo.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/teraranger_tr_duo.urdf.xacro
@@ -2,52 +2,50 @@
 <robot
   name="sensor_teraranger_duo"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="sensor_teraranger_duo"
     params="prefix parent prefix_topic:='teraranger_duo' *origin min_angle:=-0.02618 max_angle:=0.02618">
-
     <joint
       name="${prefix}_base_joint"
       type="fixed">
       <xacro:insert_block name="origin" />
       <parent link="${parent}" />
       <child link="${prefix}_base_link" />
-	</joint>
+    </joint>
 
-	<link name="${prefix}_base_link">
-		<collision>
-			<origin
+    <link name="${prefix}_base_link">
+      <collision>
+        <origin
           xyz="0 0 0"
           rpy="0 0 0" />
-			<geometry>
-	     		<mesh
+        <geometry>
+          <mesh
             filename="package://robotnik_sensors/meshes/teraranger_tr_duo.dae" />
-			</geometry>
-		</collision>
+        </geometry>
+      </collision>
 
-		<visual>
-			<origin
+      <visual>
+        <origin
           xyz="0 0 0"
           rpy="0 0 0" />
-			<geometry>
-	     		<mesh
+        <geometry>
+          <mesh
             filename="package://robotnik_sensors/meshes/teraranger_tr_duo.dae" />
-			</geometry>
-		</visual>
+        </geometry>
+      </visual>
 
-		<inertial>
-			<mass value="0.016" />
-			<origin
+      <inertial>
+        <mass value="0.016" />
+        <origin
           xyz="0.01 0 0"
           rpy="0 0 0" />
-	        <xacro:solid_cuboid_inertia
+        <xacro:solid_cuboid_inertia
           m="0.016"
           w="0.02"
           h="0.03"
           d="0.053" />
-		</inertial>
-	</link>
+      </inertial>
+    </link>
 
     <joint
       name="${prefix}_sonar_joint"
@@ -57,9 +55,9 @@
       <origin
         xyz="0.02 0 0.012"
         rpy="0 0 0" />
-	</joint>
+    </joint>
 
-	<joint
+    <joint
       name="${prefix}_laser_joint"
       type="fixed">
       <parent link="${prefix}_base_link" />
@@ -67,94 +65,92 @@
       <origin
         xyz="0.02 0 -0.015"
         rpy="0 0 0" />
-	</joint>
+    </joint>
 
-	<link name="${prefix}_sonar_link">
-	</link>
-	<link name="${prefix}_laser_link">
-    </link>
-	<!-- TODO add Gazebo stuff for simulation-->
+    <link name="${prefix}_sonar_link" />
+    <link name="${prefix}_laser_link" />
+    <!-- TODO add Gazebo stuff for simulation-->
 
-	<gazebo reference="${prefix}_sonar_link">
-		<material>Gazebo/Yellow</material>
-      	<sensor
+    <gazebo reference="${prefix}_sonar_link">
+      <material>Gazebo/Yellow</material>
+      <sensor
         type="ray"
         name="${prefix}_sensor">
-			<visualize>false</visualize>
-			<update_rate>100</update_rate>
-			<ray>
-				<scan>
-					<horizontal>
-						<samples>10</samples>
-						<resolution>1</resolution>
-						<min_angle>-0.02618</min_angle>
-						<max_angle>0.02618</max_angle>
-					</horizontal>
-					<vertical>
-						<samples>10</samples>
-						<resolution>1</resolution>
-						<min_angle>-0.02618</min_angle>
-						<max_angle>0.02618</max_angle>
-					</vertical>
-				</scan>
-				<range>
-					<min>0.02</min>
-					<max>14</max>
-					<resolution>0.05</resolution>
-				</range>
-			</ray>
-			<plugin
+        <visualize>false</visualize>
+        <update_rate>100</update_rate>
+        <ray>
+          <scan>
+            <horizontal>
+              <samples>10</samples>
+              <resolution>1</resolution>
+              <min_angle>-0.02618</min_angle>
+              <max_angle>0.02618</max_angle>
+            </horizontal>
+            <vertical>
+              <samples>10</samples>
+              <resolution>1</resolution>
+              <min_angle>-0.02618</min_angle>
+              <max_angle>0.02618</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>0.02</min>
+            <max>14</max>
+            <resolution>0.05</resolution>
+          </range>
+        </ray>
+        <plugin
           name="${prefix}_sonar_controller"
           filename="libgazebo_ros_range.so">
-				<topicName>${prefix_topic}/sonar</topicName>
-				<frameName>${prefix}_laser_link</frameName>
-				<gaussianNoise>0</gaussianNoise>
-				<updateRate>20</updateRate>
-				<radiation>ultrasound</radiation>
-				<fov>0.05</fov>
-			</plugin>
-		</sensor>
-	</gazebo>
+          <topicName>${prefix_topic}/sonar</topicName>
+          <frameName>${prefix}_laser_link</frameName>
+          <gaussianNoise>0</gaussianNoise>
+          <updateRate>20</updateRate>
+          <radiation>ultrasound</radiation>
+          <fov>0.05</fov>
+        </plugin>
+      </sensor>
+    </gazebo>
 
-	<gazebo reference="${prefix}_laser_link">
-		<material>Gazebo/Yellow</material>
-      	<sensor
+    <gazebo reference="${prefix}_laser_link">
+      <material>Gazebo/Yellow</material>
+      <sensor
         type="ray"
         name="${prefix}_sensor">
-			<visualize>false</visualize>
-			<update_rate>100</update_rate>
-			<ray>
-				<scan>
-					<horizontal>
-						<samples>10</samples>
-						<resolution>1</resolution>
-						<min_angle>-0.02618</min_angle>
-						<max_angle>0.02618</max_angle>
-					</horizontal>
-					<vertical>
-						<samples>10</samples>
-						<resolution>1</resolution>
-						<min_angle>-0.02618</min_angle>
-						<max_angle>0.02618</max_angle>
-					</vertical>
-				</scan>
-				<range>
-					<min>0.02</min>
-					<max>14</max>
-					<resolution>0.05</resolution>
-				</range>
-			</ray>
-			<plugin
+        <visualize>false</visualize>
+        <update_rate>100</update_rate>
+        <ray>
+          <scan>
+            <horizontal>
+              <samples>10</samples>
+              <resolution>1</resolution>
+              <min_angle>-0.02618</min_angle>
+              <max_angle>0.02618</max_angle>
+            </horizontal>
+            <vertical>
+              <samples>10</samples>
+              <resolution>1</resolution>
+              <min_angle>-0.02618</min_angle>
+              <max_angle>0.02618</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>0.02</min>
+            <max>14</max>
+            <resolution>0.05</resolution>
+          </range>
+        </ray>
+        <plugin
           name="${prefix}_range_controller"
           filename="libgazebo_ros_range.so">
-				<topicName>${prefix_topic}/scan</topicName>
-				<frameName>${prefix}_laser_link</frameName>
-				<gaussianNoise>0</gaussianNoise>
-				<updateRate>20</updateRate>
-				<radiation>infrared</radiation>
-				<fov>0.05</fov>
-			</plugin>
-		</sensor>
-	</gazebo>
+          <topicName>${prefix_topic}/scan</topicName>
+          <frameName>${prefix}_laser_link</frameName>
+          <gaussianNoise>0</gaussianNoise>
+          <updateRate>20</updateRate>
+          <radiation>infrared</radiation>
+          <fov>0.05</fov>
+        </plugin>
+      </sensor>
+    </gazebo>
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/deprecated/teraranger_tr_duo.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/teraranger_tr_duo.urdf.xacro
@@ -1,46 +1,72 @@
-<?xml version="1.0"?>
-<robot name="sensor_teraranger_duo" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_teraranger_duo"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="sensor_teraranger_duo" params="prefix parent prefix_topic:='teraranger_duo' *origin min_angle:=-0.02618 max_angle:=0.02618">
+  <xacro:macro
+    name="sensor_teraranger_duo"
+    params="prefix parent prefix_topic:='teraranger_duo' *origin min_angle:=-0.02618 max_angle:=0.02618">
 
-    <joint name="${prefix}_base_joint" type="fixed">
+    <joint
+      name="${prefix}_base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${prefix}_base_link"/>
+      <parent link="${parent}" />
+      <child link="${prefix}_base_link" />
 	</joint>
 
 	<link name="${prefix}_base_link">
 		<collision>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
+			<origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
 			<geometry>
-	     		<mesh filename="package://robotnik_sensors/meshes/teraranger_tr_duo.dae"/>
+	     		<mesh
+            filename="package://robotnik_sensors/meshes/teraranger_tr_duo.dae" />
 			</geometry>
 		</collision>
 
 		<visual>
-			<origin xyz="0 0 0" rpy="0 0 0"/>
+			<origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
 			<geometry>
-	     		<mesh filename="package://robotnik_sensors/meshes/teraranger_tr_duo.dae"/>
+	     		<mesh
+            filename="package://robotnik_sensors/meshes/teraranger_tr_duo.dae" />
 			</geometry>
 		</visual>
 
 		<inertial>
 			<mass value="0.016" />
-			<origin xyz="0.01 0 0" rpy="0 0 0"/>
-	        <xacro:solid_cuboid_inertia m="0.016" w="0.02" h="0.03" d="0.053" />
+			<origin
+          xyz="0.01 0 0"
+          rpy="0 0 0" />
+	        <xacro:solid_cuboid_inertia
+          m="0.016"
+          w="0.02"
+          h="0.03"
+          d="0.053" />
 		</inertial>
 	</link>
 
-    <joint name="${prefix}_sonar_joint" type="fixed">
-      <parent link="${prefix}_base_link"/>
-      <child link="${prefix}_sonar_link"/>
-      <origin xyz="0.02 0 0.012" rpy="0 0 0"/>
+    <joint
+      name="${prefix}_sonar_joint"
+      type="fixed">
+      <parent link="${prefix}_base_link" />
+      <child link="${prefix}_sonar_link" />
+      <origin
+        xyz="0.02 0 0.012"
+        rpy="0 0 0" />
 	</joint>
 
-	<joint name="${prefix}_laser_joint" type="fixed">
-      <parent link="${prefix}_base_link"/>
-      <child link="${prefix}_laser_link"/>
-      <origin xyz="0.02 0 -0.015" rpy="0 0 0"/>
+	<joint
+      name="${prefix}_laser_joint"
+      type="fixed">
+      <parent link="${prefix}_base_link" />
+      <child link="${prefix}_laser_link" />
+      <origin
+        xyz="0.02 0 -0.015"
+        rpy="0 0 0" />
 	</joint>
 
 	<link name="${prefix}_sonar_link">
@@ -51,7 +77,9 @@
 
 	<gazebo reference="${prefix}_sonar_link">
 		<material>Gazebo/Yellow</material>
-      	<sensor type="ray" name="${prefix}_sensor">
+      	<sensor
+        type="ray"
+        name="${prefix}_sensor">
 			<visualize>false</visualize>
 			<update_rate>100</update_rate>
 			<ray>
@@ -75,7 +103,9 @@
 					<resolution>0.05</resolution>
 				</range>
 			</ray>
-			<plugin name="${prefix}_sonar_controller" filename="libgazebo_ros_range.so">
+			<plugin
+          name="${prefix}_sonar_controller"
+          filename="libgazebo_ros_range.so">
 				<topicName>${prefix_topic}/sonar</topicName>
 				<frameName>${prefix}_laser_link</frameName>
 				<gaussianNoise>0</gaussianNoise>
@@ -88,7 +118,9 @@
 
 	<gazebo reference="${prefix}_laser_link">
 		<material>Gazebo/Yellow</material>
-      	<sensor type="ray" name="${prefix}_sensor">
+      	<sensor
+        type="ray"
+        name="${prefix}_sensor">
 			<visualize>false</visualize>
 			<update_rate>100</update_rate>
 			<ray>
@@ -112,7 +144,9 @@
 					<resolution>0.05</resolution>
 				</range>
 			</ray>
-			<plugin name="${prefix}_range_controller" filename="libgazebo_ros_range.so">
+			<plugin
+          name="${prefix}_range_controller"
+          filename="libgazebo_ros_range.so">
 				<topicName>${prefix_topic}/scan</topicName>
 				<frameName>${prefix}_laser_link</frameName>
 				<gaussianNoise>0</gaussianNoise>

--- a/robotnik_sensors/urdf/deprecated/ueye_cp_gige.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/ueye_cp_gige.urdf.xacro
@@ -1,6 +1,5 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="sensor_ueye_cp_gige"
     params="prefix parent *origin">
@@ -87,15 +86,15 @@
       <child link="${prefix}_rgb_optical_frame_link" />
     </joint>
     <link name="${prefix}_rgb_optical_frame_link">
-    <inertial>
-      <mass value="0.0001" />
+      <inertial>
+        <mass value="0.0001" />
         <origin xyz="0 0 0" />
         <xacro:solid_cuboid_inertia
           m="0.0001"
           w="0.0604"
           h="0.029"
           d="0.029" />
-    </inertial>
+      </inertial>
     </link>
     <sensor_ueye_cp_gige_gazebo />
   </xacro:macro>
@@ -130,7 +129,9 @@
           <updateRate>0.0</updateRate>
           <cameraName>${prefix}</cameraName>
           <imageTopicName>image_raw</imageTopicName>
-          <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+          <cameraInfoTopicName>
+            camera_info
+          </cameraInfoTopicName>
           <frameName>/${prefix}_rgb_frame_link</frameName>
           <distortionK1>0.0</distortionK1>
           <distortionK2>0.0</distortionK2>

--- a/robotnik_sensors/urdf/deprecated/ueye_cp_gige.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/ueye_cp_gige.urdf.xacro
@@ -1,60 +1,100 @@
-<?xml version="1.0"?>
+<?xml version="1.0" ?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="sensor_ueye_cp_gige" params="prefix parent *origin">
-    <joint name="${prefix}_joint" type="fixed">
-      <insert_block name="origin"/>
-      <parent link="${parent}"/>
-      <child link="${prefix}_base_link"/>
+  <xacro:macro
+    name="sensor_ueye_cp_gige"
+    params="prefix parent *origin">
+    <joint
+      name="${prefix}_joint"
+      type="fixed">
+      <insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${prefix}_base_link" />
     </joint>
     <link name="${prefix}_base_link">
       <inertial>
-        <mass value="0.0088"/>
-        <origin xyz="0.007 0 0.0145" rpy="0 0 0"/>
-        <xacro:solid_cuboid_inertia m="0.0088" w="0.0604" h="0.029" d="0.029" />
-        <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
+        <mass value="0.0088" />
+        <origin
+          xyz="0.007 0 0.0145"
+          rpy="0 0 0" />
+        <xacro:solid_cuboid_inertia
+          m="0.0088"
+          w="0.0604"
+          h="0.029"
+          d="0.029" />
+        <inertia
+          ixx="0.1"
+          ixy="0"
+          ixz="0"
+          iyy="0.1"
+          iyz="0"
+          izz="0.1" />
       </inertial>
       <visual>
-        <origin xyz="0.0 0.0 0." rpy="0 0 0"/>
+        <origin
+          xyz="0.0 0.0 0."
+          rpy="0 0 0" />
         <!-- to center the axis model -->
         <material name="axis_color">
-          <color rgba="0.1 0.1 0.1 1"/>
+          <color rgba="0.1 0.1 0.1 1" />
         </material>
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/ueye_cp_gige.stl" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/ueye_cp_gige.stl"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0.00 0.0 0.0" rpy="0 0 0"/>
+        <origin
+          xyz="0.00 0.0 0.0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/ueye_cp_gige.stl" scale="1.0 1.0 1.0"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/ueye_cp_gige.stl"
+            scale="1.0 1.0 1.0" />
         </geometry>
       </collision>
     </link>
 
-    <joint name="${prefix}_rgb_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <parent link="${prefix}_base_link"/>
-      <child link="${prefix}_rgb_frame_link"/>
+    <joint
+      name="${prefix}_rgb_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <parent link="${prefix}_base_link" />
+      <child link="${prefix}_rgb_frame_link" />
     </joint>
     <link name="${prefix}_rgb_frame_link">
       <inertial>
         <mass value="0.0001" />
         <origin xyz="0 0 0" />
-        <xacro:solid_cuboid_inertia m="0.0001" w="0.0604" h="0.029" d="0.029" />
+        <xacro:solid_cuboid_inertia
+          m="0.0001"
+          w="0.0604"
+          h="0.029"
+          d="0.029" />
       </inertial>
     </link>
 
-    <joint name="${prefix}_rgb_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <parent link="${prefix}_rgb_frame_link"/>
-      <child link="${prefix}_rgb_optical_frame_link"/>
+    <joint
+      name="${prefix}_rgb_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+      <parent link="${prefix}_rgb_frame_link" />
+      <child link="${prefix}_rgb_optical_frame_link" />
     </joint>
     <link name="${prefix}_rgb_optical_frame_link">
     <inertial>
       <mass value="0.0001" />
         <origin xyz="0 0 0" />
-        <xacro:solid_cuboid_inertia m="0.0001" w="0.0604" h="0.029" d="0.029" />
+        <xacro:solid_cuboid_inertia
+          m="0.0001"
+          w="0.0604"
+          h="0.029"
+          d="0.029" />
     </inertial>
     </link>
     <sensor_ueye_cp_gige_gazebo />
@@ -62,7 +102,9 @@
 
   <xacro:macro name="sensor_ueye_cp_gige_gazebo">
     <gazebo reference="${prefix}_base_link">
-      <sensor type="camera" name="${prefix}_sensor">
+      <sensor
+        type="camera"
+        name="${prefix}_sensor">
         <update_rate>30.0</update_rate>
         <camera name="head">
           <horizontal_fov>1.3962634</horizontal_fov>
@@ -81,7 +123,9 @@
             <stddev>0.007</stddev>
           </noise>
         </camera>
-        <plugin name="${prefix}_controller" filename="libgazebo_ros_camera.so">
+        <plugin
+          name="${prefix}_controller"
+          filename="libgazebo_ros_camera.so">
           <alwaysOn>true</alwaysOn>
           <updateRate>0.0</updateRate>
           <cameraName>${prefix}</cameraName>

--- a/robotnik_sensors/urdf/deprecated/ydlidar_4f.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/ydlidar_4f.urdf.xacro
@@ -2,19 +2,16 @@
 <robot
   name="sensor_ydlidar_4f"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="sensor_ydlidar_4f"
     params="prefix parent prefix_topic:='front_laser' *origin min_angle:=-3.14 max_angle:=3.14 gpu:=^true">
-
     <joint
       name="${prefix}_base_joint"
       type="fixed">
       <xacro:insert_block name="origin" />
       <parent link="${parent}" />
       <child link="${prefix}_base_link" />
-	  </joint>
-
+    </joint>
 
     <link name="${prefix}_base_link">
       <inertial>
@@ -67,7 +64,7 @@
       <origin
         xyz="0.0 0 0.0312"
         rpy="0 0 0" />
-	  </joint>
+    </joint>
 
     <link name="${prefix}_link">
       <inertial>
@@ -89,9 +86,8 @@
           izz="0.00011103" /-->
       </inertial>
     </link>
-	  
-    <xacro:sensor_ydlidar_4f_gazebo />
 
+    <xacro:sensor_ydlidar_4f_gazebo />
   </xacro:macro>
 
   <xacro:macro name="sensor_ydlidar_4f_gazebo">
@@ -142,7 +138,8 @@
           name="${prefix}_controller"
           filename="${plugin_lib}">
           <topicName>${prefix_topic}/scan</topicName>
-          <frameName>/${prefix}_link</frameName><!-- if not global (leading /) sets the current namespace as a prefix (/ns/name_laser_link) -->
+          <frameName>/${prefix}_link</frameName>
+          <!-- if not global (leading /) sets the current namespace as a prefix (/ns/name_laser_link) -->
         </plugin>
       </sensor>
     </gazebo>

--- a/robotnik_sensors/urdf/deprecated/ydlidar_4f.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/ydlidar_4f.urdf.xacro
@@ -1,20 +1,32 @@
-<?xml version="1.0"?>
-<robot name="sensor_ydlidar_4f" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_ydlidar_4f"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="sensor_ydlidar_4f" params="prefix parent prefix_topic:='front_laser' *origin min_angle:=-3.14 max_angle:=3.14 gpu:=^true">
+  <xacro:macro
+    name="sensor_ydlidar_4f"
+    params="prefix parent prefix_topic:='front_laser' *origin min_angle:=-3.14 max_angle:=3.14 gpu:=^true">
 
-    <joint name="${prefix}_base_joint" type="fixed">
+    <joint
+      name="${prefix}_base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${prefix}_base_link"/>
+      <parent link="${parent}" />
+      <child link="${prefix}_base_link" />
 	  </joint>
 
 
     <link name="${prefix}_base_link">
       <inertial>
-        <origin xyz="-0.0 0.0 0.0205" rpy="0 0 0" />
+        <origin
+          xyz="-0.0 0.0 0.0205"
+          rpy="0 0 0" />
         <mass value="0.188" />
-        <xacro:solid_cuboid_inertia m="0.189" w="0.071" h="0.071" d="0.041" />
+        <xacro:solid_cuboid_inertia
+          m="0.189"
+          w="0.071"
+          h="0.071"
+          d="0.041" />
         <!--inertia
           ixx="6.7885E-05"
           ixy="-1.3987E-07"
@@ -24,34 +36,50 @@
           izz="7.1972E-05" /-->
       </inertial>
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/ydlidar_4f.dae" />
+          <mesh
+            filename="package://robotnik_sensors/meshes/ydlidar_4f.dae" />
         </geometry>
         <material name="">
           <color rgba="0.64706 0.61961 0.58824 1" />
         </material>
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/ydlidar_4f.dae" />
+          <mesh
+            filename="package://robotnik_sensors/meshes/ydlidar_4f.dae" />
         </geometry>
       </collision>
     </link>
 
-    <joint name="${prefix}_joint" type="fixed">
-      <parent link="${prefix}_base_link"/>
-      <child link="${prefix}_link"/>
+    <joint
+      name="${prefix}_joint"
+      type="fixed">
+      <parent link="${prefix}_base_link" />
+      <child link="${prefix}_link" />
       <!--origin xyz="0.0 0 0.0116" rpy="0 0 0"/-->
-      <origin xyz="0.0 0 0.0312" rpy="0 0 0"/>
+      <origin
+        xyz="0.0 0 0.0312"
+        rpy="0 0 0" />
 	  </joint>
 
     <link name="${prefix}_link">
       <inertial>
-        <origin xyz="-0.0 0.0 -0.0107" rpy="0 0 0" />
+        <origin
+          xyz="-0.0 0.0 -0.0107"
+          rpy="0 0 0" />
         <mass value="0.001" />
-        <xacro:solid_cuboid_inertia m="0.001" w="0.071" h="0.071" d="0.041" />
+        <xacro:solid_cuboid_inertia
+          m="0.001"
+          w="0.071"
+          h="0.071"
+          d="0.041" />
         <!--inertia
           ixx="8.9194E-05"
           ixy="1.8116E-07"
@@ -69,14 +97,24 @@
   <xacro:macro name="sensor_ydlidar_4f_gazebo">
     <gazebo reference="${prefix}_link">
       <xacro:if value="${gpu}">
-        <xacro:property name="ray_type" value="gpu_ray" />
-        <xacro:property name="plugin_lib" value="libgazebo_ros_gpu_laser.so" />
+        <xacro:property
+          name="ray_type"
+          value="gpu_ray" />
+        <xacro:property
+          name="plugin_lib"
+          value="libgazebo_ros_gpu_laser.so" />
       </xacro:if>
       <xacro:unless value="${gpu}">
-        <xacro:property name="ray_type" value="ray" />
-        <xacro:property name="plugin_lib" value="libgazebo_ros_laser.so" />
+        <xacro:property
+          name="ray_type"
+          value="ray" />
+        <xacro:property
+          name="plugin_lib"
+          value="libgazebo_ros_laser.so" />
       </xacro:unless>
-      <sensor type="${ray_type}" name="${prefix}_sensor">
+      <sensor
+        type="${ray_type}"
+        name="${prefix}_sensor">
         <pose>0 0 0 0 0 0</pose>
         <visualize>false</visualize>
         <update_rate>12.5</update_rate>
@@ -100,7 +138,9 @@
             <stddev>0.03</stddev>
           </noise>
         </ray>
-        <plugin name="${prefix}_controller" filename="${plugin_lib}">
+        <plugin
+          name="${prefix}_controller"
+          filename="${plugin_lib}">
           <topicName>${prefix_topic}/scan</topicName>
           <frameName>/${prefix}_link</frameName><!-- if not global (leading /) sets the current namespace as a prefix (/ns/name_laser_link) -->
         </plugin>

--- a/robotnik_sensors/urdf/deprecated/yujin_yrl.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/yujin_yrl.urdf.xacro
@@ -2,8 +2,6 @@
 <robot
   name="sensor_yujin_yrl"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
-
   <xacro:macro
     name="sensor_yujin_yrl"
     params="prefix parent prefix_topic:='front_laser' *origin min_angle:=-2.3562 max_angle:=2.3562 gpu:=^|true">
@@ -16,7 +14,6 @@
       <parent link="${parent}" />
       <child link="${prefix}_base_link" />
     </joint>
-
 
     <link name="${prefix}_base_link">
       <collision>
@@ -33,7 +30,7 @@
           xyz="0 0 0.0"
           rpy="0 0 0" />
         <geometry>
-            <mesh
+          <mesh
             filename="package://robotnik_sensors/meshes/yujin_yrl.stl" />
         </geometry>
       </visual>
@@ -51,9 +48,8 @@
       </inertial>
     </link>
 
-    <link name="${prefix}_link">
-    </link>
-    
+    <link name="${prefix}_link" />
+
     <joint
       name="${prefix}_joint"
       type="fixed">
@@ -65,7 +61,5 @@
     </joint>
 
     <!-- TODO: Simulate sensor -->
-
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/yujin_yrl.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/yujin_yrl.urdf.xacro
@@ -1,46 +1,67 @@
-<?xml version="1.0"?>
-<robot name="sensor_yujin_yrl" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_yujin_yrl"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
 
-  <xacro:macro name="sensor_yujin_yrl" params="prefix parent prefix_topic:='front_laser' *origin min_angle:=-2.3562 max_angle:=2.3562 gpu:=^|true">
+  <xacro:macro
+    name="sensor_yujin_yrl"
+    params="prefix parent prefix_topic:='front_laser' *origin min_angle:=-2.3562 max_angle:=2.3562 gpu:=^|true">
     <!--arg name="namespace" value="$(arg namespace)"/-->
 
-    <joint name="${prefix}_base_joint" type="fixed">
+    <joint
+      name="${prefix}_base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${prefix}_base_link"/>
+      <parent link="${parent}" />
+      <child link="${prefix}_base_link" />
     </joint>
 
 
     <link name="${prefix}_base_link">
       <collision>
-        <origin xyz="0 0 0.0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0.0"
+          rpy="0 0 0" />
         <geometry>
-          <box size="0.010 0.010 0.010"/>
+          <box size="0.010 0.010 0.010" />
         </geometry>
       </collision>
 
       <visual>
-        <origin xyz="0 0 0.0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0.0"
+          rpy="0 0 0" />
         <geometry>
-            <mesh filename="package://robotnik_sensors/meshes/yujin_yrl.stl"/>
+            <mesh
+            filename="package://robotnik_sensors/meshes/yujin_yrl.stl" />
         </geometry>
       </visual>
 
       <inertial>
-        <origin xyz="0.0 0 0.035" rpy="0 0 0" />
+        <origin
+          xyz="0.0 0 0.035"
+          rpy="0 0 0" />
         <mass value="0.400" />
-        <xacro:solid_cuboid_inertia m="0.400" w="0.05" h="0.05" d="0.07" />
+        <xacro:solid_cuboid_inertia
+          m="0.400"
+          w="0.05"
+          h="0.05"
+          d="0.07" />
       </inertial>
     </link>
 
     <link name="${prefix}_link">
     </link>
     
-    <joint name="${prefix}_joint" type="fixed">
-      <parent link="${prefix}_base_link"/>
-      <child link="${prefix}_link"/>
-      <origin xyz="0.00 0.0 0.07" rpy="0 0 0"/>
+    <joint
+      name="${prefix}_joint"
+      type="fixed">
+      <parent link="${prefix}_base_link" />
+      <child link="${prefix}_link" />
+      <origin
+        xyz="0.00 0.0 0.07"
+        rpy="0 0 0" />
     </joint>
 
     <!-- TODO: Simulate sensor -->

--- a/robotnik_sensors/urdf/deprecated/zed.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/zed.urdf.xacro
@@ -1,16 +1,16 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="stereo_camera"
     params="prefix fps baseline hfov width height format near far">
-
     <gazebo reference="${prefix}_base_link">
       <visual>
         <material>
           <ambient>0.35 0.35 0.35 1.0</ambient>
           <diffuse>0.350754 0.350754 0.350754 1.0</diffuse>
-          <specular>0.308273 0.3508273 0.3508273 1.0</specular>
+          <specular>
+            0.308273 0.3508273 0.3508273 1.0
+          </specular>
           <emissive>0.0 0.0 0.0 0.0</emissive>
         </material>
       </visual>
@@ -19,7 +19,7 @@
         name="stereo_camera">
         <update_rate>${fps}</update_rate>
         <camera name="left">
-          <pose>0 0 0 0 0 0 </pose>
+          <pose>0 0 0 0 0 0</pose>
           <horizontal_fov>${hfov}</horizontal_fov>
           <image>
             <width>${width}</width>
@@ -60,7 +60,9 @@
           <alwaysOn>true</alwaysOn>
           <cameraName>${prefix}</cameraName>
           <imageTopicName>image_raw</imageTopicName>
-          <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+          <cameraInfoTopicName>
+            camera_info
+          </cameraInfoTopicName>
           <frameName>${prefix}_base_link</frameName>
           <hackBaseline>${baseline}</hackBaseline>
           <!-- NOTE: Distortion is currently unused -->
@@ -78,19 +80,18 @@
   <xacro:macro
     name="stereolabs_zed"
     params="prefix:=zed parent *origin model:=zed format:=R8G8B8 near:=0.05 far:=2500">
-
     <xacro:if value="${model == 'zed'}">
-        <xacro:property
+      <xacro:property
         name="baseline"
         value="0.12" />
     </xacro:if>
     <xacro:if value="${model == 'zedm'}">
-        <xacro:property
+      <xacro:property
         name="baseline"
         value="0.06" />
     </xacro:if>
     <xacro:if value="${model == 'zed2'}">
-        <xacro:property
+      <xacro:property
         name="baseline"
         value="0.12" />
     </xacro:if>
@@ -104,7 +105,7 @@
     </joint>
 
     <link name="${prefix}_base_link">
-       <visual>
+      <visual>
         <origin
           xyz="0 0 0"
           rpy="0 0 0" />
@@ -135,25 +136,24 @@
           d="0.03" />
       </inertial>
     </link>
-   <!-- Center camera -->
-   <joint
+    <!-- Center camera -->
+    <joint
       name="${prefix}_camera_center_joint"
       type="fixed">
-        <parent link="${prefix}_base_link" />
-        <child link="${prefix}_camera_center" />
-        <origin
+      <parent link="${prefix}_base_link" />
+      <child link="${prefix}_camera_center" />
+      <origin
         xyz="0.0 0.0 0.0"
         rpy="0.0 0.0 0.0" />
     </joint>
 
-   <link name="${prefix}_camera_center" />
+    <link name="${prefix}_camera_center" />
 
-
-   <!-- Left camera -->
+    <!-- Left camera -->
     <joint
       name="${prefix}_camera_left_joint"
       type="fixed">
-        <origin
+      <origin
         xyz="0 ${baseline/2} 0"
         rpy="0 0 0" />
       <parent link="${prefix}_camera_center" />
@@ -199,7 +199,7 @@
 
     <link name="${prefix}_right_camera_optical_frame" />
 
-      <xacro:stereo_camera
+    <xacro:stereo_camera
       prefix="${prefix}"
       hfov="1.2217"
       baseline="${baseline}"
@@ -221,5 +221,4 @@
       <xacro:insert_block name="origin" />
     </stereolabs_zed>
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/zed.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/zed.urdf.xacro
@@ -1,19 +1,22 @@
-<?xml version="1.0"?>
+<?xml version="1.0" ?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="stereo_camera"
+  <xacro:macro
+    name="stereo_camera"
     params="prefix fps baseline hfov width height format near far">
 
     <gazebo reference="${prefix}_base_link">
-      <visual>  
-        <material>  
-          <ambient>0.35 0.35 0.35 1.0</ambient>  
-          <diffuse>0.350754 0.350754 0.350754 1.0</diffuse>  
-          <specular>0.308273 0.3508273 0.3508273 1.0</specular>  
-          <emissive>0.0 0.0 0.0 0.0</emissive>  
-        </material>  
-      </visual>  
-      <sensor type="multicamera" name="stereo_camera">
+      <visual>
+        <material>
+          <ambient>0.35 0.35 0.35 1.0</ambient>
+          <diffuse>0.350754 0.350754 0.350754 1.0</diffuse>
+          <specular>0.308273 0.3508273 0.3508273 1.0</specular>
+          <emissive>0.0 0.0 0.0 0.0</emissive>
+        </material>
+      </visual>
+      <sensor
+        type="multicamera"
+        name="stereo_camera">
         <update_rate>${fps}</update_rate>
         <camera name="left">
           <pose>0 0 0 0 0 0 </pose>
@@ -51,7 +54,9 @@
             <stddev>0.007</stddev>
           </noise>
         </camera>
-        <plugin name="stereo_camera_controller" filename="libgazebo_ros_multicamera.so">
+        <plugin
+          name="stereo_camera_controller"
+          filename="libgazebo_ros_multicamera.so">
           <alwaysOn>true</alwaysOn>
           <cameraName>${prefix}</cameraName>
           <imageTopicName>image_raw</imageTopicName>
@@ -70,105 +75,149 @@
     </gazebo>
   </xacro:macro>
 
-  <xacro:macro name="stereolabs_zed"
+  <xacro:macro
+    name="stereolabs_zed"
     params="prefix:=zed parent *origin model:=zed format:=R8G8B8 near:=0.05 far:=2500">
 
     <xacro:if value="${model == 'zed'}">
-        <xacro:property name="baseline" value="0.12" />
+        <xacro:property
+        name="baseline"
+        value="0.12" />
     </xacro:if>
     <xacro:if value="${model == 'zedm'}">
-        <xacro:property name="baseline" value="0.06" />
+        <xacro:property
+        name="baseline"
+        value="0.06" />
     </xacro:if>
     <xacro:if value="${model == 'zed2'}">
-        <xacro:property name="baseline" value="0.12" />
+        <xacro:property
+        name="baseline"
+        value="0.12" />
     </xacro:if>
 
-    <joint name="${prefix}_base_joint" type="fixed">
+    <joint
+      name="${prefix}_base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${prefix}_base_link" />
     </joint>
 
     <link name="${prefix}_base_link">
        <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/${model}.stl"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/${model}.stl" />
         </geometry>
         <material name="light_zed_grey">
-          <color rgba="0.35 0.35 0.35 1"/>
+          <color rgba="0.35 0.35 0.35 1" />
         </material>
       </visual>
       <collision>
-        <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
+        <origin
+          xyz="0.0 0.0 0.0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/${model}.stl" />
+          <mesh
+            filename="package://robotnik_sensors/meshes/${model}.stl" />
         </geometry>
       </collision>
       <inertial>
         <mass value="0.135" />
         <origin xyz="0 0 0" />
-        <xacro:solid_cuboid_inertia m="0.135" w="0.033" h="0.175" d="0.03" />
+        <xacro:solid_cuboid_inertia
+          m="0.135"
+          w="0.033"
+          h="0.175"
+          d="0.03" />
       </inertial>
     </link>
    <!-- Center camera -->
-   <joint name="${prefix}_camera_center_joint" type="fixed">
-        <parent link="${prefix}_base_link"/>
-        <child link="${prefix}_camera_center"/>
-        <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+   <joint
+      name="${prefix}_camera_center_joint"
+      type="fixed">
+        <parent link="${prefix}_base_link" />
+        <child link="${prefix}_camera_center" />
+        <origin
+        xyz="0.0 0.0 0.0"
+        rpy="0.0 0.0 0.0" />
     </joint>
 
-   <link name="${prefix}_camera_center"/>
+   <link name="${prefix}_camera_center" />
 
 
    <!-- Left camera -->
-    <joint name="${prefix}_camera_left_joint" type="fixed">
-        <origin xyz="0 ${baseline/2} 0" rpy="0 0 0" />
+    <joint
+      name="${prefix}_camera_left_joint"
+      type="fixed">
+        <origin
+        xyz="0 ${baseline/2} 0"
+        rpy="0 0 0" />
       <parent link="${prefix}_camera_center" />
       <child link="${prefix}_left_camera_frame" />
     </joint>
 
-    <link name="${prefix}_left_camera_frame"/>
+    <link name="${prefix}_left_camera_frame" />
 
-    <joint name="${prefix}_camera_left_optical_joint" type="fixed">
-      <origin xyz="0.0 0.0 0.0" rpy="${-M_PI/2} 0.0 ${-M_PI/2}" />
+    <joint
+      name="${prefix}_camera_left_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0.0 0.0"
+        rpy="${-radians(90)} 0.0 ${-radians(90)}" />
       <parent link="${prefix}_left_camera_frame" />
       <child link="${prefix}_left_camera_optical_frame" />
     </joint>
 
-    <link name="${prefix}_left_camera_optical_frame"/>
+    <link name="${prefix}_left_camera_optical_frame" />
 
     <!-- Right camera-->
-    <joint name="${prefix}_camera_right_joint" type="fixed">
-      <origin xyz="0 -${baseline/2} 0" rpy="0 0 0" />
+    <joint
+      name="${prefix}_camera_right_joint"
+      type="fixed">
+      <origin
+        xyz="0 -${baseline/2} 0"
+        rpy="0 0 0" />
       <parent link="${prefix}_camera_center" />
       <child link="${prefix}_right_camera_frame" />
     </joint>
 
-    <link name="${prefix}_right_camera_frame"/>
+    <link name="${prefix}_right_camera_frame" />
 
-    <joint name="${prefix}_camera_right_optical_joint" type="fixed">
-      <origin xyz="0.0 0 0.0" rpy="${-M_PI/2} 0.0 ${-M_PI/2}" />
+    <joint
+      name="${prefix}_camera_right_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0 0.0"
+        rpy="${-radians(90)} 0.0 ${-radians(90)}" />
       <parent link="${prefix}_right_camera_frame" />
       <child link="${prefix}_right_camera_optical_frame" />
     </joint>
 
-    <link name="${prefix}_right_camera_optical_frame"/>
+    <link name="${prefix}_right_camera_optical_frame" />
 
       <xacro:stereo_camera
-        prefix="${prefix}"
-        hfov="1.2217"
-        baseline="${baseline}"
-        fps="40"
-        width="640"
-        height="480"
-        format="${format}"
-        near="${near}"
-        far="${far}"/>
+      prefix="${prefix}"
+      hfov="1.2217"
+      baseline="${baseline}"
+      fps="40"
+      width="640"
+      height="480"
+      format="${format}"
+      near="${near}"
+      far="${far}" />
   </xacro:macro>
 
-  <xacro:macro name="sensor_zed" params="prefix:=myzed parent *origin model:=zed" >
-    <stereolabs_zed prefix="${prefix}" parent="${parent}" model="${model}">
+  <xacro:macro
+    name="sensor_zed"
+    params="prefix:=myzed parent *origin model:=zed">
+    <stereolabs_zed
+      prefix="${prefix}"
+      parent="${parent}"
+      model="${model}">
       <xacro:insert_block name="origin" />
     </stereolabs_zed>
   </xacro:macro>

--- a/robotnik_sensors/urdf/deprecated/zed2.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/zed2.urdf.xacro
@@ -1,16 +1,16 @@
 <?xml version="1.0" ?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="depth_camera"
     params="prefix fps baseline hfov width height format near far  prefix_topic:='zed_node'">
-
     <gazebo reference="${prefix}_base_link">
       <visual>
         <material>
           <ambient>0.35 0.35 0.35 1.0</ambient>
           <diffuse>0.350754 0.350754 0.350754 1.0</diffuse>
-          <specular>0.308273 0.3508273 0.3508273 1.0</specular>
+          <specular>
+            0.308273 0.3508273 0.3508273 1.0
+          </specular>
           <emissive>0.0 0.0 0.0 0.0</emissive>
         </material>
       </visual>
@@ -44,12 +44,22 @@
             will control the frame rate. -->
           <updateRate>0.0</updateRate>
           <cameraName>${prefix_topic}</cameraName>
-          <imageTopicName> rgb/image_raw</imageTopicName>
-          <cameraInfoTopicName>rgb/camera_info</cameraInfoTopicName>
-          <depthImageTopicName>depth/image_raw</depthImageTopicName>
-          <depthImageCameraInfoTopicName>depth/camera_info</depthImageCameraInfoTopicName>
-          <pointCloudTopicName>depth/points</pointCloudTopicName>
-          <frameName>/${prefix}_depth_optical_frame</frameName>
+          <imageTopicName>rgb/image_raw</imageTopicName>
+          <cameraInfoTopicName>
+            rgb/camera_info
+          </cameraInfoTopicName>
+          <depthImageTopicName>
+            depth/image_raw
+          </depthImageTopicName>
+          <depthImageCameraInfoTopicName>
+            depth/camera_info
+          </depthImageCameraInfoTopicName>
+          <pointCloudTopicName>
+            depth/points
+          </pointCloudTopicName>
+          <frameName>
+            /${prefix}_depth_optical_frame
+          </frameName>
           <pointCloudCutoff>${near}</pointCloudCutoff>
           <pointCloudCutoffMax>${far}</pointCloudCutoffMax>
           <distortionK1>0</distortionK1>
@@ -70,19 +80,18 @@
   <xacro:macro
     name="stereolabs_zed2"
     params="prefix:=zed parent *origin model:=zed format:=R8G8B8 near:=0.5 far:=30  prefix_topic:=zed_node">
-
     <xacro:if value="${model == 'zed'}">
-        <xacro:property
+      <xacro:property
         name="baseline"
         value="0.12" />
     </xacro:if>
     <xacro:if value="${model == 'zedm'}">
-        <xacro:property
+      <xacro:property
         name="baseline"
         value="0.06" />
     </xacro:if>
     <xacro:if value="${model == 'zed2'}">
-        <xacro:property
+      <xacro:property
         name="baseline"
         value="0.12" />
     </xacro:if>
@@ -96,7 +105,7 @@
     </joint>
 
     <link name="${prefix}_base_link">
-       <visual>
+      <visual>
         <origin
           xyz="0 0 0"
           rpy="0 0 0" />
@@ -128,7 +137,7 @@
       </inertial>
     </link>
 
-   <!-- Left camera -->
+    <!-- Left camera -->
     <joint
       name="${prefix}_camera_left_joint"
       type="fixed">
@@ -203,7 +212,7 @@
 
     <link name="${prefix}_depth_optical_frame" />
 
-      <xacro:depth_camera
+    <xacro:depth_camera
       prefix="${prefix}"
       hfov="1.2217"
       baseline="${baseline}"
@@ -227,5 +236,4 @@
       <xacro:insert_block name="origin" />
     </stereolabs_zed2>
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/deprecated/zed2.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/zed2.urdf.xacro
@@ -1,19 +1,22 @@
-<?xml version="1.0"?>
+<?xml version="1.0" ?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="depth_camera"
+  <xacro:macro
+    name="depth_camera"
     params="prefix fps baseline hfov width height format near far  prefix_topic:='zed_node'">
 
     <gazebo reference="${prefix}_base_link">
-      <visual>  
-        <material>  
-          <ambient>0.35 0.35 0.35 1.0</ambient>  
-          <diffuse>0.350754 0.350754 0.350754 1.0</diffuse>  
-          <specular>0.308273 0.3508273 0.3508273 1.0</specular>  
-          <emissive>0.0 0.0 0.0 0.0</emissive>  
-        </material>  
-      </visual>  
-      <sensor type="depth" name="depth_camera">
+      <visual>
+        <material>
+          <ambient>0.35 0.35 0.35 1.0</ambient>
+          <diffuse>0.350754 0.350754 0.350754 1.0</diffuse>
+          <specular>0.308273 0.3508273 0.3508273 1.0</specular>
+          <emissive>0.0 0.0 0.0 0.0</emissive>
+        </material>
+      </visual>
+      <sensor
+        type="depth"
+        name="depth_camera">
         <update_rate>${fps}</update_rate>
         <camera>
           <horizontal_fov>${hfov}</horizontal_fov>
@@ -32,7 +35,9 @@
             <stddev>0.007</stddev>
           </noise>
         </camera>
-        <plugin name="camera_plugin" filename="libgazebo_ros_openni_kinect.so">
+        <plugin
+          name="camera_plugin"
+          filename="libgazebo_ros_openni_kinect.so">
           <baseline>${baseline}</baseline>
           <alwaysOn>true</alwaysOn>
           <!-- Keep this zero, update_rate in the parent <sensor> tag
@@ -62,115 +67,163 @@
     </gazebo>
   </xacro:macro>
 
-  <xacro:macro name="stereolabs_zed2"
+  <xacro:macro
+    name="stereolabs_zed2"
     params="prefix:=zed parent *origin model:=zed format:=R8G8B8 near:=0.5 far:=30  prefix_topic:=zed_node">
 
     <xacro:if value="${model == 'zed'}">
-        <xacro:property name="baseline" value="0.12" />
+        <xacro:property
+        name="baseline"
+        value="0.12" />
     </xacro:if>
     <xacro:if value="${model == 'zedm'}">
-        <xacro:property name="baseline" value="0.06" />
+        <xacro:property
+        name="baseline"
+        value="0.06" />
     </xacro:if>
     <xacro:if value="${model == 'zed2'}">
-        <xacro:property name="baseline" value="0.12" />
+        <xacro:property
+        name="baseline"
+        value="0.12" />
     </xacro:if>
 
-    <joint name="${prefix}_base_joint" type="fixed">
+    <joint
+      name="${prefix}_base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${prefix}_base_link" />
     </joint>
 
     <link name="${prefix}_base_link">
        <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/${model}.stl"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/${model}.stl" />
         </geometry>
         <material name="light_zed_grey">
-          <color rgba="0.35 0.35 0.35 1"/>
+          <color rgba="0.35 0.35 0.35 1" />
         </material>
       </visual>
       <collision>
-        <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
+        <origin
+          xyz="0.0 0.0 0.0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/${model}.stl" />
+          <mesh
+            filename="package://robotnik_sensors/meshes/${model}.stl" />
         </geometry>
       </collision>
       <inertial>
         <mass value="0.135" />
         <origin xyz="0 0 0" />
-        <xacro:solid_cuboid_inertia m="0.135" w="0.033" h="0.175" d="0.03" />
+        <xacro:solid_cuboid_inertia
+          m="0.135"
+          w="0.033"
+          h="0.175"
+          d="0.03" />
       </inertial>
     </link>
 
    <!-- Left camera -->
-    <joint name="${prefix}_camera_left_joint" type="fixed">
-      <origin xyz="0.0 0.06 0.0" rpy="0.0 0.0 0.0" />
+    <joint
+      name="${prefix}_camera_left_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0.06 0.0"
+        rpy="0.0 0.0 0.0" />
       <parent link="${prefix}_base_link" />
       <child link="${prefix}_left_camera_frame" />
     </joint>
 
-    <link name="${prefix}_left_camera_frame"/>
+    <link name="${prefix}_left_camera_frame" />
 
-    <joint name="${prefix}_camera_left_optical_joint" type="fixed">
-      <origin xyz="0.0 0.0 0.0" rpy="${-M_PI/2} 0.0 ${-M_PI/2}" />
+    <joint
+      name="${prefix}_camera_left_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0.0 0.0"
+        rpy="${-radians(90)} 0.0 ${-radians(90)}" />
       <parent link="${prefix}_left_camera_frame" />
       <child link="${prefix}_left_camera_optical_frame" />
     </joint>
 
-    <link name="${prefix}_left_camera_optical_frame"/>
+    <link name="${prefix}_left_camera_optical_frame" />
 
     <!-- Right camera-->
-    <joint name="${prefix}_camera_right_joint" type="fixed">
-      <origin xyz="0.0 -0.06 0.0" rpy="0.0 0.0 0.0" />
+    <joint
+      name="${prefix}_camera_right_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 -0.06 0.0"
+        rpy="0.0 0.0 0.0" />
       <parent link="${prefix}_base_link" />
       <child link="${prefix}_right_camera_frame" />
     </joint>
 
-    <link name="${prefix}_right_camera_frame"/>
+    <link name="${prefix}_right_camera_frame" />
 
-    <joint name="${prefix}_camera_right_optical_joint" type="fixed">
-      <origin xyz="0.0 0 0.0" rpy="${-M_PI/2} 0.0 ${-M_PI/2}" />
+    <joint
+      name="${prefix}_camera_right_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0 0.0"
+        rpy="${-radians(90)} 0.0 ${-radians(90)}" />
       <parent link="${prefix}_right_camera_frame" />
       <child link="${prefix}_right_camera_optical_frame" />
     </joint>
 
-    <link name="${prefix}_right_camera_optical_frame"/>
+    <link name="${prefix}_right_camera_optical_frame" />
 
     <!-- Depth image-->
-    <joint name="${prefix}_depth_joint" type="fixed">
-      <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+    <joint
+      name="${prefix}_depth_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0.0 0.0"
+        rpy="0.0 0.0 0.0" />
       <parent link="${prefix}_base_link" />
       <child link="${prefix}_depth_frame" />
     </joint>
 
-    <link name="${prefix}_depth_frame"/>
+    <link name="${prefix}_depth_frame" />
 
-    <joint name="${prefix}_depth_optical_joint" type="fixed">
-      <origin xyz="0.0 0.0 0.0" rpy="${-M_PI/2} 0.0 ${-M_PI/2}" />
+    <joint
+      name="${prefix}_depth_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0.0 0.0"
+        rpy="${-radians(90)} 0.0 ${-radians(90)}" />
       <parent link="${prefix}_depth_frame" />
       <child link="${prefix}_depth_optical_frame" />
     </joint>
 
-    <link name="${prefix}_depth_optical_frame"/>
+    <link name="${prefix}_depth_optical_frame" />
 
       <xacro:depth_camera
-        prefix="${prefix}"
-        hfov="1.2217"
-        baseline="${baseline}"
-        fps="30"
-        width="1280"
-        height="720"
-        format="${format}"
-        near="${near}"
-        far="${far}"
-        prefix_topic="${prefix_topic}"
-        />
+      prefix="${prefix}"
+      hfov="1.2217"
+      baseline="${baseline}"
+      fps="30"
+      width="1280"
+      height="720"
+      format="${format}"
+      near="${near}"
+      far="${far}"
+      prefix_topic="${prefix_topic}" />
   </xacro:macro>
 
-  <xacro:macro name="sensor_zed2" params="prefix:=zed2 parent *origin model:=zed2  prefix_topic:=zed_node" >
-    <stereolabs_zed2 prefix="${prefix}" parent="${parent}" model="${model}" prefix_topic="${prefix_topic}">
+  <xacro:macro
+    name="sensor_zed2"
+    params="prefix:=zed2 parent *origin model:=zed2  prefix_topic:=zed_node">
+    <stereolabs_zed2
+      prefix="${prefix}"
+      parent="${parent}"
+      model="${model}"
+      prefix_topic="${prefix_topic}">
       <xacro:insert_block name="origin" />
     </stereolabs_zed2>
   </xacro:macro>

--- a/robotnik_sensors/urdf/depth/azure_kinect.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/azure_kinect.urdf.xacro
@@ -1,24 +1,32 @@
-<?xml version="1.0"?>
-<robot name="sensor_azure_kinect" xmlns:xacro="http://wiki.ros.org/xacro">
-  
-  <xacro:include filename="$(find robotnik_sensors)/urdf/depth/depth_camera_plugin.urdf.xacro" />
+<?xml version="1.0" ?>
+<robot
+  name="sensor_azure_kinect"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="sensor_azure_kinect" 
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_namespace:=${None}
-                       node_name:=azure_kinect
-                       topic_prefix:=~/">
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/depth/depth_camera_plugin.urdf.xacro" />
+
+  <xacro:macro
+    name="sensor_azure_kinect"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_namespace:=${None}
+            node_name:=azure_kinect
+            topic_prefix:=~/">
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}joint" type="fixed">
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
     	<xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}link"/>
+      <parent link="${parent}" />
+      <child link="${frame_prefix}link" />
     </joint>
     <link name="${frame_prefix}link">
       <visual>
@@ -29,21 +37,31 @@
         <material name="${frame_prefix}grey" />
       </visual>
       <collision>
-        <origin xyz="-0.013 0. 0." rpy="0 0 0"/>
+        <origin
+          xyz="-0.013 0. 0."
+          rpy="0 0 0" />
         <geometry>
-          <box size="0.026 0.103 0.03039"/>
+          <box size="0.026 0.103 0.03039" />
         </geometry>
       </collision>
       <inertial>
         <mass value="0.3" />
         <origin xyz="0.0 0.0 0.0" />
-        <xacro:solid_cuboid_inertia m="0.3" w="0.026" h="0.103" d="0.03039" />
+        <xacro:solid_cuboid_inertia
+          m="0.3"
+          w="0.026"
+          h="0.103"
+          d="0.03039" />
       </inertial>
     </link>
 
-    <joint name="${frame_prefix}rgb_joint" type="fixed">
-      <origin xyz="0.0 0. 0.008" rpy="0.0 0.0 0.0"/>
-      <parent link="${frame_prefix}link"/>
+    <joint
+      name="${frame_prefix}rgb_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0. 0.008"
+        rpy="0.0 0.0 0.0" />
+      <parent link="${frame_prefix}link" />
       <child link="${frame_prefix}rgb_frame" />
     </joint>
     <link name="${frame_prefix}rgb_frame">
@@ -56,14 +74,20 @@
       </visual>
     </link>
 
-    <joint name="${frame_prefix}rgb_optical_joint" type="fixed">
-      <origin xyz="0.0 0.0 0.0" rpy="${-PI/2} 0 ${-PI/2}" />
+    <joint
+      name="${frame_prefix}rgb_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0.0 0.0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
       <parent link="${frame_prefix}rgb_frame" />
       <child link="${frame_prefix}rgb_optical_frame" />
     </joint>
     <link name="${frame_prefix}rgb_optical_frame">
       <visual>
-        <origin xyz="0.0 0.01 -0.015" rpy="0.0 0.0 ${-PI/2}" />
+        <origin
+          xyz="0.0 0.01 -0.015"
+          rpy="0.0 0.0 ${-radians(90)}" />
         <geometry>
           <box size="0.026 0.101 0.037" />
         </geometry>
@@ -71,19 +95,27 @@
       </visual>
     </link>
 
-    <joint name="${frame_prefix}depth_joint" type="fixed">
-      <origin xyz="0.0 0.0375 0.008" rpy="0 0 0" />
+    <joint
+      name="${frame_prefix}depth_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0.0375 0.008"
+        rpy="0 0 0" />
       <parent link="${frame_prefix}link" />
       <child link="${frame_prefix}depth_frame" />
     </joint>
-    <link name="${frame_prefix}depth_frame"/>
+    <link name="${frame_prefix}depth_frame" />
 
-    <joint name="${frame_prefix}depth_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="${-PI/2} 0 ${-PI/2}" />
+    <joint
+      name="${frame_prefix}depth_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
       <parent link="${frame_prefix}depth_frame" />
       <child link="${frame_prefix}depth_optical_frame" />
     </joint>
-    <link name="${frame_prefix}depth_optical_frame"/>
+    <link name="${frame_prefix}depth_optical_frame" />
 
 
     <material name="${frame_prefix}black">
@@ -110,8 +142,7 @@
       video_height="480"
       min_depth="0.05"
       max_depth="3.5"
-      rate="30"
-    >
+      rate="30">
     </xacro:depth_camera_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/depth/azure_kinect.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/azure_kinect.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_azure_kinect"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/depth/depth_camera_plugin.urdf.xacro" />
 
@@ -24,7 +23,7 @@
     <joint
       name="${frame_prefix}joint"
       type="fixed">
-    	<xacro:insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}" />
       <child link="${frame_prefix}link" />
     </joint>
@@ -117,7 +116,6 @@
     </joint>
     <link name="${frame_prefix}depth_optical_frame" />
 
-
     <material name="${frame_prefix}black">
       <color rgba="0. 0. 0. 1" />
     </material>
@@ -142,9 +140,6 @@
       video_height="480"
       min_depth="0.05"
       max_depth="3.5"
-      rate="30">
-    </xacro:depth_camera_plugin>
-
+      rate="30" />
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/depth/depth_camera_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/depth_camera_plugin.urdf.xacro
@@ -1,8 +1,11 @@
-<?xml version="1.0"?>
-<robot name="depth_camera_plugin" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="depth_camera_plugin"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="depth_camera_plugin" params="
-            node_namespace
+  <xacro:macro
+    name="depth_camera_plugin"
+    params="node_namespace
             node_name
             topic_prefix
             gazebo_ignition
@@ -14,12 +17,13 @@
             video_height
             min_depth
             max_depth
-            rate
-            ">
+            rate">
 
     <xacro:if value="${gazebo_ignition}">
       <gazebo reference="${reference_frame}">
-        <sensor name="${node_name}" type="depth">
+        <sensor
+          name="${node_name}"
+          type="depth">
           <camera name="${node_name}">
             <camera_info_topic>${node_name}/depth/camera_info</camera_info_topic>
             <horizontal_fov>${radians(float(horizontal_fov))}</horizontal_fov>
@@ -42,7 +46,7 @@
           <always_on>1</always_on>
           <update_rate>30</update_rate>
           <visualize>false</visualize>
-            
+
           <camera_info_topic>${node_namespace}/${node_name}/depth/camera_info</camera_info_topic>
           <topic>${node_namespace}/${node_name}/depth/image_raw</topic>
           <gz_frame_id>${optical_frame}</gz_frame_id>

--- a/robotnik_sensors/urdf/depth/depth_camera_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/depth_camera_plugin.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="depth_camera_plugin"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="depth_camera_plugin"
     params="node_namespace
@@ -18,16 +17,21 @@
             min_depth
             max_depth
             rate">
-
     <xacro:if value="${gazebo_ignition}">
       <gazebo reference="${reference_frame}">
         <sensor
           name="${node_name}"
           type="depth">
           <camera name="${node_name}">
-            <camera_info_topic>${node_name}/depth/camera_info</camera_info_topic>
-            <horizontal_fov>${radians(float(horizontal_fov))}</horizontal_fov>
-            <vertical_fov>${radians(float(vertical_fov))}</vertical_fov>
+            <camera_info_topic>
+              ${node_name}/depth/camera_info
+            </camera_info_topic>
+            <horizontal_fov>
+              ${radians(float(horizontal_fov))}
+            </horizontal_fov>
+            <vertical_fov>
+              ${radians(float(vertical_fov))}
+            </vertical_fov>
             <image>
               <width>${video_width}</width>
               <height>${video_height}</height>
@@ -47,15 +51,17 @@
           <update_rate>30</update_rate>
           <visualize>false</visualize>
 
-          <camera_info_topic>${node_namespace}/${node_name}/depth/camera_info</camera_info_topic>
-          <topic>${node_namespace}/${node_name}/depth/image_raw</topic>
+          <camera_info_topic>
+            ${node_namespace}/${node_name}/depth/camera_info
+          </camera_info_topic>
+          <topic>
+            ${node_namespace}/${node_name}/depth/image_raw
+          </topic>
           <gz_frame_id>${optical_frame}</gz_frame_id>
           <min_depth>${min_depth}</min_depth>
           <max_depth>${max_depth}</max_depth>
         </sensor>
       </gazebo>
     </xacro:if>
-
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/depth/intel_realsense_d435.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/intel_realsense_d435.urdf.xacro
@@ -1,157 +1,235 @@
-<?xml version="1.0"?>
-<robot name="sensor_intel_realsense_d435" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_intel_realsense_d435"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/depth/depth_camera_plugin.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/depth/irred_camera_plugin.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/camera/camera_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/depth/depth_camera_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/depth/irred_camera_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/camera/camera_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_intel_realsense_d435"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=realsense_d435
-                       node_namespace:=${None}
-                       topic_prefix:=~/">
+  <xacro:macro
+    name="sensor_intel_realsense_d435"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=realsense_d435
+            node_namespace:=${None}
+            topic_prefix:=~/">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
     <!-- The following values are approximate, and the camera node
      publishing TF values with actual calibrated camera extrinsic values -->
-    <xacro:property name="d435_cam_depth_to_infra1_offset" value="0.0"/>
-    <xacro:property name="d435_cam_depth_to_infra2_offset" value="-0.050"/>
-    <xacro:property name="d435_cam_depth_to_color_offset" value="0.015"/>
+    <xacro:property
+      name="d435_cam_depth_to_infra1_offset"
+      value="0.0" />
+    <xacro:property
+      name="d435_cam_depth_to_infra2_offset"
+      value="-0.050" />
+    <xacro:property
+      name="d435_cam_depth_to_color_offset"
+      value="0.015" />
 
     <!-- The following values model the aluminum peripherial case for the
     D435 camera, with the camera joint represented by the actual
     peripherial camera tripod mount -->
-    <xacro:property name="d435_cam_width" value="0.090"/>
-    <xacro:property name="d435_cam_height" value="0.025"/>
-    <xacro:property name="d435_cam_depth" value="0.02505"/>
-    <xacro:property name="d435_cam_mount_from_center_offset" value="0.0149"/>
+    <xacro:property
+      name="d435_cam_width"
+      value="0.090" />
+    <xacro:property
+      name="d435_cam_height"
+      value="0.025" />
+    <xacro:property
+      name="d435_cam_depth"
+      value="0.02505" />
+    <xacro:property
+      name="d435_cam_mount_from_center_offset"
+      value="0.0149" />
 
     <!-- The following offset is relative the the physical D435 camera peripherial
     camera tripod mount -->
-    <xacro:property name="d435_cam_depth_px" value="${d435_cam_mount_from_center_offset}"/>
-    <xacro:property name="d435_cam_depth_py" value="0.0175"/>
-    <xacro:property name="d435_cam_depth_pz" value="${d435_cam_height/2}"/>
+    <xacro:property
+      name="d435_cam_depth_px"
+      value="${d435_cam_mount_from_center_offset}" />
+    <xacro:property
+      name="d435_cam_depth_py"
+      value="0.0175" />
+    <xacro:property
+      name="d435_cam_depth_pz"
+      value="${d435_cam_height/2}" />
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${frame_prefix}base_link" />
     </joint>
     <link name="${frame_prefix}base_link" />
 
     <!-- camera body, with origin at bottom screw mount -->
-    <joint name="${frame_prefix}joint" type="fixed">
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
       <parent link="${frame_prefix}base_link" />
       <child link="${frame_prefix}link" />
-      <origin xyz="0.01 0.02 0" rpy="0 0 0"/>
+      <origin
+        xyz="0.01 0.02 0"
+        rpy="0 0 0" />
       <child link="${frame_prefix}link" />
     </joint>
-    <link name="${frame_prefix}link"> <!-- camera link is aligned with the infrared sensor 1 that is "in the middle of the camera", not the one in the edge -->
+    <link
+      name="${frame_prefix}link"> <!-- camera link is aligned with the infrared sensor 1 that is "in the middle of the camera", not the one in the edge -->
       <visual>
-        <origin xyz="${d435_cam_mount_from_center_offset} ${-d435_cam_depth_py} 0" rpy="${pi/2} 0 ${pi/2}"/>
+        <origin
+          xyz="${d435_cam_mount_from_center_offset} ${-d435_cam_depth_py} 0"
+          rpy="${radians(90)} 0 ${radians(90)}" />
         <geometry>
           <!-- <box size="${d435_cam_width} ${d435_cam_height} ${d435_cam_depth}"/> -->
-          <mesh filename="package://robotnik_sensors/meshes/depth/intel_realsense_d435/intel_d435_color.dae" />
+          <mesh
+            filename="package://robotnik_sensors/meshes/depth/intel_realsense_d435/intel_d435_color.dae" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0 ${-d435_cam_depth_py} 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 ${-d435_cam_depth_py} 0"
+          rpy="0 0 0" />
         <geometry>
-          <box size="${d435_cam_depth} ${d435_cam_width} ${d435_cam_height}"/>
+          <box
+            size="${d435_cam_depth} ${d435_cam_width} ${d435_cam_height}" />
         </geometry>
       </collision>
       <inertial>
-        <origin xyz="0.0025 -0.015 0.0" rpy="0 0 0" />
+        <origin
+          xyz="0.0025 -0.015 0.0"
+          rpy="0 0 0" />
         <mass value="0.1" />
-        <xacro:solid_cuboid_inertia m="0.1" w="0.025" h="0.09" d="0.025" />
+        <xacro:solid_cuboid_inertia
+          m="0.1"
+          w="0.025"
+          h="0.09"
+          d="0.025" />
       </inertial>
     </link>
 
     <!-- Use the nominal extrinsics between camera frames if the calibrated extrinsics aren't being published. e.g. running the device in simulation  -->
       <!-- camera depth joints and links -->
-      <joint name="${frame_prefix}depth_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <parent link="${frame_prefix}link"/>
+      <joint
+      name="${frame_prefix}depth_joint"
+      type="fixed">
+        <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+        <parent link="${frame_prefix}link" />
         <child link="${frame_prefix}depth_frame" />
       </joint>
-      <link name="${frame_prefix}depth_frame"/>
+      <link name="${frame_prefix}depth_frame" />
 
-      <joint name="${frame_prefix}depth_optical_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}" />
+      <joint
+      name="${frame_prefix}depth_optical_joint"
+      type="fixed">
+        <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
         <parent link="${frame_prefix}depth_frame" />
         <child link="${frame_prefix}depth_optical_frame" />
       </joint>
-      <link name="${frame_prefix}depth_optical_frame"/>
+      <link name="${frame_prefix}depth_optical_frame" />
 
       <!-- camera left IR joints and links -->
-      <joint name="${frame_prefix}infra1_joint" type="fixed">
-        <origin xyz="0 ${d435_cam_depth_to_infra1_offset} 0" rpy="0 0 0" />
+      <joint
+      name="${frame_prefix}infra1_joint"
+      type="fixed">
+        <origin
+        xyz="0 ${d435_cam_depth_to_infra1_offset} 0"
+        rpy="0 0 0" />
         <parent link="${frame_prefix}link" />
         <child link="${frame_prefix}infra1_frame" />
       </joint>
-      <link name="${frame_prefix}infra1_frame"/>
+      <link name="${frame_prefix}infra1_frame" />
 
-      <joint name="${frame_prefix}infra1_optical_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}" />
+      <joint
+      name="${frame_prefix}infra1_optical_joint"
+      type="fixed">
+        <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
         <parent link="${frame_prefix}infra1_frame" />
         <child link="${frame_prefix}infra1_optical_frame" />
       </joint>
-      <link name="${frame_prefix}infra1_optical_frame"/>
+      <link name="${frame_prefix}infra1_optical_frame" />
 
       <!-- camera right IR joints and links -->
-      <joint name="${frame_prefix}infra2_joint" type="fixed">
-        <origin xyz="0 ${d435_cam_depth_to_infra2_offset} 0" rpy="0 0 0" />
+      <joint
+      name="${frame_prefix}infra2_joint"
+      type="fixed">
+        <origin
+        xyz="0 ${d435_cam_depth_to_infra2_offset} 0"
+        rpy="0 0 0" />
         <parent link="${frame_prefix}link" />
         <child link="${frame_prefix}infra2_frame" />
       </joint>
-      <link name="${frame_prefix}infra2_frame"/>
+      <link name="${frame_prefix}infra2_frame" />
 
-      <joint name="${frame_prefix}infra2_optical_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}" />
+      <joint
+      name="${frame_prefix}infra2_optical_joint"
+      type="fixed">
+        <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
         <parent link="${frame_prefix}infra2_frame" />
         <child link="${frame_prefix}infra2_optical_frame" />
       </joint>
-      <link name="${frame_prefix}infra2_optical_frame"/>
+      <link name="${frame_prefix}infra2_optical_frame" />
 
       <!-- camera color joints and links -->
-      <joint name="${frame_prefix}color_joint" type="fixed">
-        <origin xyz="0 ${d435_cam_depth_to_color_offset} 0" rpy="0 0 0" />
+      <joint
+      name="${frame_prefix}color_joint"
+      type="fixed">
+        <origin
+        xyz="0 ${d435_cam_depth_to_color_offset} 0"
+        rpy="0 0 0" />
         <parent link="${frame_prefix}link" />
         <child link="${frame_prefix}color_frame" />
       </joint>
-      <link name="${frame_prefix}color_frame"/>
+      <link name="${frame_prefix}color_frame" />
 
-      <joint name="${frame_prefix}color_optical_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}" />
+      <joint
+      name="${frame_prefix}color_optical_joint"
+      type="fixed">
+        <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
         <parent link="${frame_prefix}color_frame" />
         <child link="${frame_prefix}color_optical_frame" />
       </joint>
-      <link name="${frame_prefix}color_optical_frame"/>
+      <link name="${frame_prefix}color_optical_frame" />
 
       <xacro:camera_plugin
-        node_namespace="${node_namespace}"
-        node_name="${node_name}_color"
-        topic_prefix="${topic_prefix}_color"
-        gazebo_ignition="${gazebo_ignition}"
-        optical_frame="${frame_prefix}color_optical_frame"
-        reference_frame="${frame_prefix}color_frame"
-        horizontal_fov="69.4"
-        vertical_fov="39"
-        video_width="1920"
-        video_height="1080"
-        min_depth="0.1"
-        max_depth="100"
-        rate="30"
-      >
+      node_namespace="${node_namespace}"
+      node_name="${node_name}_color"
+      topic_prefix="${topic_prefix}_color"
+      gazebo_ignition="${gazebo_ignition}"
+      optical_frame="${frame_prefix}color_optical_frame"
+      reference_frame="${frame_prefix}color_frame"
+      horizontal_fov="69.4"
+      vertical_fov="39"
+      video_width="1920"
+      video_height="1080"
+      min_depth="0.1"
+      max_depth="100"
+      rate="30">
       </xacro:camera_plugin>
 
-      
+
 
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/depth/intel_realsense_d435.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/intel_realsense_d435.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_intel_realsense_d435"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/depth/depth_camera_plugin.urdf.xacro" />
   <xacro:include
@@ -86,8 +85,8 @@
         rpy="0 0 0" />
       <child link="${frame_prefix}link" />
     </joint>
-    <link
-      name="${frame_prefix}link"> <!-- camera link is aligned with the infrared sensor 1 that is "in the middle of the camera", not the one in the edge -->
+    <link name="${frame_prefix}link">
+      <!-- camera link is aligned with the infrared sensor 1 that is "in the middle of the camera", not the one in the edge -->
       <visual>
         <origin
           xyz="${d435_cam_mount_from_center_offset} ${-d435_cam_depth_py} 0"
@@ -121,99 +120,99 @@
     </link>
 
     <!-- Use the nominal extrinsics between camera frames if the calibrated extrinsics aren't being published. e.g. running the device in simulation  -->
-      <!-- camera depth joints and links -->
-      <joint
+    <!-- camera depth joints and links -->
+    <joint
       name="${frame_prefix}depth_joint"
       type="fixed">
-        <origin
+      <origin
         xyz="0 0 0"
         rpy="0 0 0" />
-        <parent link="${frame_prefix}link" />
-        <child link="${frame_prefix}depth_frame" />
-      </joint>
-      <link name="${frame_prefix}depth_frame" />
+      <parent link="${frame_prefix}link" />
+      <child link="${frame_prefix}depth_frame" />
+    </joint>
+    <link name="${frame_prefix}depth_frame" />
 
-      <joint
+    <joint
       name="${frame_prefix}depth_optical_joint"
       type="fixed">
-        <origin
+      <origin
         xyz="0 0 0"
         rpy="${-radians(90)} 0 ${-radians(90)}" />
-        <parent link="${frame_prefix}depth_frame" />
-        <child link="${frame_prefix}depth_optical_frame" />
-      </joint>
-      <link name="${frame_prefix}depth_optical_frame" />
+      <parent link="${frame_prefix}depth_frame" />
+      <child link="${frame_prefix}depth_optical_frame" />
+    </joint>
+    <link name="${frame_prefix}depth_optical_frame" />
 
-      <!-- camera left IR joints and links -->
-      <joint
+    <!-- camera left IR joints and links -->
+    <joint
       name="${frame_prefix}infra1_joint"
       type="fixed">
-        <origin
+      <origin
         xyz="0 ${d435_cam_depth_to_infra1_offset} 0"
         rpy="0 0 0" />
-        <parent link="${frame_prefix}link" />
-        <child link="${frame_prefix}infra1_frame" />
-      </joint>
-      <link name="${frame_prefix}infra1_frame" />
+      <parent link="${frame_prefix}link" />
+      <child link="${frame_prefix}infra1_frame" />
+    </joint>
+    <link name="${frame_prefix}infra1_frame" />
 
-      <joint
+    <joint
       name="${frame_prefix}infra1_optical_joint"
       type="fixed">
-        <origin
+      <origin
         xyz="0 0 0"
         rpy="${-radians(90)} 0 ${-radians(90)}" />
-        <parent link="${frame_prefix}infra1_frame" />
-        <child link="${frame_prefix}infra1_optical_frame" />
-      </joint>
-      <link name="${frame_prefix}infra1_optical_frame" />
+      <parent link="${frame_prefix}infra1_frame" />
+      <child link="${frame_prefix}infra1_optical_frame" />
+    </joint>
+    <link name="${frame_prefix}infra1_optical_frame" />
 
-      <!-- camera right IR joints and links -->
-      <joint
+    <!-- camera right IR joints and links -->
+    <joint
       name="${frame_prefix}infra2_joint"
       type="fixed">
-        <origin
+      <origin
         xyz="0 ${d435_cam_depth_to_infra2_offset} 0"
         rpy="0 0 0" />
-        <parent link="${frame_prefix}link" />
-        <child link="${frame_prefix}infra2_frame" />
-      </joint>
-      <link name="${frame_prefix}infra2_frame" />
+      <parent link="${frame_prefix}link" />
+      <child link="${frame_prefix}infra2_frame" />
+    </joint>
+    <link name="${frame_prefix}infra2_frame" />
 
-      <joint
+    <joint
       name="${frame_prefix}infra2_optical_joint"
       type="fixed">
-        <origin
+      <origin
         xyz="0 0 0"
         rpy="${-radians(90)} 0 ${-radians(90)}" />
-        <parent link="${frame_prefix}infra2_frame" />
-        <child link="${frame_prefix}infra2_optical_frame" />
-      </joint>
-      <link name="${frame_prefix}infra2_optical_frame" />
+      <parent link="${frame_prefix}infra2_frame" />
+      <child link="${frame_prefix}infra2_optical_frame" />
+    </joint>
+    <link name="${frame_prefix}infra2_optical_frame" />
 
-      <!-- camera color joints and links -->
-      <joint
+    <!-- camera color joints and links -->
+    <joint
       name="${frame_prefix}color_joint"
       type="fixed">
-        <origin
+      <origin
         xyz="0 ${d435_cam_depth_to_color_offset} 0"
         rpy="0 0 0" />
-        <parent link="${frame_prefix}link" />
-        <child link="${frame_prefix}color_frame" />
-      </joint>
-      <link name="${frame_prefix}color_frame" />
+      <parent link="${frame_prefix}link" />
+      <child link="${frame_prefix}color_frame" />
+    </joint>
+    <link name="${frame_prefix}color_frame" />
 
-      <joint
+    <joint
       name="${frame_prefix}color_optical_joint"
       type="fixed">
-        <origin
+      <origin
         xyz="0 0 0"
         rpy="${-radians(90)} 0 ${-radians(90)}" />
-        <parent link="${frame_prefix}color_frame" />
-        <child link="${frame_prefix}color_optical_frame" />
-      </joint>
-      <link name="${frame_prefix}color_optical_frame" />
+      <parent link="${frame_prefix}color_frame" />
+      <child link="${frame_prefix}color_optical_frame" />
+    </joint>
+    <link name="${frame_prefix}color_optical_frame" />
 
-      <xacro:camera_plugin
+    <xacro:camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_color"
       topic_prefix="${topic_prefix}_color"
@@ -226,10 +225,6 @@
       video_height="1080"
       min_depth="0.1"
       max_depth="100"
-      rate="30">
-      </xacro:camera_plugin>
-
-
-
+      rate="30" />
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/depth/intel_realsense_d435i.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/intel_realsense_d435i.urdf.xacro
@@ -1,214 +1,294 @@
-<?xml version="1.0"?>
-<robot name="sensor_intel_realsense_d435i" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_intel_realsense_d435i"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/depth/depth_camera_plugin.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/depth/irred_camera_plugin.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/camera/camera_plugin.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/imu/imu_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/depth/depth_camera_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/depth/irred_camera_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/camera/camera_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/imu/imu_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_intel_realsense_d435i"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=realsense_d435i
-                       node_namespace:=${None}
-                       topic_prefix:=~/">
+  <xacro:macro
+    name="sensor_intel_realsense_d435i"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=realsense_d435i
+            node_namespace:=${None}
+            topic_prefix:=~/">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
     <!-- The following values are approximate, and the camera node
      publishing TF values with actual calibrated camera extrinsic values -->
-    <xacro:property name="d435_cam_depth_to_infra1_offset" value="0.0"/>
-    <xacro:property name="d435_cam_depth_to_infra2_offset" value="-0.050"/>
-    <xacro:property name="d435_cam_depth_to_color_offset" value="0.015"/>
+    <xacro:property
+      name="d435_cam_depth_to_infra1_offset"
+      value="0.0" />
+    <xacro:property
+      name="d435_cam_depth_to_infra2_offset"
+      value="-0.050" />
+    <xacro:property
+      name="d435_cam_depth_to_color_offset"
+      value="0.015" />
 
     <!-- The following values model the aluminum peripherial case for the
     D435 camera, with the camera joint represented by the actual
     peripherial camera tripod mount -->
-    <xacro:property name="d435_cam_width" value="0.090"/>
-    <xacro:property name="d435_cam_height" value="0.025"/>
-    <xacro:property name="d435_cam_depth" value="0.02505"/>
-    <xacro:property name="d435_cam_mount_from_center_offset" value="0.0149"/>
+    <xacro:property
+      name="d435_cam_width"
+      value="0.090" />
+    <xacro:property
+      name="d435_cam_height"
+      value="0.025" />
+    <xacro:property
+      name="d435_cam_depth"
+      value="0.02505" />
+    <xacro:property
+      name="d435_cam_mount_from_center_offset"
+      value="0.0149" />
 
     <!-- The following offset is relative the the physical D435 camera peripherial
     camera tripod mount -->
-    <xacro:property name="d435_cam_depth_px" value="${d435_cam_mount_from_center_offset}"/>
-    <xacro:property name="d435_cam_depth_py" value="0.0175"/>
-    <xacro:property name="d435_cam_depth_pz" value="${d435_cam_height/2}"/>
+    <xacro:property
+      name="d435_cam_depth_px"
+      value="${d435_cam_mount_from_center_offset}" />
+    <xacro:property
+      name="d435_cam_depth_py"
+      value="0.0175" />
+    <xacro:property
+      name="d435_cam_depth_pz"
+      value="${d435_cam_height/2}" />
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${frame_prefix}base_link" />
     </joint>
     <link name="${frame_prefix}base_link" />
 
     <!-- camera body, with origin at bottom screw mount -->
-    <joint name="${frame_prefix}joint" type="fixed">
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
       <parent link="${frame_prefix}base_link" />
       <child link="${frame_prefix}link" />
-      <origin xyz="0.01 0.02 0" rpy="0 0 0"/>
+      <origin
+        xyz="0.01 0.02 0"
+        rpy="0 0 0" />
       <child link="${frame_prefix}link" />
     </joint>
-    <link name="${frame_prefix}link"> <!-- camera link is aligned with the infrared sensor 1 that is "in the middle of the camera", not the one in the edge -->
+    <link
+      name="${frame_prefix}link"> <!-- camera link is aligned with the infrared sensor 1 that is "in the middle of the camera", not the one in the edge -->
       <visual>
-        <origin xyz="${d435_cam_mount_from_center_offset} ${-d435_cam_depth_py} 0" rpy="${pi/2} 0 ${pi/2}"/>
+        <origin
+          xyz="${d435_cam_mount_from_center_offset} ${-d435_cam_depth_py} 0"
+          rpy="${radians(90)} 0 ${radians(90)}" />
         <geometry>
           <!-- <box size="${d435_cam_width} ${d435_cam_height} ${d435_cam_depth}"/> -->
-          <mesh filename="package://robotnik_sensors/meshes/depth/intel_realsense_d435/intel_d435_color.dae" />
+          <mesh
+            filename="package://robotnik_sensors/meshes/depth/intel_realsense_d435/intel_d435_color.dae" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0 ${-d435_cam_depth_py} 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 ${-d435_cam_depth_py} 0"
+          rpy="0 0 0" />
         <geometry>
-          <box size="${d435_cam_depth} ${d435_cam_width} ${d435_cam_height}"/>
+          <box
+            size="${d435_cam_depth} ${d435_cam_width} ${d435_cam_height}" />
         </geometry>
       </collision>
       <inertial>
-        <origin xyz="0.0025 -0.015 0.0" rpy="0 0 0" />
+        <origin
+          xyz="0.0025 -0.015 0.0"
+          rpy="0 0 0" />
         <mass value="0.1" />
-        <xacro:solid_cuboid_inertia m="0.1" w="0.025" h="0.09" d="0.025" />
+        <xacro:solid_cuboid_inertia
+          m="0.1"
+          w="0.025"
+          h="0.09"
+          d="0.025" />
       </inertial>
     </link>
 
     <!-- Use the nominal extrinsics between camera frames if the calibrated extrinsics aren't being published. e.g. running the device in simulation  -->
       <!-- camera depth joints and links -->
-      <joint name="${frame_prefix}depth_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="0 0 0"/>
-        <parent link="${frame_prefix}link"/>
+      <joint
+      name="${frame_prefix}depth_joint"
+      type="fixed">
+        <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
+        <parent link="${frame_prefix}link" />
         <child link="${frame_prefix}depth_frame" />
       </joint>
-      <link name="${frame_prefix}depth_frame"/>
+      <link name="${frame_prefix}depth_frame" />
 
-      <joint name="${frame_prefix}depth_optical_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}" />
+      <joint
+      name="${frame_prefix}depth_optical_joint"
+      type="fixed">
+        <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
         <parent link="${frame_prefix}depth_frame" />
         <child link="${frame_prefix}depth_optical_frame" />
       </joint>
-      <link name="${frame_prefix}depth_optical_frame"/>
+      <link name="${frame_prefix}depth_optical_frame" />
 
       <!-- camera left IR joints and links -->
-      <joint name="${frame_prefix}infra1_joint" type="fixed">
-        <origin xyz="0 ${d435_cam_depth_to_infra1_offset} 0" rpy="0 0 0" />
+      <joint
+      name="${frame_prefix}infra1_joint"
+      type="fixed">
+        <origin
+        xyz="0 ${d435_cam_depth_to_infra1_offset} 0"
+        rpy="0 0 0" />
         <parent link="${frame_prefix}link" />
         <child link="${frame_prefix}infra1_frame" />
       </joint>
-      <link name="${frame_prefix}infra1_frame"/>
+      <link name="${frame_prefix}infra1_frame" />
 
-      <joint name="${frame_prefix}infra1_optical_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}" />
+      <joint
+      name="${frame_prefix}infra1_optical_joint"
+      type="fixed">
+        <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
         <parent link="${frame_prefix}infra1_frame" />
         <child link="${frame_prefix}infra1_optical_frame" />
       </joint>
-      <link name="${frame_prefix}infra1_optical_frame"/>
+      <link name="${frame_prefix}infra1_optical_frame" />
 
       <!-- camera right IR joints and links -->
-      <joint name="${frame_prefix}infra2_joint" type="fixed">
-        <origin xyz="0 ${d435_cam_depth_to_infra2_offset} 0" rpy="0 0 0" />
+      <joint
+      name="${frame_prefix}infra2_joint"
+      type="fixed">
+        <origin
+        xyz="0 ${d435_cam_depth_to_infra2_offset} 0"
+        rpy="0 0 0" />
         <parent link="${frame_prefix}link" />
         <child link="${frame_prefix}infra2_frame" />
       </joint>
-      <link name="${frame_prefix}infra2_frame"/>
+      <link name="${frame_prefix}infra2_frame" />
 
-      <joint name="${frame_prefix}infra2_optical_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}" />
+      <joint
+      name="${frame_prefix}infra2_optical_joint"
+      type="fixed">
+        <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
         <parent link="${frame_prefix}infra2_frame" />
         <child link="${frame_prefix}infra2_optical_frame" />
       </joint>
-      <link name="${frame_prefix}infra2_optical_frame"/>
+      <link name="${frame_prefix}infra2_optical_frame" />
 
       <!-- camera color joints and links -->
-      <joint name="${frame_prefix}color_joint" type="fixed">
-        <origin xyz="0 ${d435_cam_depth_to_color_offset} 0" rpy="0 0 0" />
+      <joint
+      name="${frame_prefix}color_joint"
+      type="fixed">
+        <origin
+        xyz="0 ${d435_cam_depth_to_color_offset} 0"
+        rpy="0 0 0" />
         <parent link="${frame_prefix}link" />
         <child link="${frame_prefix}color_frame" />
       </joint>
-      <link name="${frame_prefix}color_frame"/>
+      <link name="${frame_prefix}color_frame" />
 
-      <joint name="${frame_prefix}color_optical_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}" />
+      <joint
+      name="${frame_prefix}color_optical_joint"
+      type="fixed">
+        <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
         <parent link="${frame_prefix}color_frame" />
         <child link="${frame_prefix}color_optical_frame" />
       </joint>
-      <link name="${frame_prefix}color_optical_frame"/>
+      <link name="${frame_prefix}color_optical_frame" />
 
       <!-- Imu frame -->
-      <joint name="${frame_prefix}imu_joint" type="fixed">
-        <origin xyz="0 0 0" rpy="0 0 0" />
+      <joint
+      name="${frame_prefix}imu_joint"
+      type="fixed">
+        <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
         <parent link="${frame_prefix}link" />
         <child link="${frame_prefix}imu_frame" />
       </joint>
-      <link name="${frame_prefix}imu_frame"/>
+      <link name="${frame_prefix}imu_frame" />
 
       <xacro:camera_plugin
-        node_namespace="${node_namespace}"
-        node_name="${node_name}_color"
-        topic_prefix="${topic_prefix}_color"
-        gazebo_ignition="${gazebo_ignition}"
-        optical_frame="${frame_prefix}color_optical_frame"
-        reference_frame="${frame_prefix}color_frame"
-        horizontal_fov="69.4"
-        vertical_fov="39"
-        video_width="1920"
-        video_height="1080"
-        min_depth="0.1"
-        max_depth="100"
-        rate="30"
-      >
+      node_namespace="${node_namespace}"
+      node_name="${node_name}_color"
+      topic_prefix="${topic_prefix}_color"
+      gazebo_ignition="${gazebo_ignition}"
+      optical_frame="${frame_prefix}color_optical_frame"
+      reference_frame="${frame_prefix}color_frame"
+      horizontal_fov="69.4"
+      vertical_fov="39"
+      video_width="1920"
+      video_height="1080"
+      min_depth="0.1"
+      max_depth="100"
+      rate="30">
       </xacro:camera_plugin>
 
       <xacro:irred_camera_plugin
-        node_namespace="${node_namespace}"
-        node_name="${node_name}_irred1"
-        topic_prefix="${topic_prefix}_irred1"
-        gazebo_ignition="${gazebo_ignition}"
-        optical_frame="${frame_prefix}infra1_optical_frame"
-        reference_frame="${frame_prefix}infra2_frame"
-        horizontal_fov="85.2"
-        vertical_fov="48"
-        video_width="1280"
-        video_height="720"
-        min_depth="0.1"
-        max_depth="100"
-        rate="30"
-      >
+      node_namespace="${node_namespace}"
+      node_name="${node_name}_irred1"
+      topic_prefix="${topic_prefix}_irred1"
+      gazebo_ignition="${gazebo_ignition}"
+      optical_frame="${frame_prefix}infra1_optical_frame"
+      reference_frame="${frame_prefix}infra2_frame"
+      horizontal_fov="85.2"
+      vertical_fov="48"
+      video_width="1280"
+      video_height="720"
+      min_depth="0.1"
+      max_depth="100"
+      rate="30">
       </xacro:irred_camera_plugin>
 
       <xacro:irred_camera_plugin
-        node_namespace="${node_namespace}"
-        node_name="${node_name}_irred2"
-        topic_prefix="${topic_prefix}_irred2"
-        gazebo_ignition="${gazebo_ignition}"
-        optical_frame="${frame_prefix}infra2_optical_frame"
-        reference_frame="${frame_prefix}infra2_frame"
-        horizontal_fov="85.2"
-        vertical_fov="48"
-        video_width="1280"
-        video_height="720"
-        min_depth="0.1"
-        max_depth="100"
-        rate="30"
-      >
+      node_namespace="${node_namespace}"
+      node_name="${node_name}_irred2"
+      topic_prefix="${topic_prefix}_irred2"
+      gazebo_ignition="${gazebo_ignition}"
+      optical_frame="${frame_prefix}infra2_optical_frame"
+      reference_frame="${frame_prefix}infra2_frame"
+      horizontal_fov="85.2"
+      vertical_fov="48"
+      video_width="1280"
+      video_height="720"
+      min_depth="0.1"
+      max_depth="100"
+      rate="30">
       </xacro:irred_camera_plugin>
 
       <xacro:depth_camera_plugin
-        node_namespace="${node_namespace}"
-        node_name="${node_name}_depth"
-        topic_prefix="${topic_prefix}_depth"
-        gazebo_ignition="${gazebo_ignition}"
-        optical_frame="${frame_prefix}depth_optical_frame"
-        reference_frame="${frame_prefix}depth_frame"
-        horizontal_fov="85.2"
-        vertical_fov="48"
-        video_width="1280"
-        video_height="720"
-        min_depth="0.1"
-        max_depth="100"
-        rate="30"
-      >
+      node_namespace="${node_namespace}"
+      node_name="${node_name}_depth"
+      topic_prefix="${topic_prefix}_depth"
+      gazebo_ignition="${gazebo_ignition}"
+      optical_frame="${frame_prefix}depth_optical_frame"
+      reference_frame="${frame_prefix}depth_frame"
+      horizontal_fov="85.2"
+      vertical_fov="48"
+      video_width="1280"
+      video_height="720"
+      min_depth="0.1"
+      max_depth="100"
+      rate="30">
       </xacro:depth_camera_plugin>
 
       <!-- <gazebo>
@@ -244,8 +324,7 @@
       node_name="${node_name}"
       gazebo_ignition="${gazebo_ignition}"
       frame_link="${frame_prefix}link"
-      rate="200.0"
-    >
+      rate="200.0">
     </xacro:imu_plugin>
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/depth/intel_realsense_d435i.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/intel_realsense_d435i.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_intel_realsense_d435i"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/depth/depth_camera_plugin.urdf.xacro" />
   <xacro:include
@@ -88,8 +87,8 @@
         rpy="0 0 0" />
       <child link="${frame_prefix}link" />
     </joint>
-    <link
-      name="${frame_prefix}link"> <!-- camera link is aligned with the infrared sensor 1 that is "in the middle of the camera", not the one in the edge -->
+    <link name="${frame_prefix}link">
+      <!-- camera link is aligned with the infrared sensor 1 that is "in the middle of the camera", not the one in the edge -->
       <visual>
         <origin
           xyz="${d435_cam_mount_from_center_offset} ${-d435_cam_depth_py} 0"
@@ -123,111 +122,111 @@
     </link>
 
     <!-- Use the nominal extrinsics between camera frames if the calibrated extrinsics aren't being published. e.g. running the device in simulation  -->
-      <!-- camera depth joints and links -->
-      <joint
+    <!-- camera depth joints and links -->
+    <joint
       name="${frame_prefix}depth_joint"
       type="fixed">
-        <origin
+      <origin
         xyz="0 0 0"
         rpy="0 0 0" />
-        <parent link="${frame_prefix}link" />
-        <child link="${frame_prefix}depth_frame" />
-      </joint>
-      <link name="${frame_prefix}depth_frame" />
+      <parent link="${frame_prefix}link" />
+      <child link="${frame_prefix}depth_frame" />
+    </joint>
+    <link name="${frame_prefix}depth_frame" />
 
-      <joint
+    <joint
       name="${frame_prefix}depth_optical_joint"
       type="fixed">
-        <origin
+      <origin
         xyz="0 0 0"
         rpy="${-radians(90)} 0 ${-radians(90)}" />
-        <parent link="${frame_prefix}depth_frame" />
-        <child link="${frame_prefix}depth_optical_frame" />
-      </joint>
-      <link name="${frame_prefix}depth_optical_frame" />
+      <parent link="${frame_prefix}depth_frame" />
+      <child link="${frame_prefix}depth_optical_frame" />
+    </joint>
+    <link name="${frame_prefix}depth_optical_frame" />
 
-      <!-- camera left IR joints and links -->
-      <joint
+    <!-- camera left IR joints and links -->
+    <joint
       name="${frame_prefix}infra1_joint"
       type="fixed">
-        <origin
+      <origin
         xyz="0 ${d435_cam_depth_to_infra1_offset} 0"
         rpy="0 0 0" />
-        <parent link="${frame_prefix}link" />
-        <child link="${frame_prefix}infra1_frame" />
-      </joint>
-      <link name="${frame_prefix}infra1_frame" />
+      <parent link="${frame_prefix}link" />
+      <child link="${frame_prefix}infra1_frame" />
+    </joint>
+    <link name="${frame_prefix}infra1_frame" />
 
-      <joint
+    <joint
       name="${frame_prefix}infra1_optical_joint"
       type="fixed">
-        <origin
+      <origin
         xyz="0 0 0"
         rpy="${-radians(90)} 0 ${-radians(90)}" />
-        <parent link="${frame_prefix}infra1_frame" />
-        <child link="${frame_prefix}infra1_optical_frame" />
-      </joint>
-      <link name="${frame_prefix}infra1_optical_frame" />
+      <parent link="${frame_prefix}infra1_frame" />
+      <child link="${frame_prefix}infra1_optical_frame" />
+    </joint>
+    <link name="${frame_prefix}infra1_optical_frame" />
 
-      <!-- camera right IR joints and links -->
-      <joint
+    <!-- camera right IR joints and links -->
+    <joint
       name="${frame_prefix}infra2_joint"
       type="fixed">
-        <origin
+      <origin
         xyz="0 ${d435_cam_depth_to_infra2_offset} 0"
         rpy="0 0 0" />
-        <parent link="${frame_prefix}link" />
-        <child link="${frame_prefix}infra2_frame" />
-      </joint>
-      <link name="${frame_prefix}infra2_frame" />
+      <parent link="${frame_prefix}link" />
+      <child link="${frame_prefix}infra2_frame" />
+    </joint>
+    <link name="${frame_prefix}infra2_frame" />
 
-      <joint
+    <joint
       name="${frame_prefix}infra2_optical_joint"
       type="fixed">
-        <origin
+      <origin
         xyz="0 0 0"
         rpy="${-radians(90)} 0 ${-radians(90)}" />
-        <parent link="${frame_prefix}infra2_frame" />
-        <child link="${frame_prefix}infra2_optical_frame" />
-      </joint>
-      <link name="${frame_prefix}infra2_optical_frame" />
+      <parent link="${frame_prefix}infra2_frame" />
+      <child link="${frame_prefix}infra2_optical_frame" />
+    </joint>
+    <link name="${frame_prefix}infra2_optical_frame" />
 
-      <!-- camera color joints and links -->
-      <joint
+    <!-- camera color joints and links -->
+    <joint
       name="${frame_prefix}color_joint"
       type="fixed">
-        <origin
+      <origin
         xyz="0 ${d435_cam_depth_to_color_offset} 0"
         rpy="0 0 0" />
-        <parent link="${frame_prefix}link" />
-        <child link="${frame_prefix}color_frame" />
-      </joint>
-      <link name="${frame_prefix}color_frame" />
+      <parent link="${frame_prefix}link" />
+      <child link="${frame_prefix}color_frame" />
+    </joint>
+    <link name="${frame_prefix}color_frame" />
 
-      <joint
+    <joint
       name="${frame_prefix}color_optical_joint"
       type="fixed">
-        <origin
+      <origin
         xyz="0 0 0"
         rpy="${-radians(90)} 0 ${-radians(90)}" />
-        <parent link="${frame_prefix}color_frame" />
-        <child link="${frame_prefix}color_optical_frame" />
-      </joint>
-      <link name="${frame_prefix}color_optical_frame" />
+      <parent link="${frame_prefix}color_frame" />
+      <child link="${frame_prefix}color_optical_frame" />
+    </joint>
+    <link name="${frame_prefix}color_optical_frame" />
 
-      <!-- Imu frame -->
-      <joint
+    <!-- Imu frame -->
+    <joint
       name="${frame_prefix}imu_joint"
       type="fixed">
-        <origin
+      <origin
         xyz="0 0 0"
         rpy="0 0 0" />
-        <parent link="${frame_prefix}link" />
-        <child link="${frame_prefix}imu_frame" />
-      </joint>
-      <link name="${frame_prefix}imu_frame" />
+      <parent link="${frame_prefix}link" />
+      <child link="${frame_prefix}imu_frame" />
+    </joint>
+    <link name="${frame_prefix}imu_frame" />
 
-      <xacro:camera_plugin
+    <xacro:camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_color"
       topic_prefix="${topic_prefix}_color"
@@ -240,10 +239,9 @@
       video_height="1080"
       min_depth="0.1"
       max_depth="100"
-      rate="30">
-      </xacro:camera_plugin>
+      rate="30" />
 
-      <xacro:irred_camera_plugin
+    <xacro:irred_camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_irred1"
       topic_prefix="${topic_prefix}_irred1"
@@ -256,10 +254,9 @@
       video_height="720"
       min_depth="0.1"
       max_depth="100"
-      rate="30">
-      </xacro:irred_camera_plugin>
+      rate="30" />
 
-      <xacro:irred_camera_plugin
+    <xacro:irred_camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_irred2"
       topic_prefix="${topic_prefix}_irred2"
@@ -272,10 +269,9 @@
       video_height="720"
       min_depth="0.1"
       max_depth="100"
-      rate="30">
-      </xacro:irred_camera_plugin>
+      rate="30" />
 
-      <xacro:depth_camera_plugin
+    <xacro:depth_camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_depth"
       topic_prefix="${topic_prefix}_depth"
@@ -288,10 +284,9 @@
       video_height="720"
       min_depth="0.1"
       max_depth="100"
-      rate="30">
-      </xacro:depth_camera_plugin>
+      rate="30" />
 
-      <!-- <gazebo>
+    <!-- <gazebo>
         <plugin name="${node_name}" filename="librealsense_gazebo_plugin.so">
           <prefix>${node_namespace}</prefix>
           <depthUpdateRate>60.0</depthUpdateRate>
@@ -317,14 +312,13 @@
         </plugin>
       </gazebo> -->
 
-      <!-- Imu -->
+    <!-- Imu -->
 
     <xacro:imu_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
       gazebo_ignition="${gazebo_ignition}"
       frame_link="${frame_prefix}link"
-      rate="200.0">
-    </xacro:imu_plugin>
+      rate="200.0" />
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/depth/irred_camera_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/irred_camera_plugin.urdf.xacro
@@ -1,8 +1,11 @@
-<?xml version="1.0"?>
-<robot name="irred_camera_plugin" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="irred_camera_plugin"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="irred_camera_plugin" params="
-            node_namespace
+  <xacro:macro
+    name="irred_camera_plugin"
+    params="node_namespace
             node_name
             topic_prefix
             gazebo_ignition
@@ -19,7 +22,9 @@
 
     <xacro:if value="${gazebo_ignition}">
       <gazebo reference="${reference_frame}">
-        <sensor name="${node_name}" type="camera">
+        <sensor
+          name="${node_name}"
+          type="camera">
             <camera name="${node_name}">
             <horizontal_fov>${radians(horizontal_fov)}</horizontal_fov>
             <vertical_fov>${radians(float(vertical_fov))}</vertical_fov>

--- a/robotnik_sensors/urdf/depth/irred_camera_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/irred_camera_plugin.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="irred_camera_plugin"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="irred_camera_plugin"
     params="node_namespace
@@ -19,41 +18,46 @@
             max_depth
             rate
             ">
-
     <xacro:if value="${gazebo_ignition}">
       <gazebo reference="${reference_frame}">
         <sensor
           name="${node_name}"
           type="camera">
-            <camera name="${node_name}">
-            <horizontal_fov>${radians(horizontal_fov)}</horizontal_fov>
-            <vertical_fov>${radians(float(vertical_fov))}</vertical_fov>
+          <camera name="${node_name}">
+            <horizontal_fov>
+              ${radians(horizontal_fov)}
+            </horizontal_fov>
+            <vertical_fov>
+              ${radians(float(vertical_fov))}
+            </vertical_fov>
             <image>
               <width>${video_width}</width>
               <height>${video_height}</height>
-                <format>L_INT8</format>
+              <format>L_INT8</format>
             </image>
             <clip>
               <near>${min_depth}</near>
               <far>${max_depth}</far>
             </clip>
             <noise>
-                <type>gaussian</type>
-                <mean>0.0</mean>
-                <stddev>0.05</stddev>
+              <type>gaussian</type>
+              <mean>0.0</mean>
+              <stddev>0.05</stddev>
             </noise>
-            </camera>
-            <always_on>1</always_on>
-            <update_rate>${rate}</update_rate>
-            <visualize>false</visualize>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>${rate}</update_rate>
+          <visualize>false</visualize>
 
-            <topic>${node_namespace}/${node_name}/ired/image_raw</topic>
-            <gz_frame_id>${optical_frame}</gz_frame_id>
-            <camera_info_topic>${node_namespace}/${node_name}/ired/camera_info</camera_info_topic>
+          <topic>
+            ${node_namespace}/${node_name}/ired/image_raw
+          </topic>
+          <gz_frame_id>${optical_frame}</gz_frame_id>
+          <camera_info_topic>
+            ${node_namespace}/${node_name}/ired/camera_info
+          </camera_info_topic>
         </sensor>
       </gazebo>
     </xacro:if>
-
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/depth/orbbec_astra.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/orbbec_astra.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_orbbec_astra"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/depth/depth_camera_plugin.urdf.xacro" />
 
@@ -25,7 +24,7 @@
     <joint
       name="${frame_prefix}joint"
       type="fixed">
-    	<xacro:insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}" />
       <child link="${frame_prefix}link" />
     </joint>
@@ -111,7 +110,6 @@
       video_height="480"
       min_depth="0.05"
       max_depth="8.0"
-      rate="30">
-    </xacro:depth_camera_plugin>
+      rate="30" />
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/depth/orbbec_astra.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/orbbec_astra.urdf.xacro
@@ -1,69 +1,102 @@
-<?xml version="1.0"?>
-<robot name="sensor_orbbec_astra" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_orbbec_astra"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/depth/depth_camera_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/depth/depth_camera_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_orbbec_astra"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_namespace:=${None}
-                       node_name:=orbbec_astra
-                       topic_prefix:=~/">
+  <xacro:macro
+    name="sensor_orbbec_astra"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_namespace:=${None}
+            node_name:=orbbec_astra
+            topic_prefix:=~/">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-    	<xacro:insert_block name="origin"/>
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}link"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+    	<xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${frame_prefix}link" />
     </joint>
     <link name="${frame_prefix}link">
       <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/depth/orbbec_astra/orbbec_astra.dae"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/depth/orbbec_astra/orbbec_astra.dae" />
         </geometry>
       </visual>
       <collision>
-        <origin xyz="-0.02 0 0.015" rpy="0 0 0"/>
+        <origin
+          xyz="-0.02 0 0.015"
+          rpy="0 0 0" />
         <geometry>
-          <box size="0.042 0.155 0.03"/>
+          <box size="0.042 0.155 0.03" />
         </geometry>
       </collision>
       <inertial>
         <mass value="0.3" />
         <origin xyz="0.0 0.0 0.0" />
-        <xacro:solid_cuboid_inertia m="0.3" w="0.04" h="0.165" d="0.03" />
+        <xacro:solid_cuboid_inertia
+          m="0.3"
+          w="0.04"
+          h="0.165"
+          d="0.03" />
       </inertial>
     </link>
-    <joint name="${frame_prefix}rgb_joint" type="fixed">
-      <origin xyz="0.0 0.0125 0.0150" rpy="0.0 0.0 0.0"/>
-      <parent link="${frame_prefix}link"/>
+    <joint
+      name="${frame_prefix}rgb_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0.0125 0.0150"
+        rpy="0.0 0.0 0.0" />
+      <parent link="${frame_prefix}link" />
       <child link="${frame_prefix}rgb_frame" />
     </joint>
-    <link name="${frame_prefix}rgb_frame"/>
-    <joint name="${frame_prefix}rgb_optical_joint" type="fixed">
-      <origin xyz="0.0 0.0 0.0" rpy="${-pi/2} 0 ${-pi/2}" />
+    <link name="${frame_prefix}rgb_frame" />
+    <joint
+      name="${frame_prefix}rgb_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0.0 0.0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
       <parent link="${frame_prefix}rgb_frame" />
       <child link="${frame_prefix}rgb_optical_frame" />
     </joint>
-    <link name="${frame_prefix}rgb_optical_frame"/>
-    <joint name="${frame_prefix}depth_joint" type="fixed">
-      <origin xyz="0.0 0.0375 0.0150" rpy="0 0 0" />
+    <link name="${frame_prefix}rgb_optical_frame" />
+    <joint
+      name="${frame_prefix}depth_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0.0375 0.0150"
+        rpy="0 0 0" />
       <parent link="${frame_prefix}link" />
       <child link="${frame_prefix}depth_frame" />
     </joint>
-    <link name="${frame_prefix}depth_frame"/>
-    <joint name="${frame_prefix}depth_optical_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="${-pi/2} 0 ${-pi/2}" />
+    <link name="${frame_prefix}depth_frame" />
+    <joint
+      name="${frame_prefix}depth_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="${-radians(90)} 0 ${-radians(90)}" />
       <parent link="${frame_prefix}depth_frame" />
       <child link="${frame_prefix}depth_optical_frame" />
     </joint>
-    <link name="${frame_prefix}depth_optical_frame"/>
+    <link name="${frame_prefix}depth_optical_frame" />
 
     <xacro:depth_camera_plugin
       node_namespace="${node_namespace}"
@@ -78,8 +111,7 @@
       video_height="480"
       min_depth="0.05"
       max_depth="8.0"
-      rate="30"
-    >
+      rate="30">
     </xacro:depth_camera_plugin>
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/depth/stereolabs_generic.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/stereolabs_generic.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_stereolabs_generic"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/depth/depth_camera_plugin.urdf.xacro" />
   <xacro:include
@@ -35,17 +34,17 @@
     </xacro:if>
 
     <xacro:if value="${model == 'zed'}">
-        <xacro:property
+      <xacro:property
         name="baseline"
         value="0.12" />
     </xacro:if>
     <xacro:if value="${model == 'zedm'}">
-        <xacro:property
+      <xacro:property
         name="baseline"
         value="0.06" />
     </xacro:if>
     <xacro:if value="${model == 'zed2'}">
-        <xacro:property
+      <xacro:property
         name="baseline"
         value="0.12" />
     </xacro:if>
@@ -58,7 +57,7 @@
       <child link="${frame_prefix}base_link" />
     </joint>
     <link name="${frame_prefix}base_link">
-       <visual>
+      <visual>
         <origin
           xyz="0 0 0"
           rpy="0 0 0" />
@@ -90,7 +89,7 @@
       </inertial>
     </link>
 
-   <!-- Left camera -->
+    <!-- Left camera -->
     <joint
       name="${frame_prefix}color_left_joint"
       type="fixed">
@@ -175,8 +174,7 @@
       video_height="${video_height}"
       min_depth="0.1"
       max_depth="100"
-      rate="30">
-    </xacro:camera_plugin>
+      rate="30" />
 
     <xacro:camera_plugin
       node_namespace="${node_namespace}"
@@ -191,8 +189,7 @@
       video_height="${video_height}"
       min_depth="0.1"
       max_depth="100"
-      rate="30">
-    </xacro:camera_plugin>
+      rate="30" />
 
     <xacro:depth_camera_plugin
       node_namespace="${node_namespace}"
@@ -207,8 +204,6 @@
       video_height="${video_height}"
       min_depth="${min_depth}"
       max_depth="${max_depth}"
-      rate="30">
-    </xacro:depth_camera_plugin>
-
+      rate="30" />
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/depth/stereolabs_generic.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/stereolabs_generic.urdf.xacro
@@ -1,113 +1,166 @@
-<?xml version="1.0"?>
-<robot name="sensor_stereolabs_generic" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_stereolabs_generic"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/depth/depth_camera_plugin.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/depth/irred_camera_plugin.urdf.xacro" />
-  <xacro:include filename="$(find robotnik_sensors)/urdf/camera/camera_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/depth/depth_camera_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/depth/irred_camera_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/camera/camera_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_stereolabs_generic"
-               params="frame_prefix
-                       parent
-                       *origin
-                       model:=zed2
-                       gazebo_ignition:=false
-                       node_name:=stereolabs_generic
-                       node_namespace:=${None}
-                       topic_prefix:=~/
-                       horizontal_fov:=80
-                       vertical_fov:=60
-                       video_width:=1280
-                       video_height:=720
-                       video_fps:=30
-                       min_depth:=0.4
-                       max_depth:=6.5">
+  <xacro:macro
+    name="sensor_stereolabs_generic"
+    params="frame_prefix
+            parent
+            *origin
+            model:=zed2
+            gazebo_ignition:=false
+            node_name:=stereolabs_generic
+            node_namespace:=${None}
+            topic_prefix:=~/
+            horizontal_fov:=80
+            vertical_fov:=60
+            video_width:=1280
+            video_height:=720
+            video_fps:=30
+            min_depth:=0.4
+            max_depth:=6.5">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
-      <xacro:property name="node_namespace" value="${node_name}"/>
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
     </xacro:if>
 
     <xacro:if value="${model == 'zed'}">
-        <xacro:property name="baseline" value="0.12" />
+        <xacro:property
+        name="baseline"
+        value="0.12" />
     </xacro:if>
     <xacro:if value="${model == 'zedm'}">
-        <xacro:property name="baseline" value="0.06" />
+        <xacro:property
+        name="baseline"
+        value="0.06" />
     </xacro:if>
     <xacro:if value="${model == 'zed2'}">
-        <xacro:property name="baseline" value="0.12" />
+        <xacro:property
+        name="baseline"
+        value="0.12" />
     </xacro:if>
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
       <xacro:insert_block name="origin" />
-      <parent link="${parent}"/>
+      <parent link="${parent}" />
       <child link="${frame_prefix}base_link" />
     </joint>
     <link name="${frame_prefix}base_link">
        <visual>
-        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/depth/stereolabs_zed/${model}.stl"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/depth/stereolabs_zed/${model}.stl" />
         </geometry>
         <material name="light_zed_grey">
-          <color rgba="0.35 0.35 0.35 1"/>
+          <color rgba="0.35 0.35 0.35 1" />
         </material>
       </visual>
       <collision>
-        <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
+        <origin
+          xyz="0.0 0.0 0.0"
+          rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/depth/stereolabs_zed/${model}.stl"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/depth/stereolabs_zed/${model}.stl" />
         </geometry>
       </collision>
       <inertial>
         <mass value="0.135" />
         <origin xyz="0 0 0" />
-        <xacro:solid_cuboid_inertia m="0.135" w="0.033" h="0.175" d="0.03" />
+        <xacro:solid_cuboid_inertia
+          m="0.135"
+          w="0.033"
+          h="0.175"
+          d="0.03" />
       </inertial>
     </link>
 
    <!-- Left camera -->
-    <joint name="${frame_prefix}color_left_joint" type="fixed">
-      <origin xyz="0.0 0.06 0.0" rpy="0.0 0.0 0.0" />
+    <joint
+      name="${frame_prefix}color_left_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0.06 0.0"
+        rpy="0.0 0.0 0.0" />
       <parent link="${frame_prefix}base_link" />
       <child link="${frame_prefix}left_camera_frame" />
     </joint>
-    <link name="${frame_prefix}left_camera_frame"/>
+    <link name="${frame_prefix}left_camera_frame" />
 
-    <joint name="${frame_prefix}color_left_optical_joint" type="fixed">
-      <origin xyz="0.0 0.0 0.0" rpy="${-pi/2} 0.0 ${-pi/2}" />
+    <joint
+      name="${frame_prefix}color_left_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0.0 0.0"
+        rpy="${-radians(90)} 0.0 ${-radians(90)}" />
       <parent link="${frame_prefix}left_camera_frame" />
-      <child link="${frame_prefix}left_camera_optical_frame" />
+      <child
+        link="${frame_prefix}left_camera_optical_frame" />
     </joint>
-    <link name="${frame_prefix}left_camera_optical_frame"/>
+    <link name="${frame_prefix}left_camera_optical_frame" />
 
     <!-- Right camera-->
-    <joint name="${frame_prefix}color_right_joint" type="fixed">
-      <origin xyz="0.0 -0.06 0.0" rpy="0.0 0.0 0.0" />
+    <joint
+      name="${frame_prefix}color_right_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 -0.06 0.0"
+        rpy="0.0 0.0 0.0" />
       <parent link="${frame_prefix}base_link" />
       <child link="${frame_prefix}right_camera_frame" />
     </joint>
-    <link name="${frame_prefix}right_camera_frame"/>
+    <link name="${frame_prefix}right_camera_frame" />
 
-    <joint name="${frame_prefix}color_right_optical_joint" type="fixed">
-      <origin xyz="0.0 0 0.0" rpy="${-pi/2} 0.0 ${-pi/2}" />
+    <joint
+      name="${frame_prefix}color_right_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0 0.0"
+        rpy="${-radians(90)} 0.0 ${-radians(90)}" />
       <parent link="${frame_prefix}right_camera_frame" />
-      <child link="${frame_prefix}right_camera_optical_frame" />
+      <child
+        link="${frame_prefix}right_camera_optical_frame" />
     </joint>
-    <link name="${frame_prefix}right_camera_optical_frame"/>
+    <link
+      name="${frame_prefix}right_camera_optical_frame" />
 
     <!-- Depth image-->
-    <joint name="${frame_prefix}depth_joint" type="fixed">
-      <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+    <joint
+      name="${frame_prefix}depth_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0.0 0.0"
+        rpy="0.0 0.0 0.0" />
       <parent link="${frame_prefix}base_link" />
       <child link="${frame_prefix}depth_frame" />
     </joint>
-    <link name="${frame_prefix}depth_frame"/>
+    <link name="${frame_prefix}depth_frame" />
 
-    <joint name="${frame_prefix}depth_optical_joint" type="fixed">
-      <origin xyz="0.0 0.0 0.0" rpy="${-pi/2} 0.0 ${-pi/2}" />
+    <joint
+      name="${frame_prefix}depth_optical_joint"
+      type="fixed">
+      <origin
+        xyz="0.0 0.0 0.0"
+        rpy="${-radians(90)} 0.0 ${-radians(90)}" />
       <parent link="${frame_prefix}depth_frame" />
       <child link="${frame_prefix}depth_optical_frame" />
     </joint>
-    <link name="${frame_prefix}depth_optical_frame"/>
+    <link name="${frame_prefix}depth_optical_frame" />
 
     <xacro:camera_plugin
       node_namespace="${node_namespace}"
@@ -122,8 +175,7 @@
       video_height="${video_height}"
       min_depth="0.1"
       max_depth="100"
-      rate="30"
-    >
+      rate="30">
     </xacro:camera_plugin>
 
     <xacro:camera_plugin
@@ -139,8 +191,7 @@
       video_height="${video_height}"
       min_depth="0.1"
       max_depth="100"
-      rate="30"
-    >
+      rate="30">
     </xacro:camera_plugin>
 
     <xacro:depth_camera_plugin
@@ -156,8 +207,7 @@
       video_height="${video_height}"
       min_depth="${min_depth}"
       max_depth="${max_depth}"
-      rate="30"
-    >
+      rate="30">
     </xacro:depth_camera_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/depth/stereolabs_zed2.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/stereolabs_zed2.urdf.xacro
@@ -11,7 +11,6 @@
             node_namespace:=stereolabs_zed2
             node_name:=stereolabs_zed2
             topic_prefix:=~/">
-
     <xacro:sensor_stereolabs_generic
       frame_prefix="${frame_prefix}"
       parent="${parent}"

--- a/robotnik_sensors/urdf/depth/stereolabs_zed2.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/stereolabs_zed2.urdf.xacro
@@ -1,28 +1,32 @@
-<?xml version="1.0"?>
-<robot name="sensor_stereolabs_zed2" xmlns:xacro="http://wiki.ros.org/xacro">
-  <xacro:macro name="sensor_stereolabs_zed2"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_namespace:=stereolabs_zed2
-                       node_name:=stereolabs_zed2
-                       topic_prefix:=~/">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_stereolabs_zed2"
+  xmlns:xacro="http://wiki.ros.org/xacro">
+  <xacro:macro
+    name="sensor_stereolabs_zed2"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_namespace:=stereolabs_zed2
+            node_name:=stereolabs_zed2
+            topic_prefix:=~/">
 
-    <xacro:sensor_stereolabs_generic frame_prefix="${frame_prefix}"
-                                     parent="${parent}"
-                                     model="zed2"
-                                     gazebo_ignition="false"
-                                     node_namespace="${node_namespace}"
-                                     node_name="${node_name}"
-                                     topic_prefix="${topic_prefix}"
-                                     horizontal_fov="110"
-                                     vertical_fov="70"
-                                     video_width="1920"
-                                     video_height="1080"
-                                     video_fps="30"
-                                     min_depth="0.2"
-                                     max_depth="20.0">
+    <xacro:sensor_stereolabs_generic
+      frame_prefix="${frame_prefix}"
+      parent="${parent}"
+      model="zed2"
+      gazebo_ignition="false"
+      node_namespace="${node_namespace}"
+      node_name="${node_name}"
+      topic_prefix="${topic_prefix}"
+      horizontal_fov="110"
+      vertical_fov="70"
+      video_width="1920"
+      video_height="1080"
+      video_fps="30"
+      min_depth="0.2"
+      max_depth="20.0">
       <xacro:insert_block name="origin" />
     </xacro:sensor_stereolabs_generic>
   </xacro:macro>

--- a/robotnik_sensors/urdf/depth/stereolabs_zed2i.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/stereolabs_zed2i.urdf.xacro
@@ -1,41 +1,50 @@
-<?xml version="1.0"?>
-<robot name="sensor_stereolabs_zed2i" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_stereolabs_zed2i"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/imu/imu_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/imu/imu_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_stereolabs_zed2i"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_namespace:=stereolabs_zed2i
-                       node_name:=stereolabs_zed2i
-                       topic_prefix:=~/">
+  <xacro:macro
+    name="sensor_stereolabs_zed2i"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_namespace:=stereolabs_zed2i
+            node_name:=stereolabs_zed2i
+            topic_prefix:=~/">
 
-    <xacro:sensor_stereolabs_generic frame_prefix="${frame_prefix}"
-                                     parent="${parent}"
-                                     model="zed2"
-                                     gazebo_ignition="false"
-                                     node_namespace="${node_namespace}"
-                                     node_name="${node_name}"
-                                     topic_prefix="${topic_prefix}"
-                                     horizontal_fov="110"
-                                     vertical_fov="70"
-                                     video_width="1920"
-                                     video_height="1080"
-                                     video_fps="30"
-                                     min_depth="0.2"
-                                     max_depth="20.0">
+    <xacro:sensor_stereolabs_generic
+      frame_prefix="${frame_prefix}"
+      parent="${parent}"
+      model="zed2"
+      gazebo_ignition="false"
+      node_namespace="${node_namespace}"
+      node_name="${node_name}"
+      topic_prefix="${topic_prefix}"
+      horizontal_fov="110"
+      vertical_fov="70"
+      video_width="1920"
+      video_height="1080"
+      video_fps="30"
+      min_depth="0.2"
+      max_depth="20.0">
       <xacro:insert_block name="origin" />
     </xacro:sensor_stereolabs_generic>
 
     <!-- Imu frame -->
-    <joint name="${frame_prefix}imu_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="0 0 0" />
+    <joint
+      name="${frame_prefix}imu_joint"
+      type="fixed">
+      <origin
+        xyz="0 0 0"
+        rpy="0 0 0" />
       <parent link="${frame_prefix}base_link" />
       <child link="${frame_prefix}imu_frame" />
     </joint>
-    <link name="${frame_prefix}imu_frame"/>
+    <link name="${frame_prefix}imu_frame" />
 
     <!-- Imu -->
     <xacro:imu_plugin
@@ -43,8 +52,7 @@
       node_name="${node_name}"
       gazebo_ignition="${gazebo_ignition}"
       frame_link="${frame_prefix}imu_frame"
-      rate="200.0"
-    >
+      rate="200.0">
     </xacro:imu_plugin>
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/depth/stereolabs_zed2i.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/stereolabs_zed2i.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_stereolabs_zed2i"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/imu/imu_plugin.urdf.xacro" />
 
@@ -15,7 +14,6 @@
             node_namespace:=stereolabs_zed2i
             node_name:=stereolabs_zed2i
             topic_prefix:=~/">
-
     <xacro:sensor_stereolabs_generic
       frame_prefix="${frame_prefix}"
       parent="${parent}"
@@ -52,7 +50,6 @@
       node_name="${node_name}"
       gazebo_ignition="${gazebo_ignition}"
       frame_link="${frame_prefix}imu_frame"
-      rate="200.0">
-    </xacro:imu_plugin>
+      rate="200.0" />
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/gps/gps.urdf.xacro
+++ b/robotnik_sensors/urdf/gps/gps.urdf.xacro
@@ -1,42 +1,60 @@
-<?xml version="1.0"?>
-<robot name="sensor_gps" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_gps"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/gps/gps_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/gps/gps_plugin.urdf.xacro" />
 
-	<xacro:macro name="sensor_gps"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=gps
-                       node_namespace:=${None}
-                       topic_prefix:=~/
-                       update_rate:=5.0">
+	<xacro:macro
+    name="sensor_gps"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=gps
+            node_namespace:=${None}
+            topic_prefix:=~/
+            update_rate:=1.0">
 
-	  <joint name="${frame_prefix}joint" type="fixed">
-	    <xacro:insert_block name="origin"/>
-	    <parent link="${parent}"/>
-	    <child link="${frame_prefix}base_link"/>
+	  <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+	    <xacro:insert_block name="origin" />
+	    <parent link="${parent}" />
+	    <child link="${frame_prefix}base_link" />
 	  </joint>
 	  <link name="${frame_prefix}base_link">
       <inertial>
-        <origin xyz="0.0 0 0.015" rpy="0 0 0" />
+        <origin
+          xyz="0.0 0 0.015"
+          rpy="0 0 0" />
         <mass value="0.2" />
-        <xacro:solid_cuboid_inertia m="0.2" w="0.081" h="0.081" d="0.03" />
+        <xacro:solid_cuboid_inertia
+          m="0.2"
+          w="0.081"
+          h="0.081"
+          d="0.03" />
       </inertial>
 	    <visual>
-	      <origin rpy="0 0 0" xyz="0 0 0"/>
+	      <origin
+          rpy="0 0 0"
+          xyz="0 0 0" />
 	      <material name="gps_color">
-           <color rgba="1 1 1 1"/>
+           <color rgba="1 1 1 1" />
         </material>
 	      <geometry>
-	        <mesh filename="package://robotnik_sensors/meshes/gps/antenna_3GO16.stl"/>
+	        <mesh
+            filename="package://robotnik_sensors/meshes/gps/antenna_3GO16.stl" />
 	      </geometry>
 	    </visual>
 	    <collision>
-	      <origin rpy="0 0 0" xyz="0 0 0"/>
+	      <origin
+          rpy="0 0 0"
+          xyz="0 0 0" />
 	      <geometry>
-	        <mesh filename="package://robotnik_sensors/meshes/gps/antenna_3GO16.stl"/>
+	        <mesh
+            filename="package://robotnik_sensors/meshes/gps/antenna_3GO16.stl" />
 	      </geometry>
 	    </collision>
 	  </link>
@@ -52,8 +70,7 @@
       gazebo_ignition="${gazebo_ignition}"
       topic_prefix="${topic_prefix}_gps"
       frame_link="${frame_prefix}base_link"
-      rate="${update_rate}"
-    >
+      rate="${update_rate}">
     </xacro:gps_plugin>
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/gps/gps.urdf.xacro
+++ b/robotnik_sensors/urdf/gps/gps.urdf.xacro
@@ -2,11 +2,10 @@
 <robot
   name="sensor_gps"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/gps/gps_plugin.urdf.xacro" />
 
-	<xacro:macro
+  <xacro:macro
     name="sensor_gps"
     params="frame_prefix
             parent
@@ -16,15 +15,14 @@
             node_namespace:=${None}
             topic_prefix:=~/
             update_rate:=1.0">
-
-	  <joint
+    <joint
       name="${frame_prefix}joint"
       type="fixed">
-	    <xacro:insert_block name="origin" />
-	    <parent link="${parent}" />
-	    <child link="${frame_prefix}base_link" />
-	  </joint>
-	  <link name="${frame_prefix}base_link">
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
+    </joint>
+    <link name="${frame_prefix}base_link">
       <inertial>
         <origin
           xyz="0.0 0 0.015"
@@ -36,33 +34,33 @@
           h="0.081"
           d="0.03" />
       </inertial>
-	    <visual>
-	      <origin
+      <visual>
+        <origin
           rpy="0 0 0"
           xyz="0 0 0" />
-	      <material name="gps_color">
-           <color rgba="1 1 1 1" />
+        <material name="gps_color">
+          <color rgba="1 1 1 1" />
         </material>
-	      <geometry>
-	        <mesh
+        <geometry>
+          <mesh
             filename="package://robotnik_sensors/meshes/gps/antenna_3GO16.stl" />
-	      </geometry>
-	    </visual>
-	    <collision>
-	      <origin
+        </geometry>
+      </visual>
+      <collision>
+        <origin
           rpy="0 0 0"
           xyz="0 0 0" />
-	      <geometry>
-	        <mesh
+        <geometry>
+          <mesh
             filename="package://robotnik_sensors/meshes/gps/antenna_3GO16.stl" />
-	      </geometry>
-	    </collision>
-	  </link>
+        </geometry>
+      </collision>
+    </link>
 
-	  <gazebo reference="${frame_prefix}base_link">
-	    <material>Gazebo/White</material>
-	    <gravity>true</gravity>
-	  </gazebo>
+    <gazebo reference="${frame_prefix}base_link">
+      <material>Gazebo/White</material>
+      <gravity>true</gravity>
+    </gazebo>
 
     <xacro:gps_plugin
       node_namespace="${node_namespace}"
@@ -70,7 +68,6 @@
       gazebo_ignition="${gazebo_ignition}"
       topic_prefix="${topic_prefix}_gps"
       frame_link="${frame_prefix}base_link"
-      rate="${update_rate}">
-    </xacro:gps_plugin>
+      rate="${update_rate}" />
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/gps/gps_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/gps/gps_plugin.urdf.xacro
@@ -1,8 +1,11 @@
-<?xml version="1.0"?>
-<robot name="gps_plugin" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="gps_plugin"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="gps_plugin" params="
-            node_namespace
+  <xacro:macro
+    name="gps_plugin"
+    params="node_namespace
             node_name
             frame_link
             topic_prefix
@@ -12,19 +15,21 @@
 
     <xacro:if value="${gazebo_ignition}">
         <gazebo reference="${frame_link}">
-            <sensor name="${node_name}" type="navsat">
+            <sensor
+          name="${node_name}"
+          type="navsat">
                 <navsat>
                     <position_sensing>
                     <horizontal>
                         <noise type="gaussian">
-                        <mean>0.0</mean>
-                        <stddev>0.1</stddev>
+                        <mean>0</mean>
+                        <stddev>1.75e-6</stddev>
                         </noise>
                     </horizontal>
                     <vertical>
                         <noise type="gaussian">
                         <mean>0.0</mean>
-                        <stddev>0.1</stddev>
+                        <stddev>1.35e-6</stddev>
                         </noise>
                     </vertical>
                     </position_sensing>
@@ -32,22 +37,24 @@
                     <horizontal>
                         <noise type="gaussian">
                         <mean>0.0</mean>
-                        <stddev>0.1</stddev>
+                        <stddev>0.0001</stddev>
                         </noise>
                     </horizontal>
                     <vertical>
                         <noise type="gaussian">
                         <mean>0.0</mean>
-                        <stddev>0.1</stddev>
+                        <stddev>0.0001</stddev>
                         </noise>
                     </vertical>
                     </vertical_sensing>
                 </navsat>
                 <always_on>1</always_on>
-                <update_rate>${rate}</update_rate>
+                <update_rate>1.0</update_rate>
                 <topic>${node_namespace}/${node_name}/data</topic>
                 <gz_frame_id>${frame_link}</gz_frame_id>
-                <plugin filename="ignition-gazebo-navsat-system" name="ignition::gazebo::systems::NavSat"/>
+                <plugin
+            filename="ignition-gazebo-navsat-system"
+            name="ignition::gazebo::systems::NavSat" />
             </sensor>
         </gazebo>
     </xacro:if>

--- a/robotnik_sensors/urdf/gps/gps_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/gps/gps_plugin.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="gps_plugin"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="gps_plugin"
     params="node_namespace
@@ -12,53 +11,50 @@
             gazebo_ignition
             rate
             ">
-
     <xacro:if value="${gazebo_ignition}">
-        <gazebo reference="${frame_link}">
-            <sensor
+      <gazebo reference="${frame_link}">
+        <sensor
           name="${node_name}"
           type="navsat">
-                <navsat>
-                    <position_sensing>
-                    <horizontal>
-                        <noise type="gaussian">
-                        <mean>0</mean>
-                        <stddev>1.75e-6</stddev>
-                        </noise>
-                    </horizontal>
-                    <vertical>
-                        <noise type="gaussian">
-                        <mean>0.0</mean>
-                        <stddev>1.35e-6</stddev>
-                        </noise>
-                    </vertical>
-                    </position_sensing>
-                    <vertical_sensing>
-                    <horizontal>
-                        <noise type="gaussian">
-                        <mean>0.0</mean>
-                        <stddev>0.0001</stddev>
-                        </noise>
-                    </horizontal>
-                    <vertical>
-                        <noise type="gaussian">
-                        <mean>0.0</mean>
-                        <stddev>0.0001</stddev>
-                        </noise>
-                    </vertical>
-                    </vertical_sensing>
-                </navsat>
-                <always_on>1</always_on>
-                <update_rate>1.0</update_rate>
-                <topic>${node_namespace}/${node_name}/data</topic>
-                <gz_frame_id>${frame_link}</gz_frame_id>
-                <plugin
+          <navsat>
+            <position_sensing>
+              <horizontal>
+                <noise type="gaussian">
+                  <mean>0</mean>
+                  <stddev>1.75e-6</stddev>
+                </noise>
+              </horizontal>
+              <vertical>
+                <noise type="gaussian">
+                  <mean>0.0</mean>
+                  <stddev>1.35e-6</stddev>
+                </noise>
+              </vertical>
+            </position_sensing>
+            <vertical_sensing>
+              <horizontal>
+                <noise type="gaussian">
+                  <mean>0.0</mean>
+                  <stddev>0.0001</stddev>
+                </noise>
+              </horizontal>
+              <vertical>
+                <noise type="gaussian">
+                  <mean>0.0</mean>
+                  <stddev>0.0001</stddev>
+                </noise>
+              </vertical>
+            </vertical_sensing>
+          </navsat>
+          <always_on>1</always_on>
+          <update_rate>1.0</update_rate>
+          <topic>${node_namespace}/${node_name}/data</topic>
+          <gz_frame_id>${frame_link}</gz_frame_id>
+          <plugin
             filename="ignition-gazebo-navsat-system"
             name="ignition::gazebo::systems::NavSat" />
-            </sensor>
-        </gazebo>
+        </sensor>
+      </gazebo>
     </xacro:if>
-
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/gps/gps_with_mast.urdf.xacro
+++ b/robotnik_sensors/urdf/gps/gps_with_mast.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_gps_with_mast"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/gps/gps_plugin.urdf.xacro" />
 
@@ -13,7 +12,7 @@
     name="mast_radius"
     value="0.010" />
 
-	<xacro:macro
+  <xacro:macro
     name="sensor_gps_with_mast"
     params="frame_prefix
 			parent
@@ -23,111 +22,109 @@
 			node_namespace:=${None}
 			topic_prefix:=~/
 			update_rate:=1.0">
-
-	  <!-- MAST OF THE ANTENNA GPS -->
-	  <joint
+    <!-- MAST OF THE ANTENNA GPS -->
+    <joint
       name="${frame_prefix}joint"
       type="fixed">
-	    <xacro:insert_block name="origin" />
-	    <parent link="${parent}" />
-	    <child link="${frame_prefix}mast_base_link" />
-	  </joint>
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${frame_prefix}mast_base_link" />
+    </joint>
 
-	  <link name="${frame_prefix}mast_base_link">
-		<inertial>
-			<origin
+    <link name="${frame_prefix}mast_base_link">
+      <inertial>
+        <origin
           xyz="0.0 0 0.0"
           rpy="0 0 0" />
-			<mass value="1.0" />
-			<xacro:solid_cuboid_inertia
+        <mass value="1.0" />
+        <xacro:solid_cuboid_inertia
           m="1.0"
           w="${mast_radius}"
           h="${mast_radius}"
           d="${mast_height}" />
-		</inertial>
-	    <visual>
-	      <origin
+      </inertial>
+      <visual>
+        <origin
           rpy="0 0 0"
           xyz="0 0 0" />
-	      <material name="mast_color">
-            <color rgba="0.1 0.1 0.1 1" />
-          </material>
-	      <geometry>
-	        <cylinder
+        <material name="mast_color">
+          <color rgba="0.1 0.1 0.1 1" />
+        </material>
+        <geometry>
+          <cylinder
             length="${mast_height}"
             radius="${mast_radius}" />
-	      </geometry>
-	    </visual>
-	    <collision>
-	      <origin
+        </geometry>
+      </visual>
+      <collision>
+        <origin
           rpy="0 0 0"
           xyz="0 0 0" />
-	      <geometry>
-	        <cylinder
+        <geometry>
+          <cylinder
             length="${mast_height}"
             radius="${mast_radius}" />
-	      </geometry>
-	    </collision>
-	  </link>
+        </geometry>
+      </collision>
+    </link>
 
-	  <joint
+    <joint
       name="${frame_prefix}mast_joint"
       type="fixed">
-	    <parent link="${frame_prefix}mast_base_link" />
-	    <child link="${frame_prefix}base_link" />
-	    <origin
+      <parent link="${frame_prefix}mast_base_link" />
+      <child link="${frame_prefix}base_link" />
+      <origin
         xyz="0 0 ${mast_height/2.0}"
         rpy="0 0 0" />
-	  </joint>
+    </joint>
 
-	  <gazebo reference="${frame_prefix}mast_base_link">
-	    <material>Gazebo/Black</material>
-	    <gravity>true</gravity>
-	  </gazebo>
+    <gazebo reference="${frame_prefix}mast_base_link">
+      <material>Gazebo/Black</material>
+      <gravity>true</gravity>
+    </gazebo>
 
-      <!-- ANTENNA GPS -->
-	  <link name="${frame_prefix}base_link">
-	    <inertial>
-			<origin
+    <!-- ANTENNA GPS -->
+    <link name="${frame_prefix}base_link">
+      <inertial>
+        <origin
           xyz="0.0 0 0.015"
           rpy="0 0 0" />
-			<mass value="0.2" />
-			<xacro:solid_cuboid_inertia
+        <mass value="0.2" />
+        <xacro:solid_cuboid_inertia
           m="0.2"
           w="0.081"
           h="0.081"
           d="0.03" />
-      	</inertial>
-	    <visual>
-	      <origin
+      </inertial>
+      <visual>
+        <origin
           rpy="0 0 0"
           xyz="0 0 0" />
-	      <material name="gps_color">
-           <color rgba="1 1 1 1" />
+        <material name="gps_color">
+          <color rgba="1 1 1 1" />
         </material>
-	      <geometry>
-	        <mesh
+        <geometry>
+          <mesh
             filename="package://robotnik_sensors/meshes/gps/antenna_3GO16.stl"
             scale="1.0 1.0 1.0" />
-	      </geometry>
-	    </visual>
-	    <collision>
-	      <origin
+        </geometry>
+      </visual>
+      <collision>
+        <origin
           rpy="0 0 0"
           xyz="0 0 0" />
-	      <geometry>
-	        <mesh
+        <geometry>
+          <mesh
             filename="package://robotnik_sensors/meshes/gps/antenna_3GO16.stl"
             scale="1.0 1.0 1.0" />
-	      </geometry>
-	    </collision>
-	  </link>
+        </geometry>
+      </collision>
+    </link>
 
-
-	<gazebo reference="${frame_prefix}base_link">
-	<material>Gazebo/White</material>
-	<gravity>true</gravity>
-	</gazebo>
+    <gazebo reference="${frame_prefix}base_link">
+      <material>Gazebo/White</material>
+      <gravity>true</gravity>
+    </gazebo>
 
     <xacro:gps_plugin
       node_namespace="${node_namespace}"
@@ -135,9 +132,6 @@
       gazebo_ignition="${gazebo_ignition}"
       topic_prefix="${topic_prefix}_gps"
       frame_link="${frame_prefix}base_link"
-      rate="${update_rate}">
-    </xacro:gps_plugin>
-
+      rate="${update_rate}" />
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/gps/gps_with_mast.urdf.xacro
+++ b/robotnik_sensors/urdf/gps/gps_with_mast.urdf.xacro
@@ -1,55 +1,83 @@
-<?xml version="1.0"?>
-<robot name="sensor_gps_with_mast" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_gps_with_mast"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/gps/gps_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/gps/gps_plugin.urdf.xacro" />
 
-  <xacro:property name="mast_height" value="0.5" />
-  <xacro:property name="mast_radius" value="0.010" />
+  <xacro:property
+    name="mast_height"
+    value="0.5" />
+  <xacro:property
+    name="mast_radius"
+    value="0.010" />
 
-	<xacro:macro name="sensor_gps_with_mast"
-			params="frame_prefix
-					parent
-					*origin
-										gazebo_ignition:=false
-					node_name:=gps_with_mast
-					node_namespace:=${None}
-					topic_prefix:=~/
-					update_rate:=5.0">
+	<xacro:macro
+    name="sensor_gps_with_mast"
+    params="frame_prefix
+			parent
+			*origin
+			gazebo_ignition:=false
+			node_name:=gps_with_mast
+			node_namespace:=${None}
+			topic_prefix:=~/
+			update_rate:=1.0">
 
 	  <!-- MAST OF THE ANTENNA GPS -->
-	  <joint name="${frame_prefix}joint" type="fixed">
-	    <xacro:insert_block name="origin"/>
-	    <parent link="${parent}"/>
-	    <child link="${frame_prefix}mast_base_link"/>
+	  <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+	    <xacro:insert_block name="origin" />
+	    <parent link="${parent}" />
+	    <child link="${frame_prefix}mast_base_link" />
 	  </joint>
 
 	  <link name="${frame_prefix}mast_base_link">
 		<inertial>
-			<origin xyz="0.0 0 0.0" rpy="0 0 0" />
+			<origin
+          xyz="0.0 0 0.0"
+          rpy="0 0 0" />
 			<mass value="1.0" />
-			<xacro:solid_cuboid_inertia m="1.0" w="${mast_radius}" h="${mast_radius}" d="${mast_height}" />
+			<xacro:solid_cuboid_inertia
+          m="1.0"
+          w="${mast_radius}"
+          h="${mast_radius}"
+          d="${mast_height}" />
 		</inertial>
 	    <visual>
-	      <origin rpy="0 0 0" xyz="0 0 0"/>
+	      <origin
+          rpy="0 0 0"
+          xyz="0 0 0" />
 	      <material name="mast_color">
-            <color rgba="0.1 0.1 0.1 1"/>
+            <color rgba="0.1 0.1 0.1 1" />
           </material>
 	      <geometry>
-	        <cylinder length="${mast_height}" radius="${mast_radius}" />
+	        <cylinder
+            length="${mast_height}"
+            radius="${mast_radius}" />
 	      </geometry>
 	    </visual>
 	    <collision>
-	      <origin rpy="0 0 0" xyz="0 0 0"/>
+	      <origin
+          rpy="0 0 0"
+          xyz="0 0 0" />
 	      <geometry>
-	        <cylinder length="${mast_height}" radius="${mast_radius}" />
+	        <cylinder
+            length="${mast_height}"
+            radius="${mast_radius}" />
 	      </geometry>
 	    </collision>
 	  </link>
 
-	  <joint name="${frame_prefix}mast_joint" type="fixed">
-	    <parent link="${frame_prefix}mast_base_link"/>
-	    <child link="${frame_prefix}base_link"/>
-	    <origin xyz="0 0 ${mast_height/2.0}" rpy="0 0 0" />
+	  <joint
+      name="${frame_prefix}mast_joint"
+      type="fixed">
+	    <parent link="${frame_prefix}mast_base_link" />
+	    <child link="${frame_prefix}base_link" />
+	    <origin
+        xyz="0 0 ${mast_height/2.0}"
+        rpy="0 0 0" />
 	  </joint>
 
 	  <gazebo reference="${frame_prefix}mast_base_link">
@@ -60,23 +88,37 @@
       <!-- ANTENNA GPS -->
 	  <link name="${frame_prefix}base_link">
 	    <inertial>
-			<origin xyz="0.0 0 0.015" rpy="0 0 0" />
+			<origin
+          xyz="0.0 0 0.015"
+          rpy="0 0 0" />
 			<mass value="0.2" />
-			<xacro:solid_cuboid_inertia m="0.2" w="0.081" h="0.081" d="0.03" />
+			<xacro:solid_cuboid_inertia
+          m="0.2"
+          w="0.081"
+          h="0.081"
+          d="0.03" />
       	</inertial>
 	    <visual>
-	      <origin rpy="0 0 0" xyz="0 0 0"/>
+	      <origin
+          rpy="0 0 0"
+          xyz="0 0 0" />
 	      <material name="gps_color">
-           <color rgba="1 1 1 1"/>
+           <color rgba="1 1 1 1" />
         </material>
 	      <geometry>
-	        <mesh filename="package://robotnik_sensors/meshes/gps/antenna_3GO16.stl" scale="1.0 1.0 1.0"/>
+	        <mesh
+            filename="package://robotnik_sensors/meshes/gps/antenna_3GO16.stl"
+            scale="1.0 1.0 1.0" />
 	      </geometry>
 	    </visual>
 	    <collision>
-	      <origin rpy="0 0 0" xyz="0 0 0"/>
+	      <origin
+          rpy="0 0 0"
+          xyz="0 0 0" />
 	      <geometry>
-	        <mesh filename="package://robotnik_sensors/meshes/gps/antenna_3GO16.stl" scale="1.0 1.0 1.0"/>
+	        <mesh
+            filename="package://robotnik_sensors/meshes/gps/antenna_3GO16.stl"
+            scale="1.0 1.0 1.0" />
 	      </geometry>
 	    </collision>
 	  </link>
@@ -93,8 +135,7 @@
       gazebo_ignition="${gazebo_ignition}"
       topic_prefix="${topic_prefix}_gps"
       frame_link="${frame_prefix}base_link"
-      rate="${update_rate}"
-    >
+      rate="${update_rate}">
     </xacro:gps_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/gps/ublox.urdf.xacro
+++ b/robotnik_sensors/urdf/gps/ublox.urdf.xacro
@@ -2,11 +2,10 @@
 <robot
   name="sensor_ublox"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/gps/gps_plugin.urdf.xacro" />
 
-	<xacro:macro
+  <xacro:macro
     name="sensor_ublox"
     params="frame_prefix
 			      parent
@@ -16,65 +15,63 @@
 			      node_namespace:=${None}
 			      topic_prefix:=~/
 			      update_rate:=5.0">
-	  <!-- ANTENNA GPS -->
-	  <joint
+    <!-- ANTENNA GPS -->
+    <joint
       name="${frame_prefix}base_joint"
       type="fixed">
-	    <xacro:insert_block name="origin" />
-	    <parent link="${parent}" />
-	    <child link="${frame_prefix}base_link" />
-	  </joint>
-	  <link name="${frame_prefix}base_link">
-		<inertial>
-			<origin
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
+    </joint>
+    <link name="${frame_prefix}base_link">
+      <inertial>
+        <origin
           xyz="0.0 0 0.015"
           rpy="0 0 0" />
-			<mass value="0.2" />
-			<xacro:solid_cuboid_inertia
+        <mass value="0.2" />
+        <xacro:solid_cuboid_inertia
           m="0.2"
           w="0.081"
           h="0.081"
           d="0.03" />
-                </inertial>
-	    <visual>
-	      <origin
+      </inertial>
+      <visual>
+        <origin
           rpy="0 0 0"
           xyz="0 0 0" />
-		  <material name="ublox_gps_color">
-           <color rgba="0.5 0.5 0.5 1" />
-          </material>
-	      <geometry>
-	        <mesh
+        <material name="ublox_gps_color">
+          <color rgba="0.5 0.5 0.5 1" />
+        </material>
+        <geometry>
+          <mesh
             filename="package://robotnik_sensors/meshes/gps/antenna_ANN_MB.stl"
             scale="1.0 1.0 1.0" />
-	      </geometry>
-	    </visual>
-	    <collision>
-	      <origin
+        </geometry>
+      </visual>
+      <collision>
+        <origin
           rpy="0 0 0"
           xyz="0 0 0.01125" />
-	        <geometry>
-	          <box size="0.0607 0.083 0.0225" />
-	        </geometry>
-	    </collision>
-	  </link>
+        <geometry>
+          <box size="0.0607 0.083 0.0225" />
+        </geometry>
+      </collision>
+    </link>
 
-	  <gazebo reference="${frame_prefix}base_link">
-	    <material>Gazebo/White</material>
-	    <gravity>true</gravity>
-	  </gazebo>
+    <gazebo reference="${frame_prefix}base_link">
+      <material>Gazebo/White</material>
+      <gravity>true</gravity>
+    </gazebo>
 
-	  <joint
+    <joint
       name="${frame_prefix}joint"
       type="fixed">
-	      <origin xyz="0.0 0.0 0.01125" />
-	      <parent link="${frame_prefix}base_link" />
-	      <child link="${frame_prefix}link" />
-	  </joint>
+      <origin xyz="0.0 0.0 0.01125" />
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
+    </joint>
 
-	  <link name="${frame_prefix}link">
-	  </link>
-
+    <link name="${frame_prefix}link" />
 
     <xacro:gps_plugin
       node_namespace="${node_namespace}"
@@ -82,9 +79,6 @@
       gazebo_ignition="${gazebo_ignition}"
       topic_prefix="${topic_prefix}_gps"
       frame_link="${frame_prefix}base_link"
-      rate="${update_rate}">
-    </xacro:gps_plugin>
-
+      rate="${update_rate}" />
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/gps/ublox.urdf.xacro
+++ b/robotnik_sensors/urdf/gps/ublox.urdf.xacro
@@ -1,42 +1,60 @@
-<?xml version="1.0"?>
-<robot name="sensor_ublox" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_ublox"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/gps/gps_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/gps/gps_plugin.urdf.xacro" />
 
-	<xacro:macro name="sensor_ublox"
-				params="frame_prefix
-						parent
-						*origin
-												gazebo_ignition:=false
-						node_name:=ublox
-						node_namespace:=${None}
-						topic_prefix:=~/
-						update_rate:=5.0">
+	<xacro:macro
+    name="sensor_ublox"
+    params="frame_prefix
+			      parent
+			      *origin
+			      gazebo_ignition:=false
+			      node_name:=ublox
+			      node_namespace:=${None}
+			      topic_prefix:=~/
+			      update_rate:=5.0">
 	  <!-- ANTENNA GPS -->
-	  <joint name="${frame_prefix}base_joint" type="fixed">
-	    <xacro:insert_block name="origin"/>
-	    <parent link="${parent}"/>
-	    <child link="${frame_prefix}base_link"/>
+	  <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
+	    <xacro:insert_block name="origin" />
+	    <parent link="${parent}" />
+	    <child link="${frame_prefix}base_link" />
 	  </joint>
 	  <link name="${frame_prefix}base_link">
 		<inertial>
-			<origin xyz="0.0 0 0.015" rpy="0 0 0" />
+			<origin
+          xyz="0.0 0 0.015"
+          rpy="0 0 0" />
 			<mass value="0.2" />
-			<xacro:solid_cuboid_inertia m="0.2" w="0.081" h="0.081" d="0.03" />
+			<xacro:solid_cuboid_inertia
+          m="0.2"
+          w="0.081"
+          h="0.081"
+          d="0.03" />
                 </inertial>
 	    <visual>
-	      <origin rpy="0 0 0" xyz="0 0 0"/>
+	      <origin
+          rpy="0 0 0"
+          xyz="0 0 0" />
 		  <material name="ublox_gps_color">
-           <color rgba="0.5 0.5 0.5 1"/>
+           <color rgba="0.5 0.5 0.5 1" />
           </material>
 	      <geometry>
-	        <mesh filename="package://robotnik_sensors/meshes/gps/antenna_ANN_MB.stl" scale="1.0 1.0 1.0"/>
+	        <mesh
+            filename="package://robotnik_sensors/meshes/gps/antenna_ANN_MB.stl"
+            scale="1.0 1.0 1.0" />
 	      </geometry>
 	    </visual>
 	    <collision>
-	      <origin rpy="0 0 0" xyz="0 0 0.01125"/>
+	      <origin
+          rpy="0 0 0"
+          xyz="0 0 0.01125" />
 	        <geometry>
-	          <box size="0.0607 0.083 0.0225"/>
+	          <box size="0.0607 0.083 0.0225" />
 	        </geometry>
 	    </collision>
 	  </link>
@@ -46,12 +64,14 @@
 	    <gravity>true</gravity>
 	  </gazebo>
 
-	  <joint name="${frame_prefix}joint" type="fixed">
-	      <origin xyz="0.0 0.0 0.01125"/>
-	      <parent link="${frame_prefix}base_link"/>
-	      <child link="${frame_prefix}link"/>
+	  <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+	      <origin xyz="0.0 0.0 0.01125" />
+	      <parent link="${frame_prefix}base_link" />
+	      <child link="${frame_prefix}link" />
 	  </joint>
-	
+
 	  <link name="${frame_prefix}link">
 	  </link>
 
@@ -62,8 +82,7 @@
       gazebo_ignition="${gazebo_ignition}"
       topic_prefix="${topic_prefix}_gps"
       frame_link="${frame_prefix}base_link"
-      rate="${update_rate}"
-    >
+      rate="${update_rate}">
     </xacro:gps_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/gps/ublox_with_mast.urdf.xacro
+++ b/robotnik_sensors/urdf/gps/ublox_with_mast.urdf.xacro
@@ -1,75 +1,113 @@
-<?xml version="1.0"?>
-<robot name="sensor_ublox" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_ublox"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/gps/gps_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/gps/gps_plugin.urdf.xacro" />
 
-  <xacro:property name="mast_height" value="0.5" />
-  <xacro:property name="mast_radius" value="0.010" />
+  <xacro:property
+    name="mast_height"
+    value="0.5" />
+  <xacro:property
+    name="mast_radius"
+    value="0.010" />
 
-	<xacro:macro name="sensor_ublox_with_mast"
-				params="frame_prefix
-						parent
-						*origin
-												gazebo_ignition:=false
-						node_name:=ublox
-						node_namespace:=${None}
-						topic_prefix:=~/
-						update_rate:=5.0">
+	<xacro:macro
+    name="sensor_ublox_with_mast"
+    params="frame_prefix
+		        parent
+		        *origin
+		        gazebo_ignition:=false
+		        node_name:=ublox
+		        node_namespace:=${None}
+		        topic_prefix:=~/
+		        update_rate:=5.0">
 	  <!-- ANTENNA GPS -->
-	  <joint name="${frame_prefix}base_joint" type="fixed">
-	    <xacro:insert_block name="origin"/>
-	    <parent link="${parent}"/>
-	    <child link="${frame_prefix}base_link"/>
+	  <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
+	    <xacro:insert_block name="origin" />
+	    <parent link="${parent}" />
+	    <child link="${frame_prefix}base_link" />
 	  </joint>
 
 	  <link name="${frame_prefix}base_link">
 		<inertial>
-			<origin xyz="0.0 0 0.015" rpy="0 0 0" />
+			<origin
+          xyz="0.0 0 0.015"
+          rpy="0 0 0" />
 			<mass value="0.2" />
-			<xacro:solid_cuboid_inertia m="0.2" w="0.081" h="0.081" d="0.03" />
+			<xacro:solid_cuboid_inertia
+          m="0.2"
+          w="0.081"
+          h="0.081"
+          d="0.03" />
       		</inertial>
 	    	<visual>
-	      		<origin rpy="0 0 0" xyz="0 0 0"/>
+	      		<origin
+          rpy="0 0 0"
+          xyz="0 0 0" />
 		  	<material name="ublox_gps_color">
-           			<color rgba="0.5 0.5 0.5 1"/>
+           			<color rgba="0.5 0.5 0.5 1" />
           		</material>
 		        <geometry>
-				<mesh filename="package://robotnik_sensors/meshes/gps/antenna_ANN_MB.stl" scale="1.0 1.0 1.0"/>
+				<mesh
+            filename="package://robotnik_sensors/meshes/gps/antenna_ANN_MB.stl"
+            scale="1.0 1.0 1.0" />
 		        </geometry>
 	    	</visual>
 	        <collision>
-	          	<origin rpy="0 0 0" xyz="0 0 0.01125"/>
+	          	<origin
+          rpy="0 0 0"
+          xyz="0 0 0.01125" />
 		        <geometry>
-		     		<box size="0.0607 0.083 0.0225"/>
+		     		<box size="0.0607 0.083 0.0225" />
 		        </geometry>
 	        </collision>
 	  </link>
 
-	  <joint name="${frame_prefix}mast_joint" type="fixed">
-	    <parent link="${frame_prefix}base_link"/>
-	    <child link="${frame_prefix}mast_base_link"/>
-	    <origin xyz="0 0 -0.37" rpy="0 0 0" />
+	  <joint
+      name="${frame_prefix}mast_joint"
+      type="fixed">
+	    <parent link="${frame_prefix}base_link" />
+	    <child link="${frame_prefix}mast_base_link" />
+	    <origin
+        xyz="0 0 -0.37"
+        rpy="0 0 0" />
 	  </joint>
 
 	  <link name="${frame_prefix}mast_base_link">
 		<inertial>
-			<origin xyz="0.0 0 0.0" rpy="0 0 0" />
+			<origin
+          xyz="0.0 0 0.0"
+          rpy="0 0 0" />
 			<mass value="1.0" />
-			<xacro:solid_cuboid_inertia m="1.0" w="${mast_radius}" h="${mast_radius}" d="${mast_height}" />
+			<xacro:solid_cuboid_inertia
+          m="1.0"
+          w="${mast_radius}"
+          h="${mast_radius}"
+          d="${mast_height}" />
 		</inertial>
 	    	<visual>
-		      <origin rpy="0 0 0" xyz="0 0 0"/>
+		      <origin
+          rpy="0 0 0"
+          xyz="0 0 0" />
 		      <material name="mast_color">
-	              	    <color rgba="0.1 0.1 0.1 1"/>
+	              	    <color rgba="0.1 0.1 0.1 1" />
          	      </material>
 		      <geometry>
-		            <mesh filename="package://robotnik_sensors/meshes/gps/mastil_gps.stl" scale="1.0 1.0 1.0"/>
+		            <mesh
+            filename="package://robotnik_sensors/meshes/gps/mastil_gps.stl"
+            scale="1.0 1.0 1.0" />
 		      </geometry>
 	    	</visual>
 	        <collision>
-	            <origin rpy="0 0 0" xyz="0 0 0"/>
+	            <origin
+          rpy="0 0 0"
+          xyz="0 0 0" />
 	            <geometry>
-			<box size="0.05 0.05 0.2"/>
+			<box size="0.05 0.05 0.2" />
 	            </geometry>
 	    	</collision>
 	  </link>
@@ -90,8 +128,7 @@
       gazebo_ignition="${gazebo_ignition}"
       topic_prefix="${topic_prefix}_gps"
       frame_link="${frame_prefix}base_link"
-      rate="${update_rate}"
-    >
+      rate="${update_rate}">
     </xacro:gps_plugin>
 
   </xacro:macro>

--- a/robotnik_sensors/urdf/gps/ublox_with_mast.urdf.xacro
+++ b/robotnik_sensors/urdf/gps/ublox_with_mast.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_ublox"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/gps/gps_plugin.urdf.xacro" />
 
@@ -13,7 +12,7 @@
     name="mast_radius"
     value="0.010" />
 
-	<xacro:macro
+  <xacro:macro
     name="sensor_ublox_with_mast"
     params="frame_prefix
 		        parent
@@ -23,104 +22,104 @@
 		        node_namespace:=${None}
 		        topic_prefix:=~/
 		        update_rate:=5.0">
-	  <!-- ANTENNA GPS -->
-	  <joint
+    <!-- ANTENNA GPS -->
+    <joint
       name="${frame_prefix}base_joint"
       type="fixed">
-	    <xacro:insert_block name="origin" />
-	    <parent link="${parent}" />
-	    <child link="${frame_prefix}base_link" />
-	  </joint>
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
+    </joint>
 
-	  <link name="${frame_prefix}base_link">
-		<inertial>
-			<origin
+    <link name="${frame_prefix}base_link">
+      <inertial>
+        <origin
           xyz="0.0 0 0.015"
           rpy="0 0 0" />
-			<mass value="0.2" />
-			<xacro:solid_cuboid_inertia
+        <mass value="0.2" />
+        <xacro:solid_cuboid_inertia
           m="0.2"
           w="0.081"
           h="0.081"
           d="0.03" />
-      		</inertial>
-	    	<visual>
-	      		<origin
+      </inertial>
+      <visual>
+        <origin
           rpy="0 0 0"
           xyz="0 0 0" />
-		  	<material name="ublox_gps_color">
-           			<color rgba="0.5 0.5 0.5 1" />
-          		</material>
-		        <geometry>
-				<mesh
+        <material name="ublox_gps_color">
+          <color rgba="0.5 0.5 0.5 1" />
+        </material>
+        <geometry>
+          <mesh
             filename="package://robotnik_sensors/meshes/gps/antenna_ANN_MB.stl"
             scale="1.0 1.0 1.0" />
-		        </geometry>
-	    	</visual>
-	        <collision>
-	          	<origin
+        </geometry>
+      </visual>
+      <collision>
+        <origin
           rpy="0 0 0"
           xyz="0 0 0.01125" />
-		        <geometry>
-		     		<box size="0.0607 0.083 0.0225" />
-		        </geometry>
-	        </collision>
-	  </link>
+        <geometry>
+          <box size="0.0607 0.083 0.0225" />
+        </geometry>
+      </collision>
+    </link>
 
-	  <joint
+    <joint
       name="${frame_prefix}mast_joint"
       type="fixed">
-	    <parent link="${frame_prefix}base_link" />
-	    <child link="${frame_prefix}mast_base_link" />
-	    <origin
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}mast_base_link" />
+      <origin
         xyz="0 0 -0.37"
         rpy="0 0 0" />
-	  </joint>
+    </joint>
 
-	  <link name="${frame_prefix}mast_base_link">
-		<inertial>
-			<origin
+    <link name="${frame_prefix}mast_base_link">
+      <inertial>
+        <origin
           xyz="0.0 0 0.0"
           rpy="0 0 0" />
-			<mass value="1.0" />
-			<xacro:solid_cuboid_inertia
+        <mass value="1.0" />
+        <xacro:solid_cuboid_inertia
           m="1.0"
           w="${mast_radius}"
           h="${mast_radius}"
           d="${mast_height}" />
-		</inertial>
-	    	<visual>
-		      <origin
+      </inertial>
+      <visual>
+        <origin
           rpy="0 0 0"
           xyz="0 0 0" />
-		      <material name="mast_color">
-	              	    <color rgba="0.1 0.1 0.1 1" />
-         	      </material>
-		      <geometry>
-		            <mesh
+        <material name="mast_color">
+          <color rgba="0.1 0.1 0.1 1" />
+        </material>
+        <geometry>
+          <mesh
             filename="package://robotnik_sensors/meshes/gps/mastil_gps.stl"
             scale="1.0 1.0 1.0" />
-		      </geometry>
-	    	</visual>
-	        <collision>
-	            <origin
+        </geometry>
+      </visual>
+      <collision>
+        <origin
           rpy="0 0 0"
           xyz="0 0 0" />
-	            <geometry>
-			<box size="0.05 0.05 0.2" />
-	            </geometry>
-	    	</collision>
-	  </link>
+        <geometry>
+          <box size="0.05 0.05 0.2" />
+        </geometry>
+      </collision>
+    </link>
 
-	  <gazebo reference="${frame_prefix}mast_base_link">
-	    <material>Gazebo/Black</material>
-	    <gravity>true</gravity>
-	  </gazebo>
+    <gazebo reference="${frame_prefix}mast_base_link">
+      <material>Gazebo/Black</material>
+      <gravity>true</gravity>
+    </gazebo>
 
-	<gazebo reference="${frame_prefix}base_link">
-	    <material>Gazebo/White</material>
-	    <gravity>true</gravity>
-	</gazebo>
+    <gazebo reference="${frame_prefix}base_link">
+      <material>Gazebo/White</material>
+      <gravity>true</gravity>
+    </gazebo>
 
     <xacro:gps_plugin
       node_namespace="${node_namespace}"
@@ -128,9 +127,6 @@
       gazebo_ignition="${gazebo_ignition}"
       topic_prefix="${topic_prefix}_gps"
       frame_link="${frame_prefix}base_link"
-      rate="${update_rate}">
-    </xacro:gps_plugin>
-
+      rate="${update_rate}" />
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/imu/imu_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/imu/imu_plugin.urdf.xacro
@@ -1,18 +1,22 @@
-<?xml version="1.0"?>
-<robot name="imu_plugin" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="imu_plugin"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:macro name="imu_plugin" params="
-            node_namespace
+  <xacro:macro
+    name="imu_plugin"
+    params="node_namespace
             node_name
             gazebo_ignition
             frame_link
-            rate
-            ">
+            rate">
 
     <xacro:if value="${gazebo_ignition}">
       <gazebo reference="${frame_link}">
         <gravity>true</gravity>
-        <sensor name="${node_name}_sensor" type="imu">
+        <sensor
+          name="${node_name}_sensor"
+          type="imu">
           <always_on>true</always_on>
           <update_rate>${rate}</update_rate>
           <visualize>true</visualize>

--- a/robotnik_sensors/urdf/imu/imu_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/imu/imu_plugin.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="imu_plugin"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:macro
     name="imu_plugin"
     params="node_namespace
@@ -10,7 +9,6 @@
             gazebo_ignition
             frame_link
             rate">
-
     <xacro:if value="${gazebo_ignition}">
       <gazebo reference="${frame_link}">
         <gravity>true</gravity>
@@ -84,17 +82,18 @@
             </linear_acceleration>
 
             <orientation_enabled>true</orientation_enabled>
-            <angular_velocity_enabled>true</angular_velocity_enabled>
-            <linear_acceleration_enabled>true</linear_acceleration_enabled>
+            <angular_velocity_enabled>
+              true
+            </angular_velocity_enabled>
+            <linear_acceleration_enabled>
+              true
+            </linear_acceleration_enabled>
           </imu>
 
           <topic>${node_namespace}/${node_name}/data</topic>
           <gz_frame_id>${frame_link}</gz_frame_id>
-
         </sensor>
       </gazebo>
     </xacro:if>
-
   </xacro:macro>
-
 </robot>

--- a/robotnik_sensors/urdf/imu/myahrs.urdf.xacro
+++ b/robotnik_sensors/urdf/imu/myahrs.urdf.xacro
@@ -1,51 +1,69 @@
-<?xml version="1.0"?>
-<robot name="sensor_myahrs" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_myahrs"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/imu/imu_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/imu/imu_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_myahrs"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=imu
-                       node_namespace:=${None}
-                       topic_prefix:=~/">
+  <xacro:macro
+    name="sensor_myahrs"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=imu
+            node_namespace:=${None}
+            topic_prefix:=~/">
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
-      <xacro:insert_block name="origin"/>
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <inertial>
-        <origin xyz="0.0 0 0.01" rpy="0 0 0" />
+        <origin
+          xyz="0.0 0 0.01"
+          rpy="0 0 0" />
         <mass value="0.05" />
-        <xacro:solid_cuboid_inertia m="0.05" w="0.02" h="0.02" d="0.02" />
+        <xacro:solid_cuboid_inertia
+          m="0.05"
+          w="0.02"
+          h="0.02"
+          d="0.02" />
       </inertial>
       <visual>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <origin
+          rpy="0 0 0"
+          xyz="0 0 0" />
         <material name="myahrs_imu_color">
-          <color rgba="1 0 0 1"/>
+          <color rgba="1 0 0 1" />
         </material>
         <geometry>
-          <box size="0.01 0.01 0.01"/>
+          <box size="0.01 0.01 0.01" />
         </geometry>
       </visual>
       <collision>
-        <origin rpy="0 0 0" xyz="0 0 0.0045"/>
+        <origin
+          rpy="0 0 0"
+          xyz="0 0 0.0045" />
         <geometry>
-          <box size="0.036 0.037 0.009"/>
+          <box size="0.036 0.037 0.009" />
         </geometry>
       </collision>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-        <axis xyz="1 0 0"/>
-        <origin xyz="-0.00745 0.0 0.0088"/>
-        <parent link="${frame_prefix}base_link"/>
-        <child link="${frame_prefix}link"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+        <axis xyz="1 0 0" />
+        <origin xyz="-0.00745 0.0 0.0088" />
+        <parent link="${frame_prefix}base_link" />
+        <child link="${frame_prefix}link" />
     </joint>
     <link name="${frame_prefix}link" />
 
@@ -54,8 +72,7 @@
       node_name="${node_name}"
       gazebo_ignition="${gazebo_ignition}"
       frame_link="${frame_prefix}link"
-      rate="200.0"
-    >
+      rate="200.0">
     </xacro:imu_plugin>
 
     <gazebo reference="${frame_prefix}base_link">

--- a/robotnik_sensors/urdf/imu/myahrs.urdf.xacro
+++ b/robotnik_sensors/urdf/imu/myahrs.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_myahrs"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/imu/imu_plugin.urdf.xacro" />
 
@@ -15,7 +14,6 @@
             node_name:=imu
             node_namespace:=${None}
             topic_prefix:=~/">
-
     <joint
       name="${frame_prefix}base_joint"
       type="fixed">
@@ -60,10 +58,10 @@
     <joint
       name="${frame_prefix}joint"
       type="fixed">
-        <axis xyz="1 0 0" />
-        <origin xyz="-0.00745 0.0 0.0088" />
-        <parent link="${frame_prefix}base_link" />
-        <child link="${frame_prefix}link" />
+      <axis xyz="1 0 0" />
+      <origin xyz="-0.00745 0.0 0.0088" />
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
     </joint>
     <link name="${frame_prefix}link" />
 
@@ -72,12 +70,10 @@
       node_name="${node_name}"
       gazebo_ignition="${gazebo_ignition}"
       frame_link="${frame_prefix}link"
-      rate="200.0">
-    </xacro:imu_plugin>
+      rate="200.0" />
 
     <gazebo reference="${frame_prefix}base_link">
       <material>Gazebo/Red</material>
     </gazebo>
-
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/imu/pixhawk.urdf.xacro
+++ b/robotnik_sensors/urdf/imu/pixhawk.urdf.xacro
@@ -1,51 +1,69 @@
-<?xml version="1.0"?>
-<robot name="sensor_pixhawk" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_pixhawk"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/imu/imu_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/imu/imu_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_pixhawk"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=imu
-                       node_namespace:=${None}
-                       topic_prefix:=~/">
+  <xacro:macro
+    name="sensor_pixhawk"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=imu
+            node_namespace:=${None}
+            topic_prefix:=~/">
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
-      <xacro:insert_block name="origin"/>
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <inertial>
-        <origin xyz="0.0 0 0.01" rpy="0 0 0" />
+        <origin
+          xyz="0.0 0 0.01"
+          rpy="0 0 0" />
         <mass value="0.05" />
-        <xacro:solid_cuboid_inertia m="0.05" w="0.02" h="0.02" d="0.02" />
+        <xacro:solid_cuboid_inertia
+          m="0.05"
+          w="0.02"
+          h="0.02"
+          d="0.02" />
       </inertial>
       <visual>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <origin
+          rpy="0 0 0"
+          xyz="0 0 0" />
         <material name="pixhawk_imu_color">
-          <color rgba="1 0 0 1"/>
+          <color rgba="1 0 0 1" />
         </material>
         <geometry>
-          <box size="0.05 0.0815 0.0155"/>
+          <box size="0.05 0.0815 0.0155" />
         </geometry>
       </visual>
       <collision>
-        <origin rpy="0 0 0" xyz="0 0 0.0045"/>
+        <origin
+          rpy="0 0 0"
+          xyz="0 0 0.0045" />
         <geometry>
-          <box size="0.036 0.037 0.009"/>
+          <box size="0.036 0.037 0.009" />
         </geometry>
       </collision>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-        <axis xyz="1 0 0"/>
-        <origin xyz="-0.00745 0.0 0.0088"/>
-        <parent link="${frame_prefix}base_link"/>
-        <child link="${frame_prefix}link"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+        <axis xyz="1 0 0" />
+        <origin xyz="-0.00745 0.0 0.0088" />
+        <parent link="${frame_prefix}base_link" />
+        <child link="${frame_prefix}link" />
     </joint>
     <link name="${frame_prefix}link" />
 
@@ -55,8 +73,7 @@
       node_name="${node_name}"
       gazebo_ignition="${gazebo_ignition}"
       frame_link="${frame_prefix}link"
-      rate="200.0"
-    >
+      rate="200.0">
     </xacro:imu_plugin>
 
     <gazebo reference="${frame_prefix}base_link">

--- a/robotnik_sensors/urdf/imu/pixhawk.urdf.xacro
+++ b/robotnik_sensors/urdf/imu/pixhawk.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_pixhawk"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/imu/imu_plugin.urdf.xacro" />
 
@@ -15,7 +14,6 @@
             node_name:=imu
             node_namespace:=${None}
             topic_prefix:=~/">
-
     <joint
       name="${frame_prefix}base_joint"
       type="fixed">
@@ -60,25 +58,22 @@
     <joint
       name="${frame_prefix}joint"
       type="fixed">
-        <axis xyz="1 0 0" />
-        <origin xyz="-0.00745 0.0 0.0088" />
-        <parent link="${frame_prefix}base_link" />
-        <child link="${frame_prefix}link" />
+      <axis xyz="1 0 0" />
+      <origin xyz="-0.00745 0.0 0.0088" />
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
     </joint>
     <link name="${frame_prefix}link" />
-
 
     <xacro:imu_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
       gazebo_ignition="${gazebo_ignition}"
       frame_link="${frame_prefix}link"
-      rate="200.0">
-    </xacro:imu_plugin>
+      rate="200.0" />
 
     <gazebo reference="${frame_prefix}base_link">
       <material>Gazebo/Black</material>
     </gazebo>
-
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/imu/vectornav.urdf.xacro
+++ b/robotnik_sensors/urdf/imu/vectornav.urdf.xacro
@@ -1,51 +1,70 @@
-<?xml version="1.0"?>
-<robot name="sensor_vectornav" xmlns:xacro="http://wiki.ros.org/xacro">
+<?xml version="1.0" ?>
+<robot
+  name="sensor_vectornav"
+  xmlns:xacro="http://wiki.ros.org/xacro">
 
-  <xacro:include filename="$(find robotnik_sensors)/urdf/imu/imu_plugin.urdf.xacro" />
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/imu/imu_plugin.urdf.xacro" />
 
-  <xacro:macro name="sensor_vectornav"
-               params="frame_prefix
-                       parent
-                       *origin
-                       gazebo_ignition:=false
-                       node_name:=imu
-                       node_namespace:=${None}
-                       topic_prefix:=~/">
+  <xacro:macro
+    name="sensor_vectornav"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            node_name:=imu
+            node_namespace:=${None}
+            topic_prefix:=~/">
 
-    <joint name="${frame_prefix}base_joint" type="fixed">
-      <xacro:insert_block name="origin"/>
-      <parent link="${parent}"/>
-      <child link="${frame_prefix}base_link"/>
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
     </joint>
 
     <link name="${frame_prefix}base_link">
       <inertial>
-        <origin xyz="0.0 0 0.01" rpy="0 0 0" />
+        <origin
+          xyz="0.0 0 0.01"
+          rpy="0 0 0" />
         <mass value="0.05" />
-        <xacro:solid_cuboid_inertia m="0.05" w="0.02" h="0.02" d="0.02" />
+        <xacro:solid_cuboid_inertia
+          m="0.05"
+          w="0.02"
+          h="0.02"
+          d="0.02" />
       </inertial>
       <visual>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <origin
+          rpy="0 0 0"
+          xyz="0 0 0" />
         <material name="vectornav_imu_color">
-          <color rgba="1 0 0 1"/>
+          <color rgba="1 0 0 1" />
         </material>
         <geometry>
-          <mesh filename="package://robotnik_sensors/meshes/imu/vectornav_vn100.stl"/>
+          <mesh
+            filename="package://robotnik_sensors/meshes/imu/vectornav_vn100.stl" />
         </geometry>
       </visual>
       <collision>
-        <origin rpy="0 0 0" xyz="0 0 0.0045"/>
+        <origin
+          rpy="0 0 0"
+          xyz="0 0 0.0045" />
         <geometry>
-          <box size="0.036 0.037 0.009"/>
+          <box size="0.036 0.037 0.009" />
         </geometry>
       </collision>
     </link>
 
-    <joint name="${frame_prefix}joint" type="fixed">
-        <axis xyz="1 0 0"/>
-        <origin xyz="-0.00745 0.0 0.0088"/>
-        <parent link="${frame_prefix}base_link"/>
-        <child link="${frame_prefix}link"/>
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+        <axis xyz="1 0 0" />
+        <origin xyz="-0.00745 0.0 0.0088" />
+        <parent link="${frame_prefix}base_link" />
+        <child link="${frame_prefix}link" />
     </joint>
     <link name="${frame_prefix}link" />
 
@@ -54,8 +73,7 @@
       node_name="${node_name}"
       gazebo_ignition="${gazebo_ignition}"
       frame_link="${frame_prefix}link"
-      rate="200.0"
-    >
+      rate="200.0">
     </xacro:imu_plugin>
 
     <gazebo reference="${frame_prefix}base_link">

--- a/robotnik_sensors/urdf/imu/vectornav.urdf.xacro
+++ b/robotnik_sensors/urdf/imu/vectornav.urdf.xacro
@@ -2,7 +2,6 @@
 <robot
   name="sensor_vectornav"
   xmlns:xacro="http://wiki.ros.org/xacro">
-
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/imu/imu_plugin.urdf.xacro" />
 
@@ -15,7 +14,6 @@
             node_name:=imu
             node_namespace:=${None}
             topic_prefix:=~/">
-
     <joint
       name="${frame_prefix}base_joint"
       type="fixed">
@@ -61,10 +59,10 @@
     <joint
       name="${frame_prefix}joint"
       type="fixed">
-        <axis xyz="1 0 0" />
-        <origin xyz="-0.00745 0.0 0.0088" />
-        <parent link="${frame_prefix}base_link" />
-        <child link="${frame_prefix}link" />
+      <axis xyz="1 0 0" />
+      <origin xyz="-0.00745 0.0 0.0088" />
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
     </joint>
     <link name="${frame_prefix}link" />
 
@@ -73,8 +71,7 @@
       node_name="${node_name}"
       gazebo_ignition="${gazebo_ignition}"
       frame_link="${frame_prefix}link"
-      rate="200.0">
-    </xacro:imu_plugin>
+      rate="200.0" />
 
     <gazebo reference="${frame_prefix}base_link">
       <material>Gazebo/Red</material>

--- a/robotnik_sensors/urdf/utils/inertia.urdf.xacro
+++ b/robotnik_sensors/urdf/utils/inertia.urdf.xacro
@@ -1,63 +1,98 @@
-<?xml version="1.0"?>
+<?xml version="1.0" ?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
   <!-- source en.wikipedia.org/wiki/List_of_moments_of_inertia-->
 
   <!-- TODO Solid sphere of radius r and mass m-->
-  <xacro:macro name="solid_sphere_inertia" params="m r">
-    <inertia  ixx="${(2*r*r*m)/5}" ixy = "0" ixz = "0"
-              iyy="${(2*r*r*m)/5}" iyz = "0"
-              izz="${(2*r*r*m)/5}"
-     />
+  <xacro:macro
+    name="solid_sphere_inertia"
+    params="m r">
+    <inertia
+      ixx="${(2*r*r*m)/5}"
+      ixy="0"
+      ixz="0"
+      iyy="${(2*r*r*m)/5}"
+      iyz="0"
+      izz="${(2*r*r*m)/5}" />
   </xacro:macro>
 
   <!-- TODO Hollow sphere of radius r and mass m-->
-  <xacro:macro name="solid_sphere_inertia" params="m r">
-    <inertia  ixx="${(2*r*r*m)/3}" ixy = "0" ixz = "0"
-              iyy="${(2*r*r*m)/3}" iyz = "0"
-              izz="${(2*r*r*m)/3}"
-     /> 
+  <xacro:macro
+    name="solid_sphere_inertia"
+    params="m r">
+    <inertia
+      ixx="${(2*r*r*m)/3}"
+      ixy="0"
+      ixz="0"
+      iyy="${(2*r*r*m)/3}"
+      iyz="0"
+      izz="${(2*r*r*m)/3}" /> 
   </xacro:macro>
 
   <!-- TODO Solid ellipsoid of semi-axes a, b, c and mass m-->
-  <xacro:macro name="ellipsoid_semi_axes_inertia" params="a b c m r">
-    <inertia  ixx="${(m*(b*b+c*c))/5}" ixy = "0" ixz = "0"
-              iyy="${(m*(a*a+c*c))/5}" iyz = "0"
-              izz="${(m*(a*a+b*b))/5}"
-     />
+  <xacro:macro
+    name="ellipsoid_semi_axes_inertia"
+    params="a b c m r">
+    <inertia
+      ixx="${(m*(b*b+c*c))/5}"
+      ixy="0"
+      ixz="0"
+      iyy="${(m*(a*a+c*c))/5}"
+      iyz="0"
+      izz="${(m*(a*a+b*b))/5}" />
   </xacro:macro>
 
   <!-- TODO Right circular cone with radius r, height h and mass m, about the apex -->
-  <xacro:macro name="right_circular_cone_inertia" params="m r h">
-    <inertia  ixx="${((3*m*(h*h))/5)+((3*m*(r*r))/20)}" ixy = "0" ixz = "0"
-              iyy="${((3*m*(h*h))/5)+((3*m*(r*r))/20)}" iyz = "0"
-              izz="${(3*m*(r*r))/10}"
-     />
+  <xacro:macro
+    name="right_circular_cone_inertia"
+    params="m r h">
+    <inertia
+      ixx="${((3*m*(h*h))/5)+((3*m*(r*r))/20)}"
+      ixy="0"
+      ixz="0"
+      iyy="${((3*m*(h*h))/5)+((3*m*(r*r))/20)}"
+      iyz="0"
+      izz="${(3*m*(r*r))/10}" />
   </xacro:macro>
 
   <!-- TODO Solid cuboid of width w, height h, depth d, and mass m -->
   <!-- w relates to X axis, d to Z axis, and h to Y axis -->
   <!-- Keep this comment -->
-  <xacro:macro name="solid_cuboid_inertia" params="m w h d">
-    <inertia  ixx="${(m*(h*h+d*d))/12}" ixy = "0" ixz = "0"
-              iyy="${(m*(w*w+d*d))/12}" iyz = "0"
-              izz="${(m*(w*w+h*h))/12}"
-     />
+  <xacro:macro
+    name="solid_cuboid_inertia"
+    params="m w h d">
+    <inertia
+      ixx="${(m*(h*h+d*d))/12}"
+      ixy="0"
+      ixz="0"
+      iyy="${(m*(w*w+d*d))/12}"
+      iyz="0"
+      izz="${(m*(w*w+h*h))/12}" />
   </xacro:macro>
 
   <!-- TODO Solid cylinder of radius r, height h and mass m -->
-  <xacro:macro name="solid_cylinder_inertia" params="m r h">
-    <inertia  ixx="${m*(3*r*r+h*h)/12}" ixy = "0" ixz = "0"
-              iyy="${m*(3*r*r+h*h)/12}" iyz = "0"
-              izz="${m*r*r/2}"
-     />
+  <xacro:macro
+    name="solid_cylinder_inertia"
+    params="m r h">
+    <inertia
+      ixx="${m*(3*r*r+h*h)/12}"
+      ixy="0"
+      ixz="0"
+      iyy="${m*(3*r*r+h*h)/12}"
+      iyz="0"
+      izz="${m*r*r/2}" />
   </xacro:macro>
 
     <!-- TODO Thick-walled cylindrical tube with open ends, of inner radius r1, outer radius r2, length h and mass m -->
-    <xacro:macro name="thick_walled_cylinder_inertia" params="m r1 r2 h">
-    <inertia  ixx="${m*((3*(r1*r1+r2*r2))+(h*h))/12}" ixy = "0" ixz = "0"
-              iyy="${m*((3*(r1*r1+r2*r2))+(h*h))/12}" iyz = "0"
-              izz="${m*(r1*r1+r2*r2)/2}"
-     />
+    <xacro:macro
+    name="thick_walled_cylinder_inertia"
+    params="m r1 r2 h">
+    <inertia
+      ixx="${m*((3*(r1*r1+r2*r2))+(h*h))/12}"
+      ixy="0"
+      ixz="0"
+      iyy="${m*((3*(r1*r1+r2*r2))+(h*h))/12}"
+      iyz="0"
+      izz="${m*(r1*r1+r2*r2)/2}" />
   </xacro:macro>
 
 

--- a/robotnik_sensors/urdf/utils/inertia.urdf.xacro
+++ b/robotnik_sensors/urdf/utils/inertia.urdf.xacro
@@ -25,7 +25,7 @@
       ixz="0"
       iyy="${(2*r*r*m)/3}"
       iyz="0"
-      izz="${(2*r*r*m)/3}" /> 
+      izz="${(2*r*r*m)/3}" />
   </xacro:macro>
 
   <!-- TODO Solid ellipsoid of semi-axes a, b, c and mass m-->
@@ -82,8 +82,8 @@
       izz="${m*r*r/2}" />
   </xacro:macro>
 
-    <!-- TODO Thick-walled cylindrical tube with open ends, of inner radius r1, outer radius r2, length h and mass m -->
-    <xacro:macro
+  <!-- TODO Thick-walled cylindrical tube with open ends, of inner radius r1, outer radius r2, length h and mass m -->
+  <xacro:macro
     name="thick_walled_cylinder_inertia"
     params="m r1 r2 h">
     <inertia
@@ -94,6 +94,4 @@
       iyz="0"
       izz="${m*(r1*r1+r2*r2)/2}" />
   </xacro:macro>
-
-
 </robot>


### PR DESCRIPTION
This pull request introduces consistent formatting improvements across multiple URDF/Xacro files for 2D lidar sensors and adds a Prettier configuration for XML formatting. The changes focus on enhancing readability and maintainability by reformatting XML tags, attributes, and nested structures, but do not alter the functional content of the robot descriptions.

Formatting and style standardization:

* Added a `.prettierrc.json` configuration file to enforce consistent XML formatting, including tab width, line length, and attribute placement.
* Reformatted all 2D lidar sensor URDF/Xacro files (`hokuyo_urg04lx.urdf.xacro`, `hokuyo_ust10lx.urdf.xacro`, `hokuyo_ust20lx.urdf.xacro`, `hokuyo_utm30lx.urdf.xacro`, `sick_microscan3.urdf.xacro`, `sick_nanoscan3.urdf.xacro`, and `lidar_2d_plugin.urdf.xacro`) to use consistent indentation, line breaks, and attribute alignment for improved readability. [[1]](diffhunk://#diff-fade9c70f78859b18c15bbb3d34cc9a774d9a3988fafcfca333155a86d0513beL2-R10) [[2]](diffhunk://#diff-fade9c70f78859b18c15bbb3d34cc9a774d9a3988fafcfca333155a86d0513beL16-R63) [[3]](diffhunk://#diff-fade9c70f78859b18c15bbb3d34cc9a774d9a3988fafcfca333155a86d0513beL60-R81) [[4]](diffhunk://#diff-e47588f7a696bf1ae2eea754b54527f43543cca5acf20b73007f5147783d2a05L2-R10) [[5]](diffhunk://#diff-e47588f7a696bf1ae2eea754b54527f43543cca5acf20b73007f5147783d2a05L17-R72) [[6]](diffhunk://#diff-e47588f7a696bf1ae2eea754b54527f43543cca5acf20b73007f5147783d2a05L69-R92) [[7]](diffhunk://#diff-2f9f41e40b4d0f7e4dff25d9dc9f8c2e14181103536670955c1254b0aa7ab809L2-R10) [[8]](diffhunk://#diff-2f9f41e40b4d0f7e4dff25d9dc9f8c2e14181103536670955c1254b0aa7ab809L17-R74) [[9]](diffhunk://#diff-2f9f41e40b4d0f7e4dff25d9dc9f8c2e14181103536670955c1254b0aa7ab809L66-R91) [[10]](diffhunk://#diff-a73786dc28776b1c6e5522487e7eaaadf15d1e0b67bdd201907fa2eb7a43b77eL2-R10) [[11]](diffhunk://#diff-a73786dc28776b1c6e5522487e7eaaadf15d1e0b67bdd201907fa2eb7a43b77eL17-R28) [[12]](diffhunk://#diff-a73786dc28776b1c6e5522487e7eaaadf15d1e0b67bdd201907fa2eb7a43b77eL33-R70) [[13]](diffhunk://#diff-a73786dc28776b1c6e5522487e7eaaadf15d1e0b67bdd201907fa2eb7a43b77eL67-R88) [[14]](diffhunk://#diff-bfd6c7cc33eb6a15c7081cf2b06ebd25ff80299d508aa824fa51173c7d59a5c2L2-R8) [[15]](diffhunk://#diff-bfd6c7cc33eb6a15c7081cf2b06ebd25ff80299d508aa824fa51173c7d59a5c2L20-R25) [[16]](diffhunk://#diff-e38a9479f5fe3e59bf67ecfbbe0cb9ad2cb725bb7524f443c27621773e696dccL2-R10) [[17]](diffhunk://#diff-e38a9479f5fe3e59bf67ecfbbe0cb9ad2cb725bb7524f443c27621773e696dccL17-R71) [[18]](diffhunk://#diff-e38a9479f5fe3e59bf67ecfbbe0cb9ad2cb725bb7524f443c27621773e696dccL66-R90) [[19]](diffhunk://#diff-02edf98854c5fabbbd11764a12c33d74ea61adb94824d86cfe1a94fc139f6af1L2-R10) [[20]](diffhunk://#diff-02edf98854c5fabbbd11764a12c33d74ea61adb94824d86cfe1a94fc139f6af1L17-R71)
* Updated example usage in the `README.md` to match the new XML formatting conventions.

These changes are purely stylistic and do not impact the logic or behavior of the sensor descriptions or plugins.