### PR TITLE
Feat/jazzy/low performance arg 4 plugins

### DIFF
--- a/robotnik_sensors/urdf/3d_lidar/robosense_helios_16p.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/robosense_helios_16p.urdf.xacro
@@ -14,7 +14,8 @@
             node_name:=robosense_helios_16p
             node_namespace:=${None}
             topic_prefix:=~/
-            gpu:=false">
+            gpu:=false
+            low_performance:=false">
     <xacro:if value="${node_namespace == None}">
       <xacro:property
         name="node_namespace"
@@ -74,17 +75,33 @@
 
     <link name="${frame_prefix}link" />
 
-    <xacro:lidar_3d_plugin
-      node_namespace="${node_namespace}"
-      node_name="${node_name}"
-      gazebo_ignition="${gazebo_ignition}"
-      min_range="0.2"
-      max_range="150.0"
-      min_angle="-15.0"
-      max_angle="15.0"
-      frame_link="${frame_prefix}link"
-      rate="10"
-      horizontal_samples="1800"
-      vertical_samples="16" />
+    <xacro:if value="${low_performance}">
+      <xacro:lidar_3d_plugin
+        node_namespace="${node_namespace}"
+        node_name="${node_name}"
+        gazebo_ignition="${gazebo_ignition}"
+        min_range="0.2"
+        max_range="60.0"
+        min_angle="-15.0"
+        max_angle="15.0"
+        frame_link="${frame_prefix}link"
+        rate="5"
+        horizontal_samples="900"
+        vertical_samples="16" />
+    </xacro:if>
+    <xacro:unless value="${low_performance}">
+      <xacro:lidar_3d_plugin
+        node_namespace="${node_namespace}"
+        node_name="${node_name}"
+        gazebo_ignition="${gazebo_ignition}"
+        min_range="0.2"
+        max_range="150.0"
+        min_angle="-15.0"
+        max_angle="15.0"
+        frame_link="${frame_prefix}link"
+        rate="10"
+        horizontal_samples="1800"
+        vertical_samples="16" />
+    </xacro:unless>
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/camera/link_750_nh.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/link_750_nh.urdf.xacro
@@ -34,7 +34,8 @@
             gazebo_ignition:=false
             node_name:=link_750_nh
             node_namespace:=${None}
-            topic_prefix:=~/">
+            topic_prefix:=~/
+            low_performance:=false">
     <joint
       name="${frame_prefix}base_joint"
       type="fixed">
@@ -271,20 +272,38 @@
     </gazebo>
 
     <!-- camera sensor for simulation -->
-    <xacro:camera_plugin
-      node_namespace="${node_namespace}"
-      node_name="${node_name}_color"
-      topic_prefix="${topic_prefix}_color"
-      gazebo_ignition="${gazebo_ignition}"
-      optical_frame="${frame_prefix}optical_frame_link"
-      reference_frame="${frame_prefix}frame_link"
-      horizontal_fov="63.7"
-      vertical_fov="32"
-      video_width="1920"
-      video_height="1080"
-      min_depth="0.1"
-      max_depth="100"
-      rate="30" />
+    <xacro:if value="${low_performance}">
+      <xacro:camera_plugin
+        node_namespace="${node_namespace}"
+        node_name="${node_name}_color"
+        topic_prefix="${topic_prefix}_color"
+        gazebo_ignition="${gazebo_ignition}"
+        optical_frame="${frame_prefix}optical_frame_link"
+        reference_frame="${frame_prefix}frame_link"
+        horizontal_fov="63.7"
+        vertical_fov="32"
+        video_width="1280"
+        video_height="720"
+        min_depth="0.1"
+        max_depth="100"
+        rate="5" />
+    </xacro:if>
+    <xacro:unless value="${low_performance}">
+      <xacro:camera_plugin
+        node_namespace="${node_namespace}"
+        node_name="${node_name}_color"
+        topic_prefix="${topic_prefix}_color"
+        gazebo_ignition="${gazebo_ignition}"
+        optical_frame="${frame_prefix}optical_frame_link"
+        reference_frame="${frame_prefix}frame_link"
+        horizontal_fov="63.7"
+        vertical_fov="32"
+        video_width="1920"
+        video_height="1080"
+        min_depth="0.1"
+        max_depth="100"
+        rate="25" />
+    </xacro:unless>
 
     <ros2_control
       name="${node_name}_control"

--- a/robotnik_sensors/urdf/depth/intel_realsense_d435.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/intel_realsense_d435.urdf.xacro
@@ -17,7 +17,8 @@
             gazebo_ignition:=false
             node_name:=realsense_d435
             node_namespace:=${None}
-            topic_prefix:=~/">
+            topic_prefix:=~/
+            low_performance:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
       <xacro:property
@@ -212,19 +213,37 @@
     </joint>
     <link name="${frame_prefix}color_optical_frame" />
 
-    <xacro:camera_plugin
-      node_namespace="${node_namespace}"
-      node_name="${node_name}_color"
-      topic_prefix="${topic_prefix}_color"
-      gazebo_ignition="${gazebo_ignition}"
-      optical_frame="${frame_prefix}color_optical_frame"
-      reference_frame="${frame_prefix}color_frame"
-      horizontal_fov="69.4"
-      vertical_fov="39"
-      video_width="1920"
-      video_height="1080"
-      min_depth="0.1"
-      max_depth="100"
-      rate="30" />
+    <xacro:if value="${low_performance}">
+      <xacro:camera_plugin
+        node_namespace="${node_namespace}"
+        node_name="${node_name}_color"
+        topic_prefix="${topic_prefix}_color"
+        gazebo_ignition="${gazebo_ignition}"
+        optical_frame="${frame_prefix}color_optical_frame"
+        reference_frame="${frame_prefix}color_frame"
+        horizontal_fov="69.4"
+        vertical_fov="39"
+        video_width="1280"
+        video_height="720"
+        min_depth="0.1"
+        max_depth="100"
+        rate="5" />
+    </xacro:if>
+    <xacro:unless value="${low_performance}">
+      <xacro:camera_plugin
+        node_namespace="${node_namespace}"
+        node_name="${node_name}_color"
+        topic_prefix="${topic_prefix}_color"
+        gazebo_ignition="${gazebo_ignition}"
+        optical_frame="${frame_prefix}color_optical_frame"
+        reference_frame="${frame_prefix}color_frame"
+        horizontal_fov="69.4" 
+        vertical_fov="39"
+        video_width="1920"
+        video_height="1080"
+        min_depth="0.1"
+        max_depth="100"
+        rate="30" />
+    </xacro:unless>      
   </xacro:macro>
 </robot>


### PR DESCRIPTION
This pull request introduces a new `low_performance` parameter to several sensor URDF Xacro files, allowing for simplified configuration of sensors for lower performance simulation scenarios. When `low_performance` is set to `true`, the sensors use reduced frame rates and resolutions, which can help decrease computational load during simulation. The changes are consistently applied across 3D lidar, camera, and depth sensor macros.

**Low performance mode support for sensors:**

* Added a `low_performance` parameter to the macro arguments in `robosense_helios_16p.urdf.xacro`, `link_750_nh.urdf.xacro`, and `intel_realsense_d435.urdf.xacro` to enable easy switching between normal and low performance modes. [[1]](diffhunk://#diff-c003d547ed5f7983b2b5cd2ce787ff7f17a82c55287599d4a62a706d81b5f1a4L17-R18) [[2]](diffhunk://#diff-7909b4b3cc8e259b89d5a79cd1c28855227d8215c5ad54b078fc670441d3ce1bL37-R38) [[3]](diffhunk://#diff-55426f21af15a649d88ff91903d4e4133f07d3edee82141acb22b656008d8dd4L20-R21)

**Conditional sensor plugin configuration:**

* For each sensor macro, added conditional Xacro blocks (`xacro:if` and `xacro:unless`) to instantiate plugins with reduced settings (lower frame rates, resolutions, and sample counts) when `low_performance` is enabled. [[1]](diffhunk://#diff-c003d547ed5f7983b2b5cd2ce787ff7f17a82c55287599d4a62a706d81b5f1a4R78-R92) [[2]](diffhunk://#diff-7909b4b3cc8e259b89d5a79cd1c28855227d8215c5ad54b078fc670441d3ce1bR275-R291) [[3]](diffhunk://#diff-55426f21af15a649d88ff91903d4e4133f07d3edee82141acb22b656008d8dd4R216-R232)

**Specific changes to plugin parameters:**

* For the 3D lidar (`robosense_helios_16p.urdf.xacro`), the low performance mode sets the rate to 5 Hz and horizontal samples to 900, while the normal mode uses 10 Hz and 1800 samples. [[1]](diffhunk://#diff-c003d547ed5f7983b2b5cd2ce787ff7f17a82c55287599d4a62a706d81b5f1a4R78-R92) [[2]](diffhunk://#diff-c003d547ed5f7983b2b5cd2ce787ff7f17a82c55287599d4a62a706d81b5f1a4R105)
* For the cameras (`link_750_nh.urdf.xacro` and `intel_realsense_d435.urdf.xacro`), the low performance mode uses 1280x720 resolution at 5 Hz, while the normal mode uses higher resolution and frame rates (up to 25 or 30 Hz). [[1]](diffhunk://#diff-7909b4b3cc8e259b89d5a79cd1c28855227d8215c5ad54b078fc670441d3ce1bR275-R291) [[2]](diffhunk://#diff-7909b4b3cc8e259b89d5a79cd1c28855227d8215c5ad54b078fc670441d3ce1bL287-R306) [[3]](diffhunk://#diff-55426f21af15a649d88ff91903d4e4133f07d3edee82141acb22b656008d8dd4R216-R232) [[4]](diffhunk://#diff-55426f21af15a649d88ff91903d4e4133f07d3edee82141acb22b656008d8dd4R247)

These changes make it easier to run simulations on less powerful hardware or when high fidelity is not required.