### PR TITLE
feat: add low performance argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ For simulation, the following arguments are also available:
 | gpu             | boolean to use the GPU for the sensor (only available for 2d and 3d lidar)      |
 
 
+### Global argument
+
+There is a global property that is set in the [all_sensors.urdf.xacro](robotnik_sensors/urdf/all_sensors.urdf.xacro) file:
+
+- `low_performance`: boolean to set low performance mode for simulation. When set to true, the sensor plugins will use lower resolution and frame rates to reduce CPU/GPU usage.
+
+> **Note**: All properties can be overridden after including the `all_sensors.urdf.xacro` file.
+
 #### Example
 
 This example shows how to include a SICK S300 2D LiDAR in a robot description:

--- a/robotnik_sensors/urdf/3d_lidar/robosense_helios_16p.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/robosense_helios_16p.urdf.xacro
@@ -14,8 +14,7 @@
             node_name:=robosense_helios_16p
             node_namespace:=${None}
             topic_prefix:=~/
-            gpu:=false
-            low_performance:=false">
+            gpu:=false">
     <xacro:if value="${node_namespace == None}">
       <xacro:property
         name="node_namespace"

--- a/robotnik_sensors/urdf/3d_lidar/robosense_helios_16p.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/robosense_helios_16p.urdf.xacro
@@ -14,7 +14,8 @@
             node_name:=robosense_helios_16p
             node_namespace:=${None}
             topic_prefix:=~/
-            gpu:=false">
+            gpu:=false
+            low_performance:=false">
     <xacro:if value="${node_namespace == None}">
       <xacro:property
         name="node_namespace"
@@ -74,17 +75,33 @@
 
     <link name="${frame_prefix}link" />
 
-    <xacro:lidar_3d_plugin
-      node_namespace="${node_namespace}"
-      node_name="${node_name}"
-      gazebo_ignition="${gazebo_ignition}"
-      min_range="0.2"
-      max_range="150.0"
-      min_angle="-15.0"
-      max_angle="15.0"
-      frame_link="${frame_prefix}link"
-      rate="10"
-      horizontal_samples="1800"
-      vertical_samples="16" />
+    <xacro:if value="${low_performance}">
+      <xacro:lidar_3d_plugin
+        node_namespace="${node_namespace}"
+        node_name="${node_name}"
+        gazebo_ignition="${gazebo_ignition}"
+        min_range="0.2"
+        max_range="60.0"
+        min_angle="-15.0"
+        max_angle="15.0"
+        frame_link="${frame_prefix}link"
+        rate="5"
+        horizontal_samples="900"
+        vertical_samples="16" />
+    </xacro:if>
+    <xacro:unless value="${low_performance}">
+      <xacro:lidar_3d_plugin
+        node_namespace="${node_namespace}"
+        node_name="${node_name}"
+        gazebo_ignition="${gazebo_ignition}"
+        min_range="0.2"
+        max_range="150.0"
+        min_angle="-15.0"
+        max_angle="15.0"
+        frame_link="${frame_prefix}link"
+        rate="10"
+        horizontal_samples="1800"
+        vertical_samples="16" />
+    </xacro:unless>
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/all_sensors.urdf.xacro
+++ b/robotnik_sensors/urdf/all_sensors.urdf.xacro
@@ -4,6 +4,10 @@
   xmlns:xacro="http://wiki.ros.org/xacro">
   <!-- This file unifies all sensors that can be used on simulation, defined as xacro:macros -->
 
+  <!-- Declare global argument to set low_performance mode -->
+  <xacro:arg name="low_performance" default="false" />
+  <xacro:property name="low_performance" value="$(arg low_performance)" />
+
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/utils/inertia.urdf.xacro" />
 

--- a/robotnik_sensors/urdf/camera/link_750_nh.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/link_750_nh.urdf.xacro
@@ -34,7 +34,8 @@
             gazebo_ignition:=false
             node_name:=link_750_nh
             node_namespace:=${None}
-            topic_prefix:=~/">
+            topic_prefix:=~/
+            low_performance:=false">
     <joint
       name="${frame_prefix}base_joint"
       type="fixed">
@@ -271,20 +272,38 @@
     </gazebo>
 
     <!-- camera sensor for simulation -->
-    <xacro:camera_plugin
-      node_namespace="${node_namespace}"
-      node_name="${node_name}_color"
-      topic_prefix="${topic_prefix}_color"
-      gazebo_ignition="${gazebo_ignition}"
-      optical_frame="${frame_prefix}optical_frame_link"
-      reference_frame="${frame_prefix}frame_link"
-      horizontal_fov="63.7"
-      vertical_fov="32"
-      video_width="1920"
-      video_height="1080"
-      min_depth="0.1"
-      max_depth="100"
-      rate="30" />
+    <xacro:if value="${low_performance}">
+      <xacro:camera_plugin
+        node_namespace="${node_namespace}"
+        node_name="${node_name}_color"
+        topic_prefix="${topic_prefix}_color"
+        gazebo_ignition="${gazebo_ignition}"
+        optical_frame="${frame_prefix}optical_frame_link"
+        reference_frame="${frame_prefix}frame_link"
+        horizontal_fov="63.7"
+        vertical_fov="32"
+        video_width="1280"
+        video_height="720"
+        min_depth="0.1"
+        max_depth="100"
+        rate="5" />
+    </xacro:if>
+    <xacro:unless value="${low_performance}">
+      <xacro:camera_plugin
+        node_namespace="${node_namespace}"
+        node_name="${node_name}_color"
+        topic_prefix="${topic_prefix}_color"
+        gazebo_ignition="${gazebo_ignition}"
+        optical_frame="${frame_prefix}optical_frame_link"
+        reference_frame="${frame_prefix}frame_link"
+        horizontal_fov="63.7"
+        vertical_fov="32"
+        video_width="1920"
+        video_height="1080"
+        min_depth="0.1"
+        max_depth="100"
+        rate="25" />
+    </xacro:unless>
 
     <ros2_control
       name="${node_name}_control"

--- a/robotnik_sensors/urdf/camera/link_750_nh.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/link_750_nh.urdf.xacro
@@ -34,8 +34,7 @@
             gazebo_ignition:=false
             node_name:=link_750_nh
             node_namespace:=${None}
-            topic_prefix:=~/
-            low_performance:=false">
+            topic_prefix:=~/">
     <joint
       name="${frame_prefix}base_joint"
       type="fixed">

--- a/robotnik_sensors/urdf/depth/intel_realsense_d435.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/intel_realsense_d435.urdf.xacro
@@ -17,7 +17,8 @@
             gazebo_ignition:=false
             node_name:=realsense_d435
             node_namespace:=${None}
-            topic_prefix:=~/">
+            topic_prefix:=~/
+            low_performance:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
       <xacro:property
@@ -212,19 +213,37 @@
     </joint>
     <link name="${frame_prefix}color_optical_frame" />
 
-    <xacro:camera_plugin
-      node_namespace="${node_namespace}"
-      node_name="${node_name}_color"
-      topic_prefix="${topic_prefix}_color"
-      gazebo_ignition="${gazebo_ignition}"
-      optical_frame="${frame_prefix}color_optical_frame"
-      reference_frame="${frame_prefix}color_frame"
-      horizontal_fov="69.4"
-      vertical_fov="39"
-      video_width="1920"
-      video_height="1080"
-      min_depth="0.1"
-      max_depth="100"
-      rate="30" />
+    <xacro:if value="${low_performance}">
+      <xacro:camera_plugin
+        node_namespace="${node_namespace}"
+        node_name="${node_name}_color"
+        topic_prefix="${topic_prefix}_color"
+        gazebo_ignition="${gazebo_ignition}"
+        optical_frame="${frame_prefix}color_optical_frame"
+        reference_frame="${frame_prefix}color_frame"
+        horizontal_fov="69.4"
+        vertical_fov="39"
+        video_width="1280"
+        video_height="720"
+        min_depth="0.1"
+        max_depth="100"
+        rate="5" />
+    </xacro:if>
+    <xacro:unless value="${low_performance}">
+      <xacro:camera_plugin
+        node_namespace="${node_namespace}"
+        node_name="${node_name}_color"
+        topic_prefix="${topic_prefix}_color"
+        gazebo_ignition="${gazebo_ignition}"
+        optical_frame="${frame_prefix}color_optical_frame"
+        reference_frame="${frame_prefix}color_frame"
+        horizontal_fov="69.4" 
+        vertical_fov="39"
+        video_width="1920"
+        video_height="1080"
+        min_depth="0.1"
+        max_depth="100"
+        rate="30" />
+    </xacro:unless>      
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/depth/intel_realsense_d435.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/intel_realsense_d435.urdf.xacro
@@ -17,8 +17,7 @@
             gazebo_ignition:=false
             node_name:=realsense_d435
             node_namespace:=${None}
-            topic_prefix:=~/
-            low_performance:=false">
+            topic_prefix:=~/">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
       <xacro:property


### PR DESCRIPTION
This pull request introduces a new global `low_performance` mode for sensor simulations, allowing users to reduce CPU and GPU usage by lowering sensor resolutions and frame rates across multiple sensor plugins. The feature is implemented as a global argument in the main sensor configuration and applied conditionally in individual sensor URDF Xacro files.

**Global low performance mode:**

* Added a global `low_performance` argument and property in `all_sensors.urdf.xacro` to enable low performance simulation mode for all sensors.
* Updated `README.md` to document the new `low_performance` global property, including its purpose and usage instructions.

**Conditional sensor plugin configuration:**

* Modified `robosense_helios_16p.urdf.xacro` to use lower resolution and frame rate when `low_performance` is enabled (rate reduced from 10 to 5, horizontal samples from 1800 to 900). [[1]](diffhunk://#diff-c003d547ed5f7983b2b5cd2ce787ff7f17a82c55287599d4a62a706d81b5f1a4R77-R91) [[2]](diffhunk://#diff-c003d547ed5f7983b2b5cd2ce787ff7f17a82c55287599d4a62a706d81b5f1a4R104)
* Updated `link_750_nh.urdf.xacro` camera plugin to use lower video resolution and frame rate in low performance mode (1280x720 at 5 FPS vs. 1920x1080 at 25 FPS). [[1]](diffhunk://#diff-7909b4b3cc8e259b89d5a79cd1c28855227d8215c5ad54b078fc670441d3ce1bR274-R290) [[2]](diffhunk://#diff-7909b4b3cc8e259b89d5a79cd1c28855227d8215c5ad54b078fc670441d3ce1bL287-R305)
* Updated `intel_realsense_d435.urdf.xacro` to add a low performance mode for the camera plugin (1280x720 at 5 FPS vs. 30 FPS). [[1]](diffhunk://#diff-55426f21af15a649d88ff91903d4e4133f07d3edee82141acb22b656008d8dd4R215-R231) [[2]](diffhunk://#diff-55426f21af15a649d88ff91903d4e4133f07d3edee82141acb22b656008d8dd4R246)