### PR TITLE
Fix: jazzy/realsense435camera

### DIFF
--- a/robotnik_sensors/package.xml
+++ b/robotnik_sensors/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>robotnik_sensors</name>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
   <description>Robotnik standard sensors description. URDF and meshses.</description>
 
   <maintainer email="asoriano@robotnik.es">Angel Soriano</maintainer>

--- a/robotnik_sensors/urdf/depth/intel_realsense_d435.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/intel_realsense_d435.urdf.xacro
@@ -226,5 +226,51 @@
       min_depth="0.1"
       max_depth="100"
       rate="30" />
+    
+    <xacro:irred_camera_plugin
+      node_namespace="${node_namespace}"
+      node_name="${node_name}_irred1"
+      topic_prefix="${topic_prefix}_irred1"
+      gazebo_ignition="${gazebo_ignition}"
+      optical_frame="${frame_prefix}infra1_optical_frame"
+      reference_frame="${frame_prefix}infra2_frame"
+      horizontal_fov="85.2"
+      vertical_fov="48"
+      video_width="1280"
+      video_height="720"
+      min_depth="0.1"
+      max_depth="100"
+      rate="30" />
+
+    <xacro:irred_camera_plugin
+      node_namespace="${node_namespace}"
+      node_name="${node_name}_irred2"
+      topic_prefix="${topic_prefix}_irred2"
+      gazebo_ignition="${gazebo_ignition}"
+      optical_frame="${frame_prefix}infra2_optical_frame"
+      reference_frame="${frame_prefix}infra2_frame"
+      horizontal_fov="85.2"
+      vertical_fov="48"
+      video_width="1280"
+      video_height="720"
+      min_depth="0.1"
+      max_depth="100"
+      rate="30" />
+
+    <xacro:depth_camera_plugin
+      node_namespace="${node_namespace}"
+      node_name="${node_name}_depth"
+      topic_prefix="${topic_prefix}_depth"
+      gazebo_ignition="${gazebo_ignition}"
+      optical_frame="${frame_prefix}depth_optical_frame"
+      reference_frame="${frame_prefix}depth_frame"
+      horizontal_fov="85.2"
+      vertical_fov="48"
+      video_width="1280"
+      video_height="720"
+      min_depth="0.1"
+      max_depth="100"
+      rate="30" />
+      
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/depth/intel_realsense_d435i.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/intel_realsense_d435i.urdf.xacro
@@ -286,32 +286,6 @@
       max_depth="100"
       rate="30" />
 
-    <!-- <gazebo>
-        <plugin name="${node_name}" filename="librealsense_gazebo_plugin.so">
-          <prefix>${node_namespace}</prefix>
-          <depthUpdateRate>60.0</depthUpdateRate>
-          <colorUpdateRate>60.0</colorUpdateRate>
-          <infraredUpdateRate>60.0</infraredUpdateRate>
-          <depthTopicName>${topic_prefix}depth/image_rect_raw</depthTopicName>
-          <depthCameraInfoTopicName>${topic_prefix}depth/camera_info</depthCameraInfoTopicName>
-          <colorTopicName>${topic_prefix}color/image_raw</colorTopicName>
-          <colorCameraInfoTopicName>${topic_prefix}color/camera_info</colorCameraInfoTopicName>
-          <infrared1TopicName>${topic_prefix}infra1/image_raw</infrared1TopicName>
-          <infrared1CameraInfoTopicName>${topic_prefix}infra1/camera_info</infrared1CameraInfoTopicName>
-          <infrared2TopicName>${topic_prefix}infra2/image_raw</infrared2TopicName>
-          <infrared2CameraInfoTopicName>${topic_prefix}infra2/camera_info</infrared2CameraInfoTopicName>
-          <colorOpticalframeName>${frame_prefix}color_optical_frame</colorOpticalframeName>
-          <depthOpticalframeName>${frame_prefix}depth_optical_frame</depthOpticalframeName>
-          <infrared1OpticalframeName>${frame_prefix}infra1_optical_frame</infrared1OpticalframeName>
-          <infrared2OpticalframeName>${frame_prefix}infra2_optical_frame</infrared2OpticalframeName>
-          <rangeMinDepth>0.2</rangeMinDepth>
-          <rangeMaxDepth>10.0</rangeMaxDepth>
-          <pointCloud>true</pointCloud>
-          <pointCloudTopicName>${topic_prefix}depth/color/points</pointCloudTopicName>
-          <pointCloudCutoff>0.5</pointCloudCutoff>
-        </plugin>
-      </gazebo> -->
-
     <!-- Imu -->
 
     <xacro:imu_plugin


### PR DESCRIPTION
This pull request updates the `robotnik_sensors` package to add improved simulation support for Intel RealSense depth cameras, particularly by introducing new plugins for infrared and depth sensors in the D435 model's URDF. It also bumps the package version and cleans up legacy plugin code for the D435i model.

**Simulation plugin enhancements:**

* Added two new `<xacro:irred_camera_plugin>` instances for the `infra1` and `infra2` infrared sensors, and a `<xacro:depth_camera_plugin>` for the depth sensor in `intel_realsense_d435.urdf.xacro`, improving the simulation fidelity for these sensors.

**Codebase maintenance:**

* Removed a large commented-out block for the legacy `librealsense_gazebo_plugin` in `intel_realsense_d435i.urdf.xacro`, cleaning up the URDF and reducing confusion over simulation methods.

**Versioning:**

* Bumped the package version from `2.1.0` to `2.1.1` in `package.xml` to reflect these changes.