### PR TITLE
feat: add max_angle and min_angle to 2d and 3d lidar models

### DIFF
--- a/robotnik_sensors/CHANGELOG.rst
+++ b/robotnik_sensors/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package robotnik_sensors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Unreleased
+----------
+* Add min_angle and max_angle to define angle limits for 2d and 3d laser in simulation
+
 2.1.0 (2025-09-11)
 ------------------
 * BRAKING_CHANGE: removed `gazebo_classic` parameter for sensor macros

--- a/robotnik_sensors/urdf/2d_lidar/hokuyo_urg04lx.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/hokuyo_urg04lx.urdf.xacro
@@ -13,6 +13,8 @@
             gazebo_ignition:=false
             node_name:=hokuyo_urg04lx
             node_namespace:=${None}
+            min_angle:=-2.0943
+            max_angle:=2.0943
             topic_prefix:=~/">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
@@ -71,8 +73,8 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.06"
       max_range="4.0"
-      min_angle="-2.0943"
-      max_angle="2.0943"
+      min_angle="${min_angle}"
+      max_angle="${max_angle}"
       frame_link="${frame_prefix}link"
       rate="10"
       resolution="0.004359297"

--- a/robotnik_sensors/urdf/2d_lidar/hokuyo_ust10lx.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/hokuyo_ust10lx.urdf.xacro
@@ -13,6 +13,8 @@
             gazebo_ignition:=false
             node_name:=hokuyo_ust10lx
             node_namespace:=${None}
+            min_angle:=-2.35
+            max_angle:=2.35
             topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
@@ -82,8 +84,8 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.06"
       max_range="10.0"
-      min_angle="-2.3562"
-      max_angle="2.3562"
+      min_angle="${min_angle}"
+      max_angle="${max_angle}"
       frame_link="${frame_prefix}link"
       rate="40"
       resolution="0.004359297"

--- a/robotnik_sensors/urdf/2d_lidar/hokuyo_ust20lx.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/hokuyo_ust20lx.urdf.xacro
@@ -13,6 +13,8 @@
             gazebo_ignition:=false
             node_name:=hokuyo_ust20lx
             node_namespace:=${None}
+            min_angle:=-2.3562
+            max_angle:=2.3562
             topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
@@ -82,8 +84,8 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.06"
       max_range="20.0"
-      min_angle="-2.3562"
-      max_angle="2.3562"
+      min_angle="${min_angle}"
+      max_angle="${max_angle}"
       frame_link="${frame_prefix}link"
       rate="40"
       resolution="0.004359297"

--- a/robotnik_sensors/urdf/2d_lidar/hokuyo_utm30lx.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/hokuyo_utm30lx.urdf.xacro
@@ -13,6 +13,8 @@
             gazebo_ignition:=false
             node_name:=hokuyo_utm30lx
             node_namespace:=${None}
+            min_angle:=-2.35
+            max_angle:=2.35
             topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
@@ -77,8 +79,8 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.10"
       max_range="30.0"
-      min_angle="-2.35"
-      max_angle="2.35"
+      min_angle="${min_angle}"
+      max_angle="${max_angle}"
       frame_link="${frame_prefix}link"
       rate="30"
       resolution="0.01"

--- a/robotnik_sensors/urdf/2d_lidar/sick_microscan3.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_microscan3.urdf.xacro
@@ -13,6 +13,8 @@
             gazebo_ignition:=false
             node_name:=sick_microscan3
             node_namespace:=${None}
+            min_angle:=-2.35
+            max_angle:=2.35
             topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
@@ -81,8 +83,8 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.05"
       max_range="64.0"
-      min_angle="-2.35"
-      max_angle="2.35"
+      min_angle="${min_angle}"
+      max_angle="${max_angle}"
       frame_link="${frame_prefix}link"
       rate="30"
       resolution="0.00575"

--- a/robotnik_sensors/urdf/2d_lidar/sick_nanoscan3.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_nanoscan3.urdf.xacro
@@ -13,6 +13,8 @@
             gazebo_ignition:=false
             node_name:=sick_nanoscan3
             node_namespace:=${None}
+            min_angle:=-2.35
+            max_angle:=2.35
             topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
@@ -81,8 +83,8 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.05"
       max_range="40.0"
-      min_angle="${-radians(135)}"
-      max_angle="${radians(135)}"
+      min_angle="${min_angle}"
+      max_angle="${max_angle}"
       frame_link="${frame_prefix}link"
       rate="12.5"
       resolution="0.00575"

--- a/robotnik_sensors/urdf/2d_lidar/sick_outdoorscan3.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_outdoorscan3.urdf.xacro
@@ -13,6 +13,8 @@
             gazebo_ignition:=false
             node_name:=sick_outdoorscan3
             node_namespace:=${None}
+            min_angle:=-2.35
+            max_angle:=2.35
             topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->

--- a/robotnik_sensors/urdf/2d_lidar/sick_s300.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_s300.urdf.xacro
@@ -13,6 +13,8 @@
             gazebo_ignition:=false
             node_name:=sick_s300
             node_namespace:=${None}
+            min_angle:=-2.35
+            max_angle:=2.35
             topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
@@ -80,8 +82,8 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.05"
       max_range="10.0"
-      min_angle="${-radians(130)}"
-      max_angle="${radians(130)}"
+      min_angle="${min_angle}"
+      max_angle="${max_angle}"
       frame_link="${frame_prefix}link"
       rate="25.0"
       resolution="0.00575"

--- a/robotnik_sensors/urdf/2d_lidar/sick_s3000.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_s3000.urdf.xacro
@@ -13,6 +13,8 @@
             gazebo_ignition:=false
             node_name:=sick_s3000
             node_namespace:=${None}
+            min_angle:=-1.62316
+            max_angle:=1.62316
             topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
@@ -80,8 +82,8 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.07"
       max_range="49.0"
-      min_angle="${-radians(93)}"
-      max_angle="${radians(93)}"
+      min_angle="${min_angle}"
+      max_angle="${max_angle}"
       frame_link="${frame_prefix}link"
       rate="15.0"
       resolution="0.00575"

--- a/robotnik_sensors/urdf/2d_lidar/sick_tim551.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_tim551.urdf.xacro
@@ -13,6 +13,8 @@
             gazebo_ignition:=false
             node_name:=sick_tim551
             node_namespace:=${None}
+            min_angle:=-2.35
+            max_angle:=2.35
             topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
@@ -80,8 +82,8 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.05"
       max_range="30.0"
-      min_angle="${-radians(135)}"
-      max_angle="${radians(135)}"
+      min_angle="${min_angle}"
+      max_angle="${max_angle}"
       frame_link="${frame_prefix}link"
       rate="15.0"
       resolution="0.00575"

--- a/robotnik_sensors/urdf/2d_lidar/sick_tim571.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_tim571.urdf.xacro
@@ -13,6 +13,8 @@
             gazebo_ignition:=false
             node_name:=sick_tim571
             node_namespace:=${None}
+            min_angle:=-2.35
+            max_angle:=2.35
             topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
@@ -80,8 +82,8 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.05"
       max_range="25.0"
-      min_angle="${-radians(130)}"
-      max_angle="${radians(130)}"
+      min_angle="${min_angle}"
+      max_angle="${max_angle}"
       frame_link="${frame_prefix}link"
       rate="15.0"
       resolution="0.00575"

--- a/robotnik_sensors/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro
@@ -11,6 +11,8 @@
             max_range
             min_angle
             max_angle
+            min_fov
+            max_fov
             frame_link
             rate
             horizontal_samples
@@ -29,14 +31,14 @@
               <horizontal>
                 <samples>${horizontal_samples}</samples>
                 <resolution>1</resolution>
-                <min_angle>${-radians(180)}</min_angle>
-                <max_angle>${radians(180)}</max_angle>
+                <min_angle>${min_angle}</min_angle>
+                <max_angle>${max_angle}</max_angle>
               </horizontal>
               <vertical>
                 <samples>${vertical_samples}</samples>
                 <resolution>1.0</resolution>
-                <min_angle>${radians(min_angle)}</min_angle>
-                <max_angle>${radians(max_angle)}</max_angle>
+                <min_angle>${min_fov}</min_angle>
+                <max_angle>${max_fov}</max_angle>
               </vertical>
             </scan>
             <range>

--- a/robotnik_sensors/urdf/3d_lidar/livox_mid_360.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/livox_mid_360.urdf.xacro
@@ -11,6 +11,8 @@
             parent
             *origin
             gazebo_ignition:=false
+            max_angle:=${radians(180)}
+            min_angle:=${-radians(180)}
             node_name:=livox_mid_360
             node_namespace:=${None}
             topic_prefix:=~/
@@ -86,8 +88,10 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="100.0"
-      min_angle="0.0"
-      max_angle="85"
+      min_angle="${min_angle}"
+      max_angle="${max_angle}"
+      min_fov="${radians(0)}"
+      max_fov="${radians(59)}"
       frame_link="${frame_prefix}link"
       rate="10"
       horizontal_samples="1200"

--- a/robotnik_sensors/urdf/3d_lidar/ouster.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/ouster.urdf.xacro
@@ -11,6 +11,8 @@
             parent
             *origin
             gazebo_ignition:=false
+            max_angle:=${radians(180)}
+            min_angle:=${-radians(180)}
             node_name:=ouster
             node_namespace:=${None}
             topic_prefix:=~/
@@ -77,15 +79,17 @@
     </joint>
 
     <link name="${frame_prefix}link" />
-
+    <!-- Ouster OS2 -->
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="50.0"
-      min_angle="0.0"
-      max_angle="85"
+      min_angle="${min_angle}"
+      max_angle="${max_angle}"
+      min_fov="${-radians(11.25)}"
+      max_fov="${radians(11.25)}"
       frame_link="${frame_prefix}link"
       rate="10"
       horizontal_samples="1200"

--- a/robotnik_sensors/urdf/3d_lidar/robosense_bpearl.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/robosense_bpearl.urdf.xacro
@@ -11,6 +11,8 @@
             parent
             *origin
             gazebo_ignition:=false
+            max_angle:=${radians(180)}
+            min_angle:=${-radians(180)}
             node_name:=robosense_bpearl
             node_namespace:=${None}
             topic_prefix:=~/
@@ -79,8 +81,10 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="100.0"
-      min_angle="0.0"
-      max_angle="85.0"
+      min_angle="${min_angle}"
+      max_angle="${max_angle}"
+      min_fov="${radians(0)}"
+      max_fov="${radians(85)}"
       frame_link="${frame_prefix}link"
       rate="10"
       horizontal_samples="1200"

--- a/robotnik_sensors/urdf/3d_lidar/robosense_helios_16p.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/robosense_helios_16p.urdf.xacro
@@ -11,6 +11,8 @@
             parent
             *origin
             gazebo_ignition:=false
+            max_angle:=${radians(180)}
+            min_angle:=${-radians(180)}
             node_name:=robosense_helios_16p
             node_namespace:=${None}
             topic_prefix:=~/
@@ -81,8 +83,10 @@
         gazebo_ignition="${gazebo_ignition}"
         min_range="0.2"
         max_range="60.0"
-        min_angle="-15.0"
-        max_angle="15.0"
+        min_angle="${min_angle}"
+        max_angle="${max_angle}"
+        min_fov="-0.2618"
+        max_fov="0.2618"
         frame_link="${frame_prefix}link"
         rate="5"
         horizontal_samples="900"
@@ -95,8 +99,10 @@
         gazebo_ignition="${gazebo_ignition}"
         min_range="0.2"
         max_range="150.0"
-        min_angle="-15.0"
-        max_angle="15.0"
+        min_angle="${min_angle}"
+        max_angle="${max_angle}"
+        min_fov="${-radians(15)}"
+        max_fov="${radians(15)}"
         frame_link="${frame_prefix}link"
         rate="10"
         horizontal_samples="1800"

--- a/robotnik_sensors/urdf/3d_lidar/sick_multiscan_100.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/sick_multiscan_100.urdf.xacro
@@ -11,6 +11,8 @@
             parent
             *origin
             gazebo_ignition:=false
+            max_angle:=${radians(180)}
+            min_angle:=${-radians(180)}
             node_name:=sick_multiscan_100
             node_namespace:=${None}
             topic_prefix:=~/
@@ -86,8 +88,10 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="52.0"
-      min_angle="0.0"
-      max_angle="65"
+      min_angle="${min_angle}"
+      max_angle="${max_angle}"
+      min_fov="${-radians(32.5)}"
+      max_fov="${radians(32.5)}"
       frame_link="${frame_prefix}link"
       rate="10"
       horizontal_samples="1200"

--- a/robotnik_sensors/urdf/3d_lidar/velodyne_vlp16.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/velodyne_vlp16.urdf.xacro
@@ -11,6 +11,8 @@
             parent
             *origin
             gazebo_ignition:=false
+            max_angle:=${radians(180)}
+            min_angle:=${-radians(180)}
             node_name:=velodyne_vlp16
             node_namespace:=${None}
             topic_prefix:=~/
@@ -79,8 +81,10 @@
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="100.0"
-      min_angle="-15"
-      max_angle="15"
+      min_angle="${min_angle}"
+      max_angle="${max_angle}"
+      min_fov="${-radians(20)}"
+      max_fov="${radians(20)}"
       frame_link="${frame_prefix}link"
       rate="10"
       horizontal_samples="1200"


### PR DESCRIPTION
This PR adds `max_angle` and `min_angle` parameters to all LiDAR models.

These new parameters allow users to configure the angular field of view for any laser macro.

The main purpose of this feature is enabling it to detect (or ignore) specific parts of the robot when it is
navigating in simulation. 

This functionality is also supported by the real hardware, as many LiDAR drivers allow configuring their angular range.

Do not overuse this parameter in simulation, since the number of points is fixed; reducing the angular range will increase the point density artificially.