### PR TITLE
Port rslidar lidar family to ROS2 for rbcar simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This example shows how to include a SICK S300 2D LiDAR in a robot description:
 ```sh
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/all_sensors.urdf.xacro" />
-  
+
   <xacro:sensor_sick_s300
     frame_prefix="$(arg prefix)front_laser_"
     parent="$(arg prefix)chassis_link"
@@ -111,6 +111,7 @@ The available sensors in the package are:
 - ouster
 - robosense_bpearl
 - robosense_helios_16p
+- rslidar
 - sick_multiscan_100
 - velodyne_vlp16
 

--- a/robotnik_sensors/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro
@@ -6,6 +6,7 @@
     name="lidar_3d_plugin"
     params="node_namespace
             node_name
+            topic_prefix
             gazebo_ignition
             min_range
             max_range

--- a/robotnik_sensors/urdf/3d_lidar/livox_mid_360.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/livox_mid_360.urdf.xacro
@@ -85,6 +85,7 @@
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
+      topic_prefix="${topic_prefix}"
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="100.0"

--- a/robotnik_sensors/urdf/3d_lidar/ouster.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/ouster.urdf.xacro
@@ -83,6 +83,7 @@
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
+      topic_prefix="${topic_prefix}"
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="50.0"

--- a/robotnik_sensors/urdf/3d_lidar/robosense_airy.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/robosense_airy.urdf.xacro
@@ -59,6 +59,7 @@
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
+      topic_prefix="${topic_prefix}"
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="60.0"

--- a/robotnik_sensors/urdf/3d_lidar/robosense_bpearl.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/robosense_bpearl.urdf.xacro
@@ -78,6 +78,7 @@
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
+      topic_prefix="${topic_prefix}"
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="100.0"

--- a/robotnik_sensors/urdf/3d_lidar/robosense_helios_16p.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/robosense_helios_16p.urdf.xacro
@@ -80,6 +80,7 @@
       <xacro:lidar_3d_plugin
         node_namespace="${node_namespace}"
         node_name="${node_name}"
+        topic_prefix="${topic_prefix}"
         gazebo_ignition="${gazebo_ignition}"
         min_range="0.2"
         max_range="60.0"
@@ -96,6 +97,7 @@
       <xacro:lidar_3d_plugin
         node_namespace="${node_namespace}"
         node_name="${node_name}"
+        topic_prefix="${topic_prefix}"
         gazebo_ignition="${gazebo_ignition}"
         min_range="0.2"
         max_range="150.0"

--- a/robotnik_sensors/urdf/3d_lidar/rslidar.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/rslidar.urdf.xacro
@@ -86,6 +86,7 @@
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
+      topic_prefix="${topic_prefix}"
       gazebo_ignition="${gazebo_ignition}"
       min_range="${min_range}"
       max_range="${max_range}"

--- a/robotnik_sensors/urdf/3d_lidar/rslidar.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/rslidar.urdf.xacro
@@ -162,24 +162,46 @@
             node_name:=rslidar_32
             node_namespace:=${None}
             gpu:=false">
-    <xacro:sensor_rslidar
-      frame_prefix="${frame_prefix}"
-      parent="${parent}"
-      gazebo_ignition="${gazebo_ignition}"
-      min_range="0.4"
-      max_range="200.0"
-      min_angle="${min_angle}"
-      max_angle="${max_angle}"
-      min_fov="${-radians(20)}"
-      max_fov="${radians(20)}"
-      node_name="${node_name}"
-      node_namespace="${node_namespace}"
-      rate="20"
-      horizontal_samples="3600"
-      vertical_samples="121"
-      gpu="${gpu}">
-      <xacro:insert_block name="origin" />
-    </xacro:sensor_rslidar>
+    <xacro:if value="${low_performance}">
+      <xacro:sensor_rslidar
+        frame_prefix="${frame_prefix}"
+        parent="${parent}"
+        gazebo_ignition="${gazebo_ignition}"
+        min_range="0.4"
+        max_range="80.0"
+        min_angle="${min_angle}"
+        max_angle="${max_angle}"
+        min_fov="${-radians(20)}"
+        max_fov="${radians(20)}"
+        node_name="${node_name}"
+        node_namespace="${node_namespace}"
+        rate="10"
+        horizontal_samples="1800"
+        vertical_samples="61"
+        gpu="${gpu}">
+        <xacro:insert_block name="origin" />
+      </xacro:sensor_rslidar>
+    </xacro:if>
+    <xacro:unless value="${low_performance}">
+      <xacro:sensor_rslidar
+        frame_prefix="${frame_prefix}"
+        parent="${parent}"
+        gazebo_ignition="${gazebo_ignition}"
+        min_range="0.4"
+        max_range="200.0"
+        min_angle="${min_angle}"
+        max_angle="${max_angle}"
+        min_fov="${-radians(20)}"
+        max_fov="${radians(20)}"
+        node_name="${node_name}"
+        node_namespace="${node_namespace}"
+        rate="20"
+        horizontal_samples="3600"
+        vertical_samples="121"
+        gpu="${gpu}">
+        <xacro:insert_block name="origin" />
+      </xacro:sensor_rslidar>
+    </xacro:unless>
   </xacro:macro>
 
   <xacro:macro
@@ -193,24 +215,46 @@
             node_name:=rslidar_ruby
             node_namespace:=${None}
             gpu:=false">
-    <xacro:sensor_rslidar
-      frame_prefix="${frame_prefix}"
-      parent="${parent}"
-      gazebo_ignition="${gazebo_ignition}"
-      min_range="0.4"
-      max_range="250.0"
-      min_angle="${min_angle}"
-      max_angle="${max_angle}"
-      min_fov="${-radians(20)}"
-      max_fov="${radians(20)}"
-      node_name="${node_name}"
-      node_namespace="${node_namespace}"
-      rate="20"
-      horizontal_samples="3600"
-      vertical_samples="400"
-      gpu="${gpu}">
-      <xacro:insert_block name="origin" />
-    </xacro:sensor_rslidar>
+    <xacro:if value="${low_performance}">
+      <xacro:sensor_rslidar
+        frame_prefix="${frame_prefix}"
+        parent="${parent}"
+        gazebo_ignition="${gazebo_ignition}"
+        min_range="0.4"
+        max_range="100.0"
+        min_angle="${min_angle}"
+        max_angle="${max_angle}"
+        min_fov="${-radians(20)}"
+        max_fov="${radians(20)}"
+        node_name="${node_name}"
+        node_namespace="${node_namespace}"
+        rate="10"
+        horizontal_samples="1800"
+        vertical_samples="200"
+        gpu="${gpu}">
+        <xacro:insert_block name="origin" />
+      </xacro:sensor_rslidar>
+    </xacro:if>
+    <xacro:unless value="${low_performance}">
+      <xacro:sensor_rslidar
+        frame_prefix="${frame_prefix}"
+        parent="${parent}"
+        gazebo_ignition="${gazebo_ignition}"
+        min_range="0.4"
+        max_range="250.0"
+        min_angle="${min_angle}"
+        max_angle="${max_angle}"
+        min_fov="${-radians(20)}"
+        max_fov="${radians(20)}"
+        node_name="${node_name}"
+        node_namespace="${node_namespace}"
+        rate="20"
+        horizontal_samples="3600"
+        vertical_samples="400"
+        gpu="${gpu}">
+        <xacro:insert_block name="origin" />
+      </xacro:sensor_rslidar>
+    </xacro:unless>
   </xacro:macro>
 
   <xacro:macro
@@ -225,23 +269,45 @@
             node_namespace:=${None}
             gpu:=false">
     <!-- Keep the legacy rbcar M1 scan characteristics. -->
-    <xacro:sensor_rslidar
-      frame_prefix="${frame_prefix}"
-      parent="${parent}"
-      gazebo_ignition="${gazebo_ignition}"
-      min_range="0.4"
-      max_range="250.0"
-      min_angle="${min_angle}"
-      max_angle="${max_angle}"
-      min_fov="${-radians(12.5)}"
-      max_fov="${radians(12.5)}"
-      node_name="${node_name}"
-      node_namespace="${node_namespace}"
-      rate="20"
-      horizontal_samples="1200"
-      vertical_samples="125"
-      gpu="${gpu}">
-      <xacro:insert_block name="origin" />
-    </xacro:sensor_rslidar>
+    <xacro:if value="${low_performance}">
+      <xacro:sensor_rslidar
+        frame_prefix="${frame_prefix}"
+        parent="${parent}"
+        gazebo_ignition="${gazebo_ignition}"
+        min_range="0.4"
+        max_range="100.0"
+        min_angle="${min_angle}"
+        max_angle="${max_angle}"
+        min_fov="${-radians(12.5)}"
+        max_fov="${radians(12.5)}"
+        node_name="${node_name}"
+        node_namespace="${node_namespace}"
+        rate="10"
+        horizontal_samples="600"
+        vertical_samples="63"
+        gpu="${gpu}">
+        <xacro:insert_block name="origin" />
+      </xacro:sensor_rslidar>
+    </xacro:if>
+    <xacro:unless value="${low_performance}">
+      <xacro:sensor_rslidar
+        frame_prefix="${frame_prefix}"
+        parent="${parent}"
+        gazebo_ignition="${gazebo_ignition}"
+        min_range="0.4"
+        max_range="250.0"
+        min_angle="${min_angle}"
+        max_angle="${max_angle}"
+        min_fov="${-radians(12.5)}"
+        max_fov="${radians(12.5)}"
+        node_name="${node_name}"
+        node_namespace="${node_namespace}"
+        rate="20"
+        horizontal_samples="1200"
+        vertical_samples="125"
+        gpu="${gpu}">
+        <xacro:insert_block name="origin" />
+      </xacro:sensor_rslidar>
+    </xacro:unless>
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/3d_lidar/rslidar.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/rslidar.urdf.xacro
@@ -219,21 +219,29 @@
             parent
             *origin
             gazebo_ignition:=false
-            max_angle:=${radians(180)}
-            min_angle:=${-radians(180)}
+            max_angle:=${radians(60)}
+            min_angle:=${-radians(60)}
             node_name:=rslidar_m1
             node_namespace:=${None}
             gpu:=false">
-    <xacro:sensor_rslidar_ruby
+    <!-- Keep the legacy rbcar M1 scan characteristics. -->
+    <xacro:sensor_rslidar
       frame_prefix="${frame_prefix}"
       parent="${parent}"
       gazebo_ignition="${gazebo_ignition}"
-      max_angle="${max_angle}"
+      min_range="0.4"
+      max_range="250.0"
       min_angle="${min_angle}"
+      max_angle="${max_angle}"
+      min_fov="${-radians(12.5)}"
+      max_fov="${radians(12.5)}"
       node_name="${node_name}"
       node_namespace="${node_namespace}"
+      rate="20"
+      horizontal_samples="1200"
+      vertical_samples="125"
       gpu="${gpu}">
       <xacro:insert_block name="origin" />
-    </xacro:sensor_rslidar_ruby>
+    </xacro:sensor_rslidar>
   </xacro:macro>
 </robot>

--- a/robotnik_sensors/urdf/3d_lidar/rslidar.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/rslidar.urdf.xacro
@@ -1,0 +1,239 @@
+<?xml version="1.0" ?>
+<robot
+  name="sensor_rslidar"
+  xmlns:xacro="http://wiki.ros.org/xacro">
+  <xacro:include
+    filename="$(find robotnik_sensors)/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro" />
+
+  <xacro:macro
+    name="sensor_rslidar"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            min_range:=0.4
+            max_range:=150.0
+            max_angle:=${radians(180)}
+            min_angle:=${-radians(180)}
+            min_fov:=${-radians(15)}
+            max_fov:=${radians(15)}
+            node_name:=rslidar
+            node_namespace:=${None}
+            rate:=20
+            horizontal_samples:=3600
+            vertical_samples:=15
+            gpu:=false">
+    <xacro:if value="${node_namespace == None}">
+      <xacro:property
+        name="node_namespace"
+        value="${node_name}" />
+    </xacro:if>
+
+    <joint
+      name="${frame_prefix}base_joint"
+      type="fixed">
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}" />
+      <child link="${frame_prefix}base_link" />
+    </joint>
+
+    <link name="${frame_prefix}base_link">
+      <collision>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <geometry>
+          <mesh
+            filename="package://robotnik_sensors/meshes/rslidar.stl" />
+        </geometry>
+      </collision>
+      <visual>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0" />
+        <geometry>
+          <mesh
+            filename="package://robotnik_sensors/meshes/rslidar.dae" />
+        </geometry>
+        <material name="blackgray_color">
+          <color rgba="0.25 0.25 0.25 1" />
+        </material>
+      </visual>
+      <inertial>
+        <mass value="0.840" />
+        <origin xyz="0 0 0.04135" />
+        <xacro:solid_cuboid_inertia
+          m="0.840"
+          w="0.109"
+          h="0.109"
+          d="0.0827" />
+      </inertial>
+    </link>
+
+    <joint
+      name="${frame_prefix}joint"
+      type="fixed">
+      <parent link="${frame_prefix}base_link" />
+      <child link="${frame_prefix}link" />
+      <origin
+        xyz="0.0 0 0.038"
+        rpy="0 0 0" />
+    </joint>
+
+    <link name="${frame_prefix}link" />
+
+    <xacro:lidar_3d_plugin
+      node_namespace="${node_namespace}"
+      node_name="${node_name}"
+      gazebo_ignition="${gazebo_ignition}"
+      min_range="${min_range}"
+      max_range="${max_range}"
+      min_angle="${min_angle}"
+      max_angle="${max_angle}"
+      min_fov="${min_fov}"
+      max_fov="${max_fov}"
+      frame_link="${frame_prefix}link"
+      rate="${rate}"
+      horizontal_samples="${horizontal_samples}"
+      vertical_samples="${vertical_samples}" />
+  </xacro:macro>
+
+  <xacro:macro
+    name="sensor_rslidar_16"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            max_angle:=${radians(180)}
+            min_angle:=${-radians(180)}
+            node_name:=rslidar_16
+            node_namespace:=${None}
+            gpu:=false">
+    <xacro:if value="${low_performance}">
+      <xacro:sensor_rslidar
+        frame_prefix="${frame_prefix}"
+        parent="${parent}"
+        gazebo_ignition="${gazebo_ignition}"
+        min_range="0.4"
+        max_range="60.0"
+        min_angle="${min_angle}"
+        max_angle="${max_angle}"
+        min_fov="${-radians(15)}"
+        max_fov="${radians(15)}"
+        node_name="${node_name}"
+        node_namespace="${node_namespace}"
+        rate="10"
+        horizontal_samples="1800"
+        vertical_samples="15"
+        gpu="${gpu}">
+        <xacro:insert_block name="origin" />
+      </xacro:sensor_rslidar>
+    </xacro:if>
+    <xacro:unless value="${low_performance}">
+      <xacro:sensor_rslidar
+        frame_prefix="${frame_prefix}"
+        parent="${parent}"
+        gazebo_ignition="${gazebo_ignition}"
+        min_range="0.4"
+        max_range="150.0"
+        min_angle="${min_angle}"
+        max_angle="${max_angle}"
+        min_fov="${-radians(15)}"
+        max_fov="${radians(15)}"
+        node_name="${node_name}"
+        node_namespace="${node_namespace}"
+        rate="20"
+        horizontal_samples="3600"
+        vertical_samples="15"
+        gpu="${gpu}">
+        <xacro:insert_block name="origin" />
+      </xacro:sensor_rslidar>
+    </xacro:unless>
+  </xacro:macro>
+
+  <xacro:macro
+    name="sensor_rslidar_32"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            max_angle:=${radians(180)}
+            min_angle:=${-radians(180)}
+            node_name:=rslidar_32
+            node_namespace:=${None}
+            gpu:=false">
+    <xacro:sensor_rslidar
+      frame_prefix="${frame_prefix}"
+      parent="${parent}"
+      gazebo_ignition="${gazebo_ignition}"
+      min_range="0.4"
+      max_range="200.0"
+      min_angle="${min_angle}"
+      max_angle="${max_angle}"
+      min_fov="${-radians(20)}"
+      max_fov="${radians(20)}"
+      node_name="${node_name}"
+      node_namespace="${node_namespace}"
+      rate="20"
+      horizontal_samples="3600"
+      vertical_samples="121"
+      gpu="${gpu}">
+      <xacro:insert_block name="origin" />
+    </xacro:sensor_rslidar>
+  </xacro:macro>
+
+  <xacro:macro
+    name="sensor_rslidar_ruby"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            max_angle:=${radians(180)}
+            min_angle:=${-radians(180)}
+            node_name:=rslidar_ruby
+            node_namespace:=${None}
+            gpu:=false">
+    <xacro:sensor_rslidar
+      frame_prefix="${frame_prefix}"
+      parent="${parent}"
+      gazebo_ignition="${gazebo_ignition}"
+      min_range="0.4"
+      max_range="250.0"
+      min_angle="${min_angle}"
+      max_angle="${max_angle}"
+      min_fov="${-radians(20)}"
+      max_fov="${radians(20)}"
+      node_name="${node_name}"
+      node_namespace="${node_namespace}"
+      rate="20"
+      horizontal_samples="3600"
+      vertical_samples="400"
+      gpu="${gpu}">
+      <xacro:insert_block name="origin" />
+    </xacro:sensor_rslidar>
+  </xacro:macro>
+
+  <xacro:macro
+    name="sensor_rslidar_m1"
+    params="frame_prefix
+            parent
+            *origin
+            gazebo_ignition:=false
+            max_angle:=${radians(180)}
+            min_angle:=${-radians(180)}
+            node_name:=rslidar_m1
+            node_namespace:=${None}
+            gpu:=false">
+    <xacro:sensor_rslidar_ruby
+      frame_prefix="${frame_prefix}"
+      parent="${parent}"
+      gazebo_ignition="${gazebo_ignition}"
+      max_angle="${max_angle}"
+      min_angle="${min_angle}"
+      node_name="${node_name}"
+      node_namespace="${node_namespace}"
+      gpu="${gpu}">
+      <xacro:insert_block name="origin" />
+    </xacro:sensor_rslidar_ruby>
+  </xacro:macro>
+</robot>

--- a/robotnik_sensors/urdf/3d_lidar/rslidar.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/rslidar.urdf.xacro
@@ -19,6 +19,7 @@
             max_fov:=${radians(15)}
             node_name:=rslidar
             node_namespace:=${None}
+            topic_prefix:=~/
             rate:=20
             horizontal_samples:=3600
             vertical_samples:=15
@@ -108,6 +109,7 @@
             min_angle:=${-radians(180)}
             node_name:=rslidar_16
             node_namespace:=${None}
+            topic_prefix:=~/
             gpu:=false">
     <xacro:if value="${low_performance}">
       <xacro:sensor_rslidar
@@ -122,6 +124,7 @@
         max_fov="${radians(15)}"
         node_name="${node_name}"
         node_namespace="${node_namespace}"
+        topic_prefix="${topic_prefix}"
         rate="10"
         horizontal_samples="1800"
         vertical_samples="15"
@@ -142,6 +145,7 @@
         max_fov="${radians(15)}"
         node_name="${node_name}"
         node_namespace="${node_namespace}"
+        topic_prefix="${topic_prefix}"
         rate="20"
         horizontal_samples="3600"
         vertical_samples="15"
@@ -161,6 +165,7 @@
             min_angle:=${-radians(180)}
             node_name:=rslidar_32
             node_namespace:=${None}
+            topic_prefix:=~/
             gpu:=false">
     <xacro:if value="${low_performance}">
       <xacro:sensor_rslidar
@@ -175,6 +180,7 @@
         max_fov="${radians(20)}"
         node_name="${node_name}"
         node_namespace="${node_namespace}"
+        topic_prefix="${topic_prefix}"
         rate="10"
         horizontal_samples="1800"
         vertical_samples="61"
@@ -195,6 +201,7 @@
         max_fov="${radians(20)}"
         node_name="${node_name}"
         node_namespace="${node_namespace}"
+        topic_prefix="${topic_prefix}"
         rate="20"
         horizontal_samples="3600"
         vertical_samples="121"
@@ -214,6 +221,7 @@
             min_angle:=${-radians(180)}
             node_name:=rslidar_ruby
             node_namespace:=${None}
+            topic_prefix:=~/
             gpu:=false">
     <xacro:if value="${low_performance}">
       <xacro:sensor_rslidar
@@ -228,6 +236,7 @@
         max_fov="${radians(20)}"
         node_name="${node_name}"
         node_namespace="${node_namespace}"
+        topic_prefix="${topic_prefix}"
         rate="10"
         horizontal_samples="1800"
         vertical_samples="200"
@@ -248,6 +257,7 @@
         max_fov="${radians(20)}"
         node_name="${node_name}"
         node_namespace="${node_namespace}"
+        topic_prefix="${topic_prefix}"
         rate="20"
         horizontal_samples="3600"
         vertical_samples="400"
@@ -267,6 +277,7 @@
             min_angle:=${-radians(60)}
             node_name:=rslidar_m1
             node_namespace:=${None}
+            topic_prefix:=~/
             gpu:=false">
     <!-- Keep the legacy rbcar M1 scan characteristics. -->
     <xacro:if value="${low_performance}">
@@ -282,6 +293,7 @@
         max_fov="${radians(12.5)}"
         node_name="${node_name}"
         node_namespace="${node_namespace}"
+        topic_prefix="${topic_prefix}"
         rate="10"
         horizontal_samples="600"
         vertical_samples="63"
@@ -302,6 +314,7 @@
         max_fov="${radians(12.5)}"
         node_name="${node_name}"
         node_namespace="${node_namespace}"
+        topic_prefix="${topic_prefix}"
         rate="20"
         horizontal_samples="1200"
         vertical_samples="125"

--- a/robotnik_sensors/urdf/3d_lidar/sick_multiscan_100.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/sick_multiscan_100.urdf.xacro
@@ -85,6 +85,7 @@
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
+      topic_prefix="${topic_prefix}"
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="52.0"

--- a/robotnik_sensors/urdf/3d_lidar/velodyne_vlp16.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/velodyne_vlp16.urdf.xacro
@@ -78,6 +78,7 @@
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
+      topic_prefix="${topic_prefix}"
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="100.0"

--- a/robotnik_sensors/urdf/all_sensors.urdf.xacro
+++ b/robotnik_sensors/urdf/all_sensors.urdf.xacro
@@ -63,6 +63,8 @@
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/3d_lidar/velodyne_vlp16.urdf.xacro" />
   <xacro:include
+    filename="$(find robotnik_sensors)/urdf/3d_lidar/rslidar.urdf.xacro" />
+  <xacro:include
     filename="$(find robotnik_sensors)/urdf/3d_lidar/robosense_bpearl.urdf.xacro" />
   <xacro:include
     filename="$(find robotnik_sensors)/urdf/3d_lidar/robosense_helios_16p.urdf.xacro" />


### PR DESCRIPTION
## Summary

This PR ports the `rslidar` lidar family to the ROS 2 / Gazebo Ignition sensor stack so it can be used by `rbcar`.

Included in this change:
- New common `rslidar` 3D lidar base macro for ROS 2 simulation
- Ported variants for:
  - `rslidar_16`
  - `rslidar_32`
  - `rslidar_ruby`
  - `rslidar_m1`
- Updated `all_sensors.urdf.xacro` to include the new `rslidar` family
- Added `low_performance` support across all `rslidar` variants


Main goal:
- Enable `rbcar` to use its original `rslidar`-based sensors in ROS 2 simulation without relying on deprecated ROS 1 sensor definitions

cc @asoriano1