### PR TITLE
Remove unused topic_prefix parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ For simulation, the following arguments are also available:
 | node_namespace 	| namespace of the plugin                                                       	|
 | node_name      	| name used for the plugin node in Gazebo                                       	|
 | gazebo_ignition	| boolean to additional information for Gazebo Ignition simulation                              |
-| topic_prefix   	| prefix added to the topic name                                                	|
 | gpu             | boolean to use the GPU for the sensor (only available for 2d and 3d lidar)      |
 
 

--- a/robotnik_sensors/test/test.xacro
+++ b/robotnik_sensors/test/test.xacro
@@ -14,8 +14,7 @@
       parent="world"
       node_namespace="$(arg namespace)"
       node_name="$(arg name)"
-      gazebo_ignition="$(arg gazebo_ignition)"
-      topic_prefix="~/$(arg name)">
+      gazebo_ignition="$(arg gazebo_ignition)">
     <origin xyz="0.0 0.0 0.1" rpy="0.0 0.0 0.0"/>
   </xacro:call>
 </robot>

--- a/robotnik_sensors/urdf/2d_lidar/hokuyo_urg04lx.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/hokuyo_urg04lx.urdf.xacro
@@ -14,8 +14,7 @@
             node_name:=hokuyo_urg04lx
             node_namespace:=${None}
             min_angle:=-2.0943
-            max_angle:=2.0943
-            topic_prefix:=~/">
+            max_angle:=2.0943">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
       <xacro:property

--- a/robotnik_sensors/urdf/2d_lidar/hokuyo_ust10lx.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/hokuyo_ust10lx.urdf.xacro
@@ -15,7 +15,6 @@
             node_namespace:=${None}
             min_angle:=-2.35
             max_angle:=2.35
-            topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">

--- a/robotnik_sensors/urdf/2d_lidar/hokuyo_ust20lx.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/hokuyo_ust20lx.urdf.xacro
@@ -15,7 +15,6 @@
             node_namespace:=${None}
             min_angle:=-2.3562
             max_angle:=2.3562
-            topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">

--- a/robotnik_sensors/urdf/2d_lidar/hokuyo_utm30lx.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/hokuyo_utm30lx.urdf.xacro
@@ -15,7 +15,6 @@
             node_namespace:=${None}
             min_angle:=-2.35
             max_angle:=2.35
-            topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">

--- a/robotnik_sensors/urdf/2d_lidar/sick_microscan3.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_microscan3.urdf.xacro
@@ -15,7 +15,6 @@
             node_namespace:=${None}
             min_angle:=-2.35
             max_angle:=2.35
-            topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">

--- a/robotnik_sensors/urdf/2d_lidar/sick_nanoscan3.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_nanoscan3.urdf.xacro
@@ -15,7 +15,6 @@
             node_namespace:=${None}
             min_angle:=-2.35
             max_angle:=2.35
-            topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">

--- a/robotnik_sensors/urdf/2d_lidar/sick_outdoorscan3.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_outdoorscan3.urdf.xacro
@@ -15,7 +15,6 @@
             node_namespace:=${None}
             min_angle:=-2.35
             max_angle:=2.35
-            topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">

--- a/robotnik_sensors/urdf/2d_lidar/sick_picoscan120.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_picoscan120.urdf.xacro
@@ -15,7 +15,6 @@
             node_namespace:=${None}
             min_angle:=-2.35
             max_angle:=2.35
-            topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">

--- a/robotnik_sensors/urdf/2d_lidar/sick_s300.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_s300.urdf.xacro
@@ -15,7 +15,6 @@
             node_namespace:=${None}
             min_angle:=-2.35
             max_angle:=2.35
-            topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">

--- a/robotnik_sensors/urdf/2d_lidar/sick_s3000.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_s3000.urdf.xacro
@@ -15,7 +15,6 @@
             node_namespace:=${None}
             min_angle:=-1.62316
             max_angle:=1.62316
-            topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">

--- a/robotnik_sensors/urdf/2d_lidar/sick_tim551.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_tim551.urdf.xacro
@@ -15,7 +15,6 @@
             node_namespace:=${None}
             min_angle:=-2.35
             max_angle:=2.35
-            topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">

--- a/robotnik_sensors/urdf/2d_lidar/sick_tim571.urdf.xacro
+++ b/robotnik_sensors/urdf/2d_lidar/sick_tim571.urdf.xacro
@@ -15,7 +15,6 @@
             node_namespace:=${None}
             min_angle:=-2.35
             max_angle:=2.35
-            topic_prefix:=~/
             gpu:=false">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">

--- a/robotnik_sensors/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/lidar_3d_plugin.urdf.xacro
@@ -6,7 +6,6 @@
     name="lidar_3d_plugin"
     params="node_namespace
             node_name
-            topic_prefix:=~/
             gazebo_ignition
             min_range
             max_range

--- a/robotnik_sensors/urdf/3d_lidar/livox_mid_360.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/livox_mid_360.urdf.xacro
@@ -15,7 +15,6 @@
             min_angle:=${-radians(180)}
             node_name:=livox_mid_360
             node_namespace:=${None}
-            topic_prefix:=~/
             gpu:=false">
     <material name="black_alu">
       <color rgba="0.9 0.9 0.9 1" />
@@ -85,7 +84,6 @@
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
-      topic_prefix="${topic_prefix}"
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="100.0"

--- a/robotnik_sensors/urdf/3d_lidar/ouster.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/ouster.urdf.xacro
@@ -15,7 +15,6 @@
             min_angle:=${-radians(180)}
             node_name:=ouster
             node_namespace:=${None}
-            topic_prefix:=~/
             gpu:=false">
     <material name="black_alu">
       <color rgba="0.9 0.9 0.9 1" />
@@ -83,7 +82,6 @@
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
-      topic_prefix="${topic_prefix}"
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="50.0"

--- a/robotnik_sensors/urdf/3d_lidar/robosense_airy.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/robosense_airy.urdf.xacro
@@ -12,7 +12,6 @@
     min_angle:=${-radians(180)}
     node_name:=robosense_airy
     node_namespace:=${None}
-    topic_prefix:=~/
     gpu:=false
     ">
 
@@ -59,7 +58,6 @@
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
-      topic_prefix="${topic_prefix}"
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="60.0"

--- a/robotnik_sensors/urdf/3d_lidar/robosense_bpearl.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/robosense_bpearl.urdf.xacro
@@ -15,7 +15,6 @@
             min_angle:=${-radians(180)}
             node_name:=robosense_bpearl
             node_namespace:=${None}
-            topic_prefix:=~/
             gpu:=false">
     <xacro:if value="${node_namespace == None}">
       <xacro:property
@@ -78,7 +77,6 @@
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
-      topic_prefix="${topic_prefix}"
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="100.0"

--- a/robotnik_sensors/urdf/3d_lidar/robosense_helios_16p.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/robosense_helios_16p.urdf.xacro
@@ -15,7 +15,6 @@
             min_angle:=${-radians(180)}
             node_name:=robosense_helios_16p
             node_namespace:=${None}
-            topic_prefix:=~/
             gpu:=false">
     <xacro:if value="${node_namespace == None}">
       <xacro:property
@@ -80,7 +79,6 @@
       <xacro:lidar_3d_plugin
         node_namespace="${node_namespace}"
         node_name="${node_name}"
-        topic_prefix="${topic_prefix}"
         gazebo_ignition="${gazebo_ignition}"
         min_range="0.2"
         max_range="60.0"
@@ -97,7 +95,6 @@
       <xacro:lidar_3d_plugin
         node_namespace="${node_namespace}"
         node_name="${node_name}"
-        topic_prefix="${topic_prefix}"
         gazebo_ignition="${gazebo_ignition}"
         min_range="0.2"
         max_range="150.0"

--- a/robotnik_sensors/urdf/3d_lidar/rslidar.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/rslidar.urdf.xacro
@@ -19,7 +19,6 @@
             max_fov:=${radians(15)}
             node_name:=rslidar
             node_namespace:=${None}
-            topic_prefix:=~/
             rate:=20
             horizontal_samples:=3600
             vertical_samples:=15
@@ -86,7 +85,6 @@
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
-      topic_prefix="${topic_prefix}"
       gazebo_ignition="${gazebo_ignition}"
       min_range="${min_range}"
       max_range="${max_range}"
@@ -110,7 +108,6 @@
             min_angle:=${-radians(180)}
             node_name:=rslidar_16
             node_namespace:=${None}
-            topic_prefix:=~/
             gpu:=false">
     <xacro:if value="${low_performance}">
       <xacro:sensor_rslidar
@@ -125,7 +122,6 @@
         max_fov="${radians(15)}"
         node_name="${node_name}"
         node_namespace="${node_namespace}"
-        topic_prefix="${topic_prefix}"
         rate="10"
         horizontal_samples="1800"
         vertical_samples="15"
@@ -146,7 +142,6 @@
         max_fov="${radians(15)}"
         node_name="${node_name}"
         node_namespace="${node_namespace}"
-        topic_prefix="${topic_prefix}"
         rate="20"
         horizontal_samples="3600"
         vertical_samples="15"
@@ -166,7 +161,6 @@
             min_angle:=${-radians(180)}
             node_name:=rslidar_32
             node_namespace:=${None}
-            topic_prefix:=~/
             gpu:=false">
     <xacro:if value="${low_performance}">
       <xacro:sensor_rslidar
@@ -181,7 +175,6 @@
         max_fov="${radians(20)}"
         node_name="${node_name}"
         node_namespace="${node_namespace}"
-        topic_prefix="${topic_prefix}"
         rate="10"
         horizontal_samples="1800"
         vertical_samples="61"
@@ -202,7 +195,6 @@
         max_fov="${radians(20)}"
         node_name="${node_name}"
         node_namespace="${node_namespace}"
-        topic_prefix="${topic_prefix}"
         rate="20"
         horizontal_samples="3600"
         vertical_samples="121"
@@ -222,7 +214,6 @@
             min_angle:=${-radians(180)}
             node_name:=rslidar_ruby
             node_namespace:=${None}
-            topic_prefix:=~/
             gpu:=false">
     <xacro:if value="${low_performance}">
       <xacro:sensor_rslidar
@@ -237,7 +228,6 @@
         max_fov="${radians(20)}"
         node_name="${node_name}"
         node_namespace="${node_namespace}"
-        topic_prefix="${topic_prefix}"
         rate="10"
         horizontal_samples="1800"
         vertical_samples="200"
@@ -258,7 +248,6 @@
         max_fov="${radians(20)}"
         node_name="${node_name}"
         node_namespace="${node_namespace}"
-        topic_prefix="${topic_prefix}"
         rate="20"
         horizontal_samples="3600"
         vertical_samples="400"
@@ -278,7 +267,6 @@
             min_angle:=${-radians(60)}
             node_name:=rslidar_m1
             node_namespace:=${None}
-            topic_prefix:=~/
             gpu:=false">
     <!-- Keep the legacy rbcar M1 scan characteristics. -->
     <xacro:if value="${low_performance}">
@@ -294,7 +282,6 @@
         max_fov="${radians(12.5)}"
         node_name="${node_name}"
         node_namespace="${node_namespace}"
-        topic_prefix="${topic_prefix}"
         rate="10"
         horizontal_samples="600"
         vertical_samples="63"
@@ -315,7 +302,6 @@
         max_fov="${radians(12.5)}"
         node_name="${node_name}"
         node_namespace="${node_namespace}"
-        topic_prefix="${topic_prefix}"
         rate="20"
         horizontal_samples="1200"
         vertical_samples="125"

--- a/robotnik_sensors/urdf/3d_lidar/sick_multiscan_100.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/sick_multiscan_100.urdf.xacro
@@ -15,7 +15,6 @@
             min_angle:=${-radians(180)}
             node_name:=sick_multiscan_100
             node_namespace:=${None}
-            topic_prefix:=~/
             gpu:=false">
     <material name="black_alu">
       <color rgba="0.9 0.9 0.9 1" />
@@ -85,7 +84,6 @@
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
-      topic_prefix="${topic_prefix}"
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="52.0"

--- a/robotnik_sensors/urdf/3d_lidar/velodyne_vlp16.urdf.xacro
+++ b/robotnik_sensors/urdf/3d_lidar/velodyne_vlp16.urdf.xacro
@@ -15,7 +15,6 @@
             min_angle:=${-radians(180)}
             node_name:=velodyne_vlp16
             node_namespace:=${None}
-            topic_prefix:=~/
             gpu:=false">
     <xacro:if value="${node_namespace == None}">
       <xacro:property
@@ -78,7 +77,6 @@
     <xacro:lidar_3d_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
-      topic_prefix="${topic_prefix}"
       gazebo_ignition="${gazebo_ignition}"
       min_range="0.1"
       max_range="100.0"

--- a/robotnik_sensors/urdf/camera/axis_m5013.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/axis_m5013.urdf.xacro
@@ -30,8 +30,7 @@
             *origin
             gazebo_ignition:=false
             node_name:=axis_m5013
-            node_namespace:=${None}
-            topic_prefix:=~/">
+            node_namespace:=${None}">
     <joint
       name="${frame_prefix}base_joint"
       type="fixed">
@@ -198,7 +197,6 @@
     <xacro:camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_color"
-      topic_prefix="${topic_prefix}_color"
       gazebo_ignition="${gazebo_ignition}"
       optical_frame="${frame_prefix}color_optical_frame"
       reference_frame="${frame_prefix}color_frame"

--- a/robotnik_sensors/urdf/camera/axis_m5074.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/axis_m5074.urdf.xacro
@@ -30,8 +30,7 @@
             *origin
             gazebo_ignition:=false
             node_name:=axis_m5074
-            node_namespace:=${None}
-            topic_prefix:=~/">
+            node_namespace:=${None}">
     <joint
       name="${frame_prefix}base_joint"
       type="fixed">
@@ -197,7 +196,6 @@
     <xacro:camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_color"
-      topic_prefix="${topic_prefix}_color"
       gazebo_ignition="${gazebo_ignition}"
       optical_frame="${frame_prefix}color_optical_frame"
       reference_frame="${frame_prefix}color_frame"

--- a/robotnik_sensors/urdf/camera/axis_m5525.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/axis_m5525.urdf.xacro
@@ -30,8 +30,7 @@
             *origin
             gazebo_ignition:=false
             node_name:=axis_m5525
-            node_namespace:=${None}
-            topic_prefix:=~/">
+            node_namespace:=${None}">
     <joint
       name="${frame_prefix}base_joint"
       type="fixed">
@@ -193,7 +192,6 @@
     <xacro:camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_color"
-      topic_prefix="${topic_prefix}_color"
       gazebo_ignition="${gazebo_ignition}"
       optical_frame="${frame_prefix}color_optical_frame"
       reference_frame="${frame_prefix}color_frame"

--- a/robotnik_sensors/urdf/camera/axis_m5526.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/axis_m5526.urdf.xacro
@@ -30,8 +30,7 @@
             *origin
             gazebo_ignition:=false
             node_name:=axis_m5526
-            node_namespace:=${None}
-            topic_prefix:=~/">
+            node_namespace:=${None}">
     <joint
       name="${frame_prefix}base_joint"
       type="fixed">
@@ -193,7 +192,6 @@
     <xacro:camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_color"
-      topic_prefix="${topic_prefix}_color"
       gazebo_ignition="${gazebo_ignition}"
       optical_frame="${frame_prefix}color_optical_frame"
       reference_frame="${frame_prefix}color_frame"

--- a/robotnik_sensors/urdf/camera/camera_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/camera_plugin.urdf.xacro
@@ -6,7 +6,6 @@
     name="camera_plugin"
     params="node_namespace
             node_name
-            topic_prefix
             gazebo_ignition
             optical_frame
             reference_frame

--- a/robotnik_sensors/urdf/camera/link_750_nh.urdf.xacro
+++ b/robotnik_sensors/urdf/camera/link_750_nh.urdf.xacro
@@ -33,8 +33,7 @@
             *origin
             gazebo_ignition:=false
             node_name:=link_750_nh
-            node_namespace:=${None}
-            topic_prefix:=~/">
+            node_namespace:=${None}">
     <joint
       name="${frame_prefix}base_joint"
       type="fixed">
@@ -275,7 +274,6 @@
       <xacro:camera_plugin
         node_namespace="${node_namespace}"
         node_name="${node_name}_color"
-        topic_prefix="${topic_prefix}_color"
         gazebo_ignition="${gazebo_ignition}"
         optical_frame="${frame_prefix}optical_frame_link"
         reference_frame="${frame_prefix}frame_link"
@@ -291,7 +289,6 @@
       <xacro:camera_plugin
         node_namespace="${node_namespace}"
         node_name="${node_name}_color"
-        topic_prefix="${topic_prefix}_color"
         gazebo_ignition="${gazebo_ignition}"
         optical_frame="${frame_prefix}optical_frame_link"
         reference_frame="${frame_prefix}frame_link"

--- a/robotnik_sensors/urdf/deprecated/asus_xtion_pro.urdf.xacro
+++ b/robotnik_sensors/urdf/deprecated/asus_xtion_pro.urdf.xacro
@@ -28,7 +28,6 @@
                         simulation:=false
                         node_name:=asus_xtion_pro
                         node_namespace:=${None}
-                        topic_prefix:=~/
                         horizontal_fov:=58
                         vertical_fov:=45
                         video_width:=1280

--- a/robotnik_sensors/urdf/depth/azure_kinect.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/azure_kinect.urdf.xacro
@@ -12,8 +12,7 @@
             *origin
             gazebo_ignition:=false
             node_namespace:=${None}
-            node_name:=azure_kinect
-            topic_prefix:=~/">
+            node_name:=azure_kinect">
     <xacro:if value="${node_namespace == None}">
       <xacro:property
         name="node_namespace"
@@ -130,7 +129,6 @@
     <xacro:depth_camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
-      topic_prefix="${topic_prefix}"
       gazebo_ignition="${gazebo_ignition}"
       optical_frame="${frame_prefix}color_optical_frame"
       reference_frame="${frame_prefix}color_frame"

--- a/robotnik_sensors/urdf/depth/depth_camera_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/depth_camera_plugin.urdf.xacro
@@ -6,7 +6,6 @@
     name="depth_camera_plugin"
     params="node_namespace
             node_name
-            topic_prefix
             gazebo_ignition
             optical_frame
             reference_frame

--- a/robotnik_sensors/urdf/depth/intel_realsense_d435.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/intel_realsense_d435.urdf.xacro
@@ -16,8 +16,7 @@
             *origin
             gazebo_ignition:=false
             node_name:=realsense_d435
-            node_namespace:=${None}
-            topic_prefix:=~/">
+            node_namespace:=${None}">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
       <xacro:property
@@ -216,7 +215,6 @@
       <xacro:camera_plugin
         node_namespace="${node_namespace}"
         node_name="${node_name}_color"
-        topic_prefix="${topic_prefix}_color"
         gazebo_ignition="${gazebo_ignition}"
         optical_frame="${frame_prefix}color_optical_frame"
         reference_frame="${frame_prefix}color_frame"
@@ -232,7 +230,6 @@
       <xacro:camera_plugin
         node_namespace="${node_namespace}"
         node_name="${node_name}_color"
-        topic_prefix="${topic_prefix}_color"
         gazebo_ignition="${gazebo_ignition}"
         optical_frame="${frame_prefix}color_optical_frame"
         reference_frame="${frame_prefix}color_frame"

--- a/robotnik_sensors/urdf/depth/intel_realsense_d435i.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/intel_realsense_d435i.urdf.xacro
@@ -18,8 +18,7 @@
             *origin
             gazebo_ignition:=false
             node_name:=realsense_d435i
-            node_namespace:=${None}
-            topic_prefix:=~/">
+            node_namespace:=${None}">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
       <xacro:property
@@ -229,7 +228,6 @@
     <xacro:camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_color"
-      topic_prefix="${topic_prefix}_color"
       gazebo_ignition="${gazebo_ignition}"
       optical_frame="${frame_prefix}color_optical_frame"
       reference_frame="${frame_prefix}color_frame"
@@ -244,7 +242,6 @@
     <xacro:irred_camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_irred1"
-      topic_prefix="${topic_prefix}_irred1"
       gazebo_ignition="${gazebo_ignition}"
       optical_frame="${frame_prefix}infra1_optical_frame"
       reference_frame="${frame_prefix}infra2_frame"
@@ -259,7 +256,6 @@
     <xacro:irred_camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_irred2"
-      topic_prefix="${topic_prefix}_irred2"
       gazebo_ignition="${gazebo_ignition}"
       optical_frame="${frame_prefix}infra2_optical_frame"
       reference_frame="${frame_prefix}infra2_frame"
@@ -274,7 +270,6 @@
     <xacro:depth_camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_depth"
-      topic_prefix="${topic_prefix}_depth"
       gazebo_ignition="${gazebo_ignition}"
       optical_frame="${frame_prefix}depth_optical_frame"
       reference_frame="${frame_prefix}depth_frame"
@@ -292,14 +287,6 @@
           <depthUpdateRate>60.0</depthUpdateRate>
           <colorUpdateRate>60.0</colorUpdateRate>
           <infraredUpdateRate>60.0</infraredUpdateRate>
-          <depthTopicName>${topic_prefix}depth/image_rect_raw</depthTopicName>
-          <depthCameraInfoTopicName>${topic_prefix}depth/camera_info</depthCameraInfoTopicName>
-          <colorTopicName>${topic_prefix}color/image_raw</colorTopicName>
-          <colorCameraInfoTopicName>${topic_prefix}color/camera_info</colorCameraInfoTopicName>
-          <infrared1TopicName>${topic_prefix}infra1/image_raw</infrared1TopicName>
-          <infrared1CameraInfoTopicName>${topic_prefix}infra1/camera_info</infrared1CameraInfoTopicName>
-          <infrared2TopicName>${topic_prefix}infra2/image_raw</infrared2TopicName>
-          <infrared2CameraInfoTopicName>${topic_prefix}infra2/camera_info</infrared2CameraInfoTopicName>
           <colorOpticalframeName>${frame_prefix}color_optical_frame</colorOpticalframeName>
           <depthOpticalframeName>${frame_prefix}depth_optical_frame</depthOpticalframeName>
           <infrared1OpticalframeName>${frame_prefix}infra1_optical_frame</infrared1OpticalframeName>
@@ -307,7 +294,6 @@
           <rangeMinDepth>0.2</rangeMinDepth>
           <rangeMaxDepth>10.0</rangeMaxDepth>
           <pointCloud>true</pointCloud>
-          <pointCloudTopicName>${topic_prefix}depth/color/points</pointCloudTopicName>
           <pointCloudCutoff>0.5</pointCloudCutoff>
         </plugin>
       </gazebo> -->

--- a/robotnik_sensors/urdf/depth/intel_realsense_d455.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/intel_realsense_d455.urdf.xacro
@@ -18,8 +18,7 @@
             *origin
             gazebo_ignition:=false
             node_name:=realsense_d455
-            node_namespace:=${None}
-            topic_prefix:=~/">
+            node_namespace:=${None}">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
       <xacro:property
@@ -302,7 +301,6 @@
     <xacro:camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_color"
-      topic_prefix="${topic_prefix}_color"
       gazebo_ignition="${gazebo_ignition}"
       optical_frame="${frame_prefix}color_optical_frame"
       reference_frame="${frame_prefix}color_frame"
@@ -317,7 +315,6 @@
     <xacro:irred_camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_irred1"
-      topic_prefix="${topic_prefix}_irred1"
       gazebo_ignition="${gazebo_ignition}"
       optical_frame="${frame_prefix}infra1_optical_frame"
       reference_frame="${frame_prefix}infra1_frame"
@@ -332,7 +329,6 @@
     <xacro:irred_camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_irred2"
-      topic_prefix="${topic_prefix}_irred2"
       gazebo_ignition="${gazebo_ignition}"
       optical_frame="${frame_prefix}infra2_optical_frame"
       reference_frame="${frame_prefix}infra2_frame"
@@ -347,7 +343,6 @@
     <xacro:depth_camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_depth"
-      topic_prefix="${topic_prefix}_depth"
       gazebo_ignition="${gazebo_ignition}"
       optical_frame="${frame_prefix}depth_optical_frame"
       reference_frame="${frame_prefix}depth_frame"

--- a/robotnik_sensors/urdf/depth/irred_camera_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/irred_camera_plugin.urdf.xacro
@@ -6,7 +6,6 @@
     name="irred_camera_plugin"
     params="node_namespace
             node_name
-            topic_prefix
             gazebo_ignition
             optical_frame
             reference_frame

--- a/robotnik_sensors/urdf/depth/orbbec_astra.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/orbbec_astra.urdf.xacro
@@ -12,8 +12,7 @@
             *origin
             gazebo_ignition:=false
             node_namespace:=${None}
-            node_name:=orbbec_astra
-            topic_prefix:=~/">
+            node_name:=orbbec_astra">
     <!-- node_namespace is used from node_name if not set -->
     <xacro:if value="${node_namespace == None}">
       <xacro:property
@@ -100,7 +99,6 @@
     <xacro:depth_camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}"
-      topic_prefix="${topic_prefix}"
       gazebo_ignition="${gazebo_ignition}"
       optical_frame="${frame_prefix}depth_optical_frame"
       reference_frame="${frame_prefix}depth_frame"

--- a/robotnik_sensors/urdf/depth/stereolabs_generic.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/stereolabs_generic.urdf.xacro
@@ -18,7 +18,6 @@
             gazebo_ignition:=false
             node_name:=stereolabs_generic
             node_namespace:=${None}
-            topic_prefix:=~/
             horizontal_fov:=80
             vertical_fov:=60
             video_width:=1280
@@ -164,7 +163,6 @@
     <xacro:camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_right_sensor"
-      topic_prefix="${topic_prefix}_right_sensor"
       gazebo_ignition="${gazebo_ignition}"
       optical_frame="${frame_prefix}right_camera_optical_frame"
       reference_frame="${frame_prefix}right_camera_frame"
@@ -179,7 +177,6 @@
     <xacro:camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_left_sensor"
-      topic_prefix="${topic_prefix}_left_sensor"
       gazebo_ignition="${gazebo_ignition}"
       optical_frame="${frame_prefix}left_camera_optical_frame"
       reference_frame="${frame_prefix}left_camera_frame"
@@ -194,7 +191,6 @@
     <xacro:depth_camera_plugin
       node_namespace="${node_namespace}"
       node_name="${node_name}_depth"
-      topic_prefix="${topic_prefix}_depth"
       gazebo_ignition="${gazebo_ignition}"
       optical_frame="${frame_prefix}depth_optical_frame"
       reference_frame="${frame_prefix}depth_frame"

--- a/robotnik_sensors/urdf/depth/stereolabs_zed2.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/stereolabs_zed2.urdf.xacro
@@ -9,8 +9,7 @@
             *origin
             gazebo_ignition:=false
             node_namespace:=stereolabs_zed2
-            node_name:=stereolabs_zed2
-            topic_prefix:=~/">
+            node_name:=stereolabs_zed2">
     <xacro:sensor_stereolabs_generic
       frame_prefix="${frame_prefix}"
       parent="${parent}"
@@ -18,7 +17,6 @@
       gazebo_ignition="${gazebo_ignition}"
       node_namespace="${node_namespace}"
       node_name="${node_name}"
-      topic_prefix="${topic_prefix}"
       horizontal_fov="110"
       vertical_fov="70"
       video_width="1920"

--- a/robotnik_sensors/urdf/depth/stereolabs_zed2i.urdf.xacro
+++ b/robotnik_sensors/urdf/depth/stereolabs_zed2i.urdf.xacro
@@ -12,8 +12,7 @@
             *origin
             gazebo_ignition:=false
             node_namespace:=stereolabs_zed2i
-            node_name:=stereolabs_zed2i
-            topic_prefix:=~/">
+            node_name:=stereolabs_zed2i">
     <xacro:sensor_stereolabs_generic
       frame_prefix="${frame_prefix}"
       parent="${parent}"
@@ -21,7 +20,6 @@
       gazebo_ignition="false"
       node_namespace="${node_namespace}"
       node_name="${node_name}"
-      topic_prefix="${topic_prefix}"
       horizontal_fov="110"
       vertical_fov="70"
       video_width="1920"

--- a/robotnik_sensors/urdf/gps/gps.urdf.xacro
+++ b/robotnik_sensors/urdf/gps/gps.urdf.xacro
@@ -13,7 +13,6 @@
             gazebo_ignition:=false
             node_name:=gps
             node_namespace:=${None}
-            topic_prefix:=~/
             update_rate:=1.0">
     <joint
       name="${frame_prefix}joint"
@@ -66,7 +65,6 @@
       node_namespace="${node_namespace}"
       node_name="${node_name}"
       gazebo_ignition="${gazebo_ignition}"
-      topic_prefix="${topic_prefix}_gps"
       frame_link="${frame_prefix}base_link"
       rate="${update_rate}" />
   </xacro:macro>

--- a/robotnik_sensors/urdf/gps/gps_plugin.urdf.xacro
+++ b/robotnik_sensors/urdf/gps/gps_plugin.urdf.xacro
@@ -7,7 +7,6 @@
     params="node_namespace
             node_name
             frame_link
-            topic_prefix
             gazebo_ignition
             rate
             ">

--- a/robotnik_sensors/urdf/gps/gps_with_mast.urdf.xacro
+++ b/robotnik_sensors/urdf/gps/gps_with_mast.urdf.xacro
@@ -20,7 +20,6 @@
 			gazebo_ignition:=false
 			node_name:=gps_with_mast
 			node_namespace:=${None}
-			topic_prefix:=~/
 			update_rate:=1.0">
     <!-- MAST OF THE ANTENNA GPS -->
     <joint
@@ -130,7 +129,6 @@
       node_namespace="${node_namespace}"
       node_name="${node_name}"
       gazebo_ignition="${gazebo_ignition}"
-      topic_prefix="${topic_prefix}_gps"
       frame_link="${frame_prefix}base_link"
       rate="${update_rate}" />
   </xacro:macro>

--- a/robotnik_sensors/urdf/gps/ublox.urdf.xacro
+++ b/robotnik_sensors/urdf/gps/ublox.urdf.xacro
@@ -13,7 +13,6 @@
 			      gazebo_ignition:=false
 			      node_name:=ublox
 			      node_namespace:=${None}
-			      topic_prefix:=~/
 			      update_rate:=5.0">
     <!-- ANTENNA GPS -->
     <joint
@@ -77,7 +76,6 @@
       node_namespace="${node_namespace}"
       node_name="${node_name}"
       gazebo_ignition="${gazebo_ignition}"
-      topic_prefix="${topic_prefix}_gps"
       frame_link="${frame_prefix}base_link"
       rate="${update_rate}" />
   </xacro:macro>

--- a/robotnik_sensors/urdf/gps/ublox_with_mast.urdf.xacro
+++ b/robotnik_sensors/urdf/gps/ublox_with_mast.urdf.xacro
@@ -20,7 +20,6 @@
 		        gazebo_ignition:=false
 		        node_name:=ublox
 		        node_namespace:=${None}
-		        topic_prefix:=~/
 		        update_rate:=5.0">
     <!-- ANTENNA GPS -->
     <joint
@@ -125,7 +124,6 @@
       node_namespace="${node_namespace}"
       node_name="${node_name}"
       gazebo_ignition="${gazebo_ignition}"
-      topic_prefix="${topic_prefix}_gps"
       frame_link="${frame_prefix}base_link"
       rate="${update_rate}" />
   </xacro:macro>

--- a/robotnik_sensors/urdf/imu/myahrs.urdf.xacro
+++ b/robotnik_sensors/urdf/imu/myahrs.urdf.xacro
@@ -12,8 +12,7 @@
             *origin
             gazebo_ignition:=false
             node_name:=imu
-            node_namespace:=${None}
-            topic_prefix:=~/">
+            node_namespace:=${None}">
     <joint
       name="${frame_prefix}base_joint"
       type="fixed">

--- a/robotnik_sensors/urdf/imu/pixhawk.urdf.xacro
+++ b/robotnik_sensors/urdf/imu/pixhawk.urdf.xacro
@@ -12,8 +12,7 @@
             *origin
             gazebo_ignition:=false
             node_name:=imu
-            node_namespace:=${None}
-            topic_prefix:=~/">
+            node_namespace:=${None}">
     <joint
       name="${frame_prefix}base_joint"
       type="fixed">

--- a/robotnik_sensors/urdf/imu/vectornav.urdf.xacro
+++ b/robotnik_sensors/urdf/imu/vectornav.urdf.xacro
@@ -12,8 +12,7 @@
             *origin
             gazebo_ignition:=false
             node_name:=imu
-            node_namespace:=${None}
-            topic_prefix:=~/">
+            node_namespace:=${None}">
     <joint
       name="${frame_prefix}base_joint"
       type="fixed">


### PR DESCRIPTION
- Remove the unused `topic_prefix` parameter from sensor xacro macros and plugin wrappers.
- Update the xacro test fixture to rely on `node_namespace` and `node_name` instead.
- Remove `topic_prefix` from the README simulation arguments table.
