### PR TITLE
fix: fix typo in imu_joint

### DIFF
--- a/urdf/sick_multiscan.urdf.xacro
+++ b/urdf/sick_multiscan.urdf.xacro
@@ -49,7 +49,7 @@
     <link name="${prefix}_link_6"/> -->
 
     <!-- Relative position of the IMU to the optical origin (-17 mm, +23.5 mm, -30 mm) -->
-    <joint name="${prefix}imu_joint" type="fixed">
+    <joint name="${prefix}_imu_joint" type="fixed">
       <parent link="${prefix}_link"/>
       <child link="${prefix}_imu_link" />
       <origin xyz="-0.017 0.0235 -0.03" rpy="0 0 0"/>


### PR DESCRIPTION
This pull request makes a small but important fix to the naming convention of a joint in the `sick_multiscan.urdf.xacro` file to ensure consistency and prevent potential issues with joint references.

- Naming consistency:
  * Renamed the IMU joint from `${prefix}imu_joint` to `${prefix}_imu_joint` to match the naming pattern used elsewhere in the file and avoid conflicts or confusion.